### PR TITLE
Update history logging with timing info

### DIFF
--- a/3dp_lib/dashboard_msg_handler.js
+++ b/3dp_lib/dashboard_msg_handler.js
@@ -349,7 +349,27 @@ export function processData(data) {
   Object.entries(data).forEach(([k, v]) => setStoredData(k, v, true));
   // (2.7.3) 進捗100%以上で履歴登録
   if (Number(data.printProgress ?? 0) >= 100) {
-    machine.historyData.push(data);
+    const entry = { ...data };
+    const extraKeys = [
+      "preparationTime",
+      "firstLayerCheckTime",
+      "pauseTime",
+      "completionElapsedTime",
+      "actualStartTime",
+      "initialLeftTime",
+      "initialLeftAt",
+      "predictedFinishEpoch",
+      "estimatedRemainingTime",
+      "estimatedCompletionTime"
+    ];
+    extraKeys.forEach(k => {
+      const v = machine.storedData[k]?.rawValue;
+      if (v !== undefined) entry[k] = v;
+    });
+    ["filamentId", "filamentColor", "filamentType"].forEach(k => {
+      if (data[k] != null) entry[k] = data[k];
+    });
+    machine.historyData.push(entry);
   }
 
   // 次回比較用に保存


### PR DESCRIPTION
## Summary
- enrich print history entries when progress hits 100%

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684cdfd2a788832f9233a7adbf0b9a0b