### PR TITLE
Add JSON command test feature

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -48,7 +48,7 @@ import {
 import { notificationManager } from "./dashboard_notification_manager.js";
 import { persistAggregatorState,stopAggregatorTimer } from "./dashboard_aggregator.js";
 import { showAlert } from "./dashboard_notification_manager.js";
-import { initSendRawJson } from "./dashboard_send_command.js";
+import { initSendRawJson, initTestRawJson } from "./dashboard_send_command.js";
 /**
  * @fileoverview
  * ダッシュボードを初期化します。
@@ -233,6 +233,7 @@ export function initializeDashboard({
 
   // (19) JSONコマンド送信機能
   initSendRawJson();
+  initTestRawJson();
 }
 
 // ────────────── 印刷再開データの復元／永続化 ──────────────

--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -568,3 +568,11 @@ export function updateConnectionUI(state, opt = {}) {
       console.error(`updateConnectionUI: unknown state="${state}"`);
   }
 }
+
+/**
+ * Debug helper: treat a raw JSON string as a received WebSocket message.
+ * @param {string} jsonStr - JSON text to process
+ */
+export function simulateReceivedJson(jsonStr) {
+  handleSocketMessage({ data: jsonStr });
+}

--- a/3dp_lib/dashboard_send_command.js
+++ b/3dp_lib/dashboard_send_command.js
@@ -9,7 +9,7 @@
 
 "use strict";
 
-import { getDeviceIp, sendCommand } from "./dashboard_connection.js";
+import { getDeviceIp, sendCommand, simulateReceivedJson } from "./dashboard_connection.js";
 import { showInputDialog, showConfirmDialog } from "./dashboard_ui_confirm.js";
 import { showAlert } from "./dashboard_notification_manager.js";
 import { pushLog } from "./dashboard_log_util.js";
@@ -555,5 +555,24 @@ export function initSendRawJson() {
       }
       break;
     }
+  });
+}
+
+/**
+ * "JSONコマンドテスト" ボタンの設定とハンドラ登録
+ * 指定テキストボックスの内容を受信メッセージとして処理します。
+ */
+export function initTestRawJson() {
+  const btn   = document.getElementById("btn-test-raw-json");
+  const input = document.getElementById("cmd-test-json");
+  if (!btn || !input) return;
+
+  btn.addEventListener("click", () => {
+    const raw = input.value.trim();
+    if (!raw) {
+      showAlert("JSON文字列を入力してください。", "warn");
+      return;
+    }
+    simulateReceivedJson(raw);
   });
 }

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -262,6 +262,11 @@
             <button id="btn-file-list">ファイル一覧取得</button>
             <button id="btn-send-raw-json">JSONコマンド送信</button>
           </div>
+          <div class="cmd-group">
+            <label>受信JSON:</label>
+            <input id="cmd-test-json" type="text" />
+            <button id="btn-test-raw-json">JSONコマンドテスト</button>
+          </div>
           <div class="control-temp-area">
             <div class="temp-row" style="margin-top:5px;">
               <div class="temp-box">


### PR DESCRIPTION
## Summary
- add input and button for JSON command test
- hook up button to simulate websocket message handling
- export simulateReceivedJson to reuse message logic
- initialize test feature on dashboard setup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b7a1f6a24832fb55e622e95b56a2f