### PR TITLE
Add timers to resume persistence

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -233,6 +233,10 @@ export function initializeDashboard({
 
 // 印刷再開用に保存したいキー
 const persistKeys = [
+  "preparationTime",
+  "firstLayerCheckTime",
+  "pauseTime",
+  "completionElapsedTime",
   "actualStartTime",
   "initialLeftTime",
   "initialLeftAt",


### PR DESCRIPTION
## Summary
- store prep/check/pause/completion timers in `persistKeys`
- persist and restore these values via `localStorage`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68462dbbea74832fabe5613675ab40dd