### PR TITLE
Add extended spool fields

### DIFF
--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -32,11 +32,26 @@ export function addSpool(data) {
   const spool = {
     id: genId(),
     name: data.name || "",
-    color: data.color || "",
-    material: data.material || "",
+    reelSubName: data.reelSubName || "",
+    materialName: data.materialName || data.material || "",
+    materialSubName: data.materialSubName || "",
+    filamentDiameter: Number(data.filamentDiameter) || 1.75,
+    filamentColor: data.filamentColor || data.color || "#22C55E",
+    reelOuterDiameter: Number(data.reelOuterDiameter) || 200,
+    reelThickness: Number(data.reelThickness) || 68,
+    reelWindingInnerDiameter: Number(data.reelWindingInnerDiameter) || 95,
+    reelCenterHoleDiameter: Number(data.reelCenterHoleDiameter) || 54,
+    reelBodyColor: data.reelBodyColor || "#A1A1AA",
+    reelFlangeTransparency: data.reelFlangeTransparency ?? 0.4,
+    manufacturerName: data.manufacturerName || "",
+    purchasePrice: Number(data.purchasePrice) || 0,
+    density: Number(data.density) || 0,
     totalLengthMm: Number(data.totalLengthMm) || 0,
     remainingLengthMm: Number(data.remainingLengthMm) || 0,
-    deleted: false
+    deleted: false,
+    // old keys for backward compatibility
+    color: data.color || "",
+    material: data.material || ""
   };
   monitorData.filamentSpools.push(spool);
   saveUnifiedStorage();

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -18,6 +18,24 @@ import { logManager } from "./dashboard_log_util.js";
 let _enableStorageLog = false;
 let _lastSavedJson    = null;
 
+function applySpoolDefaults(sp) {
+  sp.filamentDiameter ??= 1.75;
+  sp.filamentColor ??= "#22C55E";
+  sp.reelOuterDiameter ??= 200;
+  sp.reelThickness ??= 68;
+  sp.reelWindingInnerDiameter ??= 95;
+  sp.reelCenterHoleDiameter ??= 54;
+  sp.reelBodyColor ??= "#A1A1AA";
+  sp.reelFlangeTransparency ??= 0.4;
+  sp.manufacturerName ??= "";
+  sp.materialName ??= sp.material ?? "";
+  sp.materialSubName ??= "";
+  sp.purchasePrice ??= 0;
+  sp.density ??= 0;
+  sp.reelSubName ??= "";
+  return sp;
+}
+
 /**
  * ローカルストレージ保存時のデバッグログを有効／無効化する。
  *
@@ -112,7 +130,7 @@ export function restoreUnifiedStorage() {
       if (data.appSettings)    monitorData.appSettings    = data.appSettings;
       if (data.machines)       monitorData.machines       = data.machines;
       if (Array.isArray(data.filamentSpools))
-        monitorData.filamentSpools = data.filamentSpools;
+        monitorData.filamentSpools = data.filamentSpools.map(sp => applySpoolDefaults(sp));
       if ("currentSpoolId" in data)
         monitorData.currentSpoolId = data.currentSpoolId;
       _lastSavedJson = saved;


### PR DESCRIPTION
## Summary
- extend `addSpool` with filament and reel details
- keep old fields for backwards compatibility
- ensure restored data gains default spool values

## Testing
- `node --check 3dp_lib/dashboard_spool.js`
- `node --check 3dp_lib/dashboard_storage.js`


------
https://chatgpt.com/codex/tasks/task_e_684d179e97ec832fac99c7408f36da91