### PR TITLE
Stop updating estimation after print completion

### DIFF
--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -353,7 +353,13 @@ function aggregateTimersAndPredictions(data) {
   }
 
   // ── 5) 予想残り時間／予想終了時刻 ────────────────────────────────
-  if (actualStartEpoch !== null && progPct > 0) {
+  if (doneStates.has(st)) {
+    // 印刷終了または失敗時は予測値をリセット
+    setStoredData("predictedFinishEpoch",    null, true);
+    setStoredData("estimatedRemainingTime",  null, true);
+    setStoredData("estimatedCompletionTime", null, true);
+  }
+  else if (actualStartEpoch !== null && progPct > 0) {
     const elapsed  = (nowSec - actualStartEpoch) - (totalCheckSec + totalPauseSec);
     const totalEst = elapsed / progPct;
     const remSec   = totalEst - elapsed;


### PR DESCRIPTION
## Summary
- prevent prediction calculations from running when the printer has finished

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68462d8edc88832f868fecaf9d42b8db