### PR TITLE
Add additional fields to jobsToRaw

### DIFF
--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -159,7 +159,13 @@ export function jobsToRaw(jobs) {
       usagetime:     finishEpoch ? finishEpoch - startEpoch : 0,
       usagematerial: job.materialUsedMm,
       printfinish:   finishEpoch ? 1 : 0,
-      filemd5:       ""
+      filemd5:       "",
+      ...(job.preparationTime      !== undefined && { preparationTime:      job.preparationTime }),
+      ...(job.firstLayerCheckTime   !== undefined && { firstLayerCheckTime:   job.firstLayerCheckTime }),
+      ...(job.pauseTime             !== undefined && { pauseTime:             job.pauseTime }),
+      ...(job.filamentId            !== undefined && { filamentId:            job.filamentId }),
+      ...(job.filamentColor         !== undefined && { filamentColor:         job.filamentColor }),
+      ...(job.filamentType          !== undefined && { filamentType:          job.filamentType })
     };
   });
 }


### PR DESCRIPTION
## Summary
- include job timing and filament details in jobsToRaw when present

## Testing
- `node --check 3dp_lib/dashboard_printmanager.js`


------
https://chatgpt.com/codex/tasks/task_e_684cdfb93764832f8b448baec98646c6