### PR TITLE
ヘッドプレビュー機能改善

### DIFF
--- a/3dp_lib/dashboard_stage_preview.js
+++ b/3dp_lib/dashboard_stage_preview.js
@@ -58,6 +58,7 @@ function saveXYPreviewState() {
  */
 function initXYPreview() {
   const container = document.getElementById("xy-stage");
+  container.style.userSelect = "none";
   const gridCount = 7;
   const width = container.clientWidth;
   const height = container.clientHeight;
@@ -151,6 +152,17 @@ function initXYPreview() {
   currentCircle.style.borderRadius = "50%";
   container.appendChild(currentCircle);
 
+  // XYZ軸の棒
+  const axisX = document.createElement("div");
+  axisX.className = "axis x-axis";
+  container.appendChild(axisX);
+  const axisY = document.createElement("div");
+  axisY.className = "axis y-axis";
+  container.appendChild(axisY);
+  const axisZ = document.createElement("div");
+  axisZ.className = "axis z-axis";
+  container.appendChild(axisZ);
+
   // ドラッグ回転
   let dragging = false, lastX = 0, lastY = 0;
   container.style.cursor = "grab";
@@ -158,22 +170,25 @@ function initXYPreview() {
     if (!dragging) return;
     const dx = e.clientX - lastX;
     const dy = e.clientY - lastY;
-    stageRotZ += dx * 0.5;
-    stageRotX -= dy * 0.5;
+    stageRotZ = (stageRotZ + dx * 0.5 + 360) % 360;
+    stageRotX = (stageRotX - dy * 0.5 + 360) % 360;
     lastX = e.clientX;
     lastY = e.clientY;
     applyStageTransform();
   };
   container.addEventListener("mousedown", e => {
+    e.preventDefault();
     dragging = true;
     lastX = e.clientX;
     lastY = e.clientY;
     container.style.cursor = "grabbing";
+    document.body.style.userSelect = "none";
   });
   window.addEventListener("mousemove", onMouseMove);
   window.addEventListener("mouseup", () => {
     dragging = false;
     container.style.cursor = "grab";
+    document.body.style.userSelect = "";
   });
 
   applyStageTransform();
@@ -244,6 +259,8 @@ function updateZPreview(z) {
 function applyStageTransform() {
   const container = document.getElementById("xy-stage");
   if (container) {
+    stageRotX = (stageRotX + 360) % 360;
+    stageRotZ = (stageRotZ + 360) % 360;
     container.style.transform = `rotateX(${stageRotX}deg) rotateZ(${stageRotZ}deg)`;
   }
 }

--- a/3dp_monitor.css
+++ b/3dp_monitor.css
@@ -244,6 +244,7 @@ body {
   box-sizing: border-box;
   perspective: 400px;
   perspective-origin: center;
+  overflow: hidden;
 }
 .stage {
   position: absolute;
@@ -836,6 +837,31 @@ input:checked + .slider:before {
   background: #555;
   border-radius: 4px 4px 0 0;
   border: 1px solid #333;
+}
+
+/* XYZ axis indicators */
+.axis {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+  transform-origin: bottom left;
+  pointer-events: none;
+}
+.x-axis {
+  width: 40px;
+  height: 2px;
+  background: red;
+}
+.y-axis {
+  width: 2px;
+  height: 40px;
+  background: green;
+}
+.z-axis {
+  width: 40px;
+  height: 2px;
+  background: blue;
+  transform: rotateX(90deg);
 }
 
 /* stage rotation control buttons */


### PR DESCRIPTION
## Summary
- keep stage rotation angles within 0-360 degrees
- prevent text selection while dragging stage
- crop rotated stage inside the preview frame
- show simple X/Y/Z axis bars for 3D orientation

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684d0bd82620832faa8a258178a8b49c