### PR TITLE
Add material specs and spool temperature defaults

### DIFF
--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -34,6 +34,11 @@ export function addSpool(data) {
     name: data.name || "",
     color: data.color || "",
     material: data.material || "",
+    printTempMin: data.printTempMin == null ? null : Number(data.printTempMin),
+    printTempMax: data.printTempMax == null ? null : Number(data.printTempMax),
+    bedTempMin:   data.bedTempMin   == null ? null : Number(data.bedTempMin),
+    bedTempMax:   data.bedTempMax   == null ? null : Number(data.bedTempMax),
+    density:      data.density      == null ? null : Number(data.density),
     totalLengthMm: Number(data.totalLengthMm) || 0,
     remainingLengthMm: Number(data.remainingLengthMm) || 0,
     deleted: false

--- a/3dp_lib/dashboard_spool_ui.js
+++ b/3dp_lib/dashboard_spool_ui.js
@@ -8,6 +8,8 @@ import {
   updateSpool,
   deleteSpool
 } from "./dashboard_spool.js";
+import { showInputDialog } from "./dashboard_ui_confirm.js";
+import { MATERIAL_SPECS } from "./material_specs.js";
 
 document.addEventListener("DOMContentLoaded", initSpoolUI);
 
@@ -54,12 +56,35 @@ function initSpoolUI() {
     });
   }
 
-  addBtn.addEventListener("click", () => {
-    const name = prompt("スプール名");
+  addBtn.addEventListener("click", async () => {
+    const name = await showInputDialog({ title: "スプール名" });
     if (!name) return;
-    const total = parseFloat(prompt("総長(mm)", "10000")) || 0;
-    const remain = parseFloat(prompt("残り長(mm)", String(total))) || 0;
-    addSpool({ name, totalLengthMm: total, remainingLengthMm: remain });
+    const material = await showInputDialog({ title: "素材", defaultValue: "PLA" });
+    if (material == null) return;
+    const spec = MATERIAL_SPECS[material.toUpperCase()];
+    const pMin = await showInputDialog({ title: "ノズル温度min", defaultValue: spec?.printTemp[0] ?? "" });
+    if (pMin == null) return;
+    const pMax = await showInputDialog({ title: "ノズル温度max", defaultValue: spec?.printTemp[1] ?? "" });
+    if (pMax == null) return;
+    const bMin = await showInputDialog({ title: "ベッド温度min", defaultValue: spec?.bedTemp[0] ?? "" });
+    if (bMin == null) return;
+    const bMax = await showInputDialog({ title: "ベッド温度max", defaultValue: spec?.bedTemp[1] ?? "" });
+    if (bMax == null) return;
+    const dens = await showInputDialog({ title: "密度(g/cm³)", defaultValue: spec?.density ?? "" });
+    if (dens == null) return;
+    const total = parseFloat(await showInputDialog({ title: "総長(mm)", defaultValue: "10000" })) || 0;
+    const remain = parseFloat(await showInputDialog({ title: "残り長(mm)", defaultValue: String(total) })) || 0;
+    addSpool({
+      name,
+      material,
+      printTempMin: parseFloat(pMin) || null,
+      printTempMax: parseFloat(pMax) || null,
+      bedTempMin:   parseFloat(bMin) || null,
+      bedTempMax:   parseFloat(bMax) || null,
+      density:      parseFloat(dens) || null,
+      totalLengthMm: total,
+      remainingLengthMm: remain
+    });
     render();
   });
 

--- a/3dp_lib/material_specs.js
+++ b/3dp_lib/material_specs.js
@@ -1,0 +1,8 @@
+"use strict";
+
+export const MATERIAL_SPECS = {
+  PLA:  { printTemp: [190, 220], bedTemp: [0, 60],  density: 1.24 },
+  PETG: { printTemp: [220, 250], bedTemp: [60, 80], density: 1.27 },
+  ABS:  { printTemp: [230, 260], bedTemp: [80, 110], density: 1.04 },
+  TPU:  { printTemp: [210, 230], bedTemp: [0, 60],  density: 1.20 }
+};


### PR DESCRIPTION
## Summary
- define a MATERIAL_SPECS map for common filaments
- extend spool data to store temperature range and density
- ask for spool attributes with defaults when creating spools

## Testing
- `node --check 3dp_lib/material_specs.js`
- `node --check 3dp_lib/dashboard_spool.js`
- `node --check 3dp_lib/dashboard_spool_ui.js`


------
https://chatgpt.com/codex/tasks/task_e_684d17b66310832fa85df819b301f8d9