### PR TITLE
Add stage preview enhancements and rename module

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -22,7 +22,10 @@ import {
   monitorData,
   setStoredData
 } from "./dashboard_data.js";
-import { restoreXYPreviewState, initXYPreview } from "./dashboard_preview.js";
+import {
+  restoreXYPreviewState,
+  initXYPreview
+} from "./dashboard_stage_preview.js";
 import {
   initLogAutoScroll,
   initLogRenderer,

--- a/3dp_lib/dashboard_msg_handler.js
+++ b/3dp_lib/dashboard_msg_handler.js
@@ -26,7 +26,10 @@ import { pushLog } from "./dashboard_log_util.js";
 import { notificationManager } from "./dashboard_notification_manager.js";
 import { handlePrintStateTransition } from "./dashboard_printstatus.js";
 import { parseCurPosition } from "./dashboard_utils.js";
-import { updateXYPreview, updateZPreview } from "./dashboard_preview.js";
+import {
+  updateXYPreview,
+  updateZPreview
+} from "./dashboard_stage_preview.js";
 import { PRINT_STATE_CODE } from "./dashboard_ui_mapping.js";
 import { ingestData, restoreAggregatorState, restartAggregatorTimer } from "./dashboard_aggregator.js";
 import { restorePrintResume } from "./3dp_dashboard_init.js";

--- a/3dp_monitor.css
+++ b/3dp_monitor.css
@@ -242,6 +242,8 @@ body {
   border-right: 4px solid #111144;
   border-bottom: 4px solid #222;
   box-sizing: border-box;
+  perspective: 400px;
+  perspective-origin: center;
 }
 .stage {
   position: absolute;
@@ -255,6 +257,8 @@ body {
   border-right: 2px solid #666;
   border-bottom: 2px solid #666;
   box-sizing: border-box;
+  transform-style: preserve-3d;
+  transition: transform 0.2s;
 }
 
 #z-preview-container {
@@ -799,4 +803,32 @@ input:checked + .slider:before {
   justify-content: center;
   z-index: 3000;
   font-size: 1.2em;
+}
+
+/* stage preview extras */
+.stage-wing {
+  position: absolute;
+  bottom: 0;
+  width: 40px;
+  height: 30px;
+  background: #555;
+  clip-path: polygon(0 100%, 100% 100%, 50% 0);
+}
+.stage-wing.left {
+  left: -30px;
+  transform: rotateY(180deg);
+}
+.stage-wing.right {
+  right: -30px;
+}
+.stage-tab {
+  position: absolute;
+  bottom: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 40px;
+  height: 15px;
+  background: #555;
+  border-radius: 4px 4px 0 0;
+  border: 1px solid #333;
 }


### PR DESCRIPTION
## Summary
- rename `dashboard_preview.js` to `dashboard_stage_preview.js`
- inject wings and tab decorations into the XY stage preview
- support dragging to rotate the stage preview
- expose helper functions to reset view and set camera view
- update CSS for 3‑D transform and new stage parts
- adjust module imports for the renamed file

## Testing
- `node --check 3dp_lib/dashboard_stage_preview.js`
- `node --check 3dp_lib/dashboard_msg_handler.js`
- `node --check 3dp_lib/3dp_dashboard_init.js`

------
https://chatgpt.com/codex/tasks/task_e_684cf26cb6e8832fbb2b13d0f775c427