### PR TITLE
Remove unused aggregatorTimer

### DIFF
--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -19,7 +19,6 @@ import * as printManager from "./dashboard_printManager.js";
 
 let ws = null;
 let heartbeatInterval = null;
-let aggregatorTimer   = null;
 let reconnectAttempts = 0;
 let reconnectTimeout  = null;
 const MAX_RECONNECT   = 5;


### PR DESCRIPTION
## Summary
- clean up dashboard_connection.js by removing unused `aggregatorTimer`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845900d4bf0832f8352ce3be5dc5f90