### PR TITLE
Fix history restore and duplicate IDs

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -197,17 +197,17 @@ export function initializeDashboard({
     });
   }
 
-  // (14.5) 上部クイックボタン → コマンドパレットボタンの代理クリック
+  // (14.5) コマンドパレット側ボタン → 上部クイックボタンの代理クリック
   const aliasClick = (src, dest) => {
     const s = document.getElementById(src);
     const d = document.getElementById(dest);
     if (s && d) s.addEventListener("click", () => d.click());
   };
-  aliasClick("btn-stop-print-top",   "btn-stop-print");
-  aliasClick("btn-pause-print-top",  "btn-pause-print");
-  aliasClick("btn-resume-print-top", "btn-resume-print");
-  aliasClick("btn-history-list-main","btn-history-list");
-  aliasClick("btn-file-list-main",  "btn-file-list");
+  aliasClick("btn-stop-print-cmd",   "btn-stop-print");
+  aliasClick("btn-pause-print-cmd",  "btn-pause-print");
+  aliasClick("btn-resume-print-cmd", "btn-resume-print");
+  aliasClick("btn-history-list-cmd","btn-history-list");
+  aliasClick("btn-file-list-cmd",  "btn-file-list");
 
   printManager.initHistoryTabs();
 

--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -197,6 +197,18 @@ export function initializeDashboard({
     });
   }
 
+  // (14.5) 上部クイックボタン → コマンドパレットボタンの代理クリック
+  const aliasClick = (src, dest) => {
+    const s = document.getElementById(src);
+    const d = document.getElementById(dest);
+    if (s && d) s.addEventListener("click", () => d.click());
+  };
+  aliasClick("btn-stop-print-top",   "btn-stop-print");
+  aliasClick("btn-pause-print-top",  "btn-pause-print");
+  aliasClick("btn-resume-print-top", "btn-resume-print");
+  aliasClick("btn-history-list-main","btn-history-list");
+  aliasClick("btn-file-list-main",  "btn-file-list");
+
   printManager.initHistoryTabs();
 
   // (15) ファイルアップロード初期化

--- a/3dp_lib/dashboard_msg_handler.js
+++ b/3dp_lib/dashboard_msg_handler.js
@@ -30,6 +30,8 @@ import { updateXYPreview, updateZPreview } from "./dashboard_preview.js";
 import { PRINT_STATE_CODE } from "./dashboard_ui_mapping.js";
 import { ingestData, restoreAggregatorState, restartAggregatorTimer } from "./dashboard_aggregator.js";
 import { restorePrintResume } from "./3dp_dashboard_init.js";
+import * as printManager from "./dashboard_printmanager.js";
+import { getDeviceIp } from "./dashboard_connection.js";
 
 /** タイマーID／タイムスタンプ／累積値 */
 let prepTimerId, checkTimerId, pauseTimerId, completionTimer;
@@ -93,6 +95,17 @@ export function handleMessage(data) {
 
     restartAggregatorTimer();
     restorePrintResume();
+
+    // 保存済み履歴と現在印刷を表示
+    const baseUrlStored = `http://${getDeviceIp()}:80`;
+    const jobs = printManager.loadHistory();
+    if (jobs.length) {
+      const raw = printManager.jobsToRaw(jobs);
+      printManager.renderHistoryTable(raw, baseUrlStored);
+    }
+    printManager.renderPrintCurrent(
+      document.getElementById("print-current-container")
+    );
 
   }
 

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -252,14 +252,14 @@
           <div class="col2">
 
           <div class="cmd-group">
-            <button id="btn-stop-print-top">停止</button>
-            <button id="btn-pause-print-top">一時停止</button>
-            <button id="btn-resume-print-top">再開</button>
+            <button id="btn-stop-print">停止</button>
+            <button id="btn-pause-print">一時停止</button>
+            <button id="btn-resume-print">再開</button>
             <button id="btn-ack-error">エラー了承</button>
           </div>
           <div class="cmd-group">
-            <button id="btn-history-list-main">履歴一覧取得</button>
-            <button id="btn-file-list-main">ファイル一覧取得</button>
+            <button id="btn-history-list">履歴一覧取得</button>
+            <button id="btn-file-list">ファイル一覧取得</button>
             <button id="btn-send-raw-json">JSONコマンド送信</button>
           </div>
           <div class="control-temp-area">
@@ -751,18 +751,18 @@
         <summary style="cursor:pointer; font-weight:bold;">コマンドパレット</summary>
           <!-- 新: 停止・一時停止・再開 -->
           <div class="cmd-group">
-            <button id="btn-stop-print">停止</button>
-            <button id="btn-pause-print">一時停止</button>
-            <button id="btn-resume-print">再開</button>
+            <button id="btn-stop-print-cmd">停止</button>
+            <button id="btn-pause-print-cmd">一時停止</button>
+            <button id="btn-resume-print-cmd">再開</button>
           </div>
           <br/><br/><br/>
           <!-- 新: 履歴一覧取得 -->
           <div class="cmd-group">
-            <button id="btn-history-list">履歴一覧取得</button>
+            <button id="btn-history-list-cmd">履歴一覧取得</button>
           </div>
           <!-- 新: G-codeファイル一覧取得 -->
           <div class="cmd-group">
-            <button id="btn-file-list">ファイル一覧取得</button>
+            <button id="btn-file-list-cmd">ファイル一覧取得</button>
           </div>
 
           <div class="col2">

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -252,14 +252,14 @@
           <div class="col2">
 
           <div class="cmd-group">
-            <button id="btn-stop-print">停止</button>
-            <button id="btn-pause-print">一時停止</button>
-            <button id="btn-resume-print">再開</button>
+            <button id="btn-stop-print-top">停止</button>
+            <button id="btn-pause-print-top">一時停止</button>
+            <button id="btn-resume-print-top">再開</button>
             <button id="btn-ack-error">エラー了承</button>
           </div>
           <div class="cmd-group">
-            <button id="btn-history-list">履歴一覧取得</button>
-            <button id="btn-file-list">ファイル一覧取得</button>
+            <button id="btn-history-list-main">履歴一覧取得</button>
+            <button id="btn-file-list-main">ファイル一覧取得</button>
             <button id="btn-send-raw-json">JSONコマンド送信</button>
           </div>
           <div class="control-temp-area">
@@ -617,7 +617,7 @@
     </div>
 
     <!-- ─── 印刷履歴タブ ─── -->
-    <div id="panel-print-history">
+    <div id="panel-print-history-tab">
   
       <h2 class="card-title">印刷履歴</h2>
       <div style="font-size:0.9em;">
@@ -643,7 +643,7 @@
         <button id="gcode-upload-btn">アップロード</button>
       </div>
       <!-- /暫定配置 -->
-      <div id="panel-print-history" class="scrollable-body">
+      <div id="print-history-body" class="scrollable-body">
         <table id="print-history-table" class="fixed-header" border="1" style="border-collapse: collapse; width:100%;">
           <thead>
             <tr>


### PR DESCRIPTION
## Summary
- restore saved history after printer connection
- merge new history with stored history
- support rendering stored history in table view
- fix duplicate HTML IDs and update tab initialization
- add quick-action button handlers that delegate to command palette

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846190fb4f0832f8734bdff8ac61413