### PR TITLE
Sync spool preview with selection

### DIFF
--- a/3dp_lib/dashboard_spool_ui.js
+++ b/3dp_lib/dashboard_spool_ui.js
@@ -3,6 +3,7 @@
 import {
   getSpools,
   getCurrentSpoolId,
+  getSpoolById,
   setCurrentSpoolId,
   addSpool,
   updateSpool,
@@ -15,6 +16,33 @@ function initSpoolUI() {
   const listEl = document.getElementById("spool-list");
   const addBtn = document.getElementById("spool-add-btn");
   if (!listEl || !addBtn) return;
+
+  /**
+   * 現在選択中のスプール情報をプレビューに反映
+   * @param {Object} sp スプールデータ
+   */
+  function updatePreview(sp) {
+    const fp = window.filamentPreview;
+    if (!fp || !sp) return;
+
+    if (sp.color) fp.setOption("filamentColor", sp.color);
+    if (typeof sp.totalLengthMm === "number")
+      fp.setOption("filamentTotalLength", sp.totalLengthMm);
+    if (typeof sp.diameterMm === "number")
+      fp.setOption("filamentDiameter", sp.diameterMm);
+    if (sp.name) {
+      fp.setOption("reelName", sp.name);
+      fp.setOption("showReelName", true);
+    }
+    if (sp.material) {
+      fp.setOption("materialName", sp.material);
+      fp.setOption("showMaterialName", true);
+    } else {
+      fp.setOption("showMaterialName", false);
+    }
+    if (typeof sp.remainingLengthMm === "number")
+      fp.setRemainingLength(sp.remainingLengthMm);
+  }
 
   function render() {
     const spools = getSpools();
@@ -29,6 +57,7 @@ function initSpoolUI() {
       sel.textContent = "選択";
       sel.addEventListener("click", () => {
         setCurrentSpoolId(sp.id);
+        updatePreview(sp);
         render();
       });
       const edit = document.createElement("button");
@@ -39,6 +68,8 @@ function initSpoolUI() {
         const remain = prompt("残り長(mm)", String(sp.remainingLengthMm));
         if (remain == null) return;
         updateSpool(sp.id, { name, remainingLengthMm: Number(remain) });
+        const updated = getSpoolById(sp.id);
+        if (sp.id === getCurrentSpoolId()) updatePreview(updated);
         render();
       });
       const del = document.createElement("button");


### PR DESCRIPTION
## Summary
- update spool UI import list
- propagate spool data to filament preview on selection and after edits

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d17911530832f87af0d683d65882b