### PR TITLE
Improve notification log styling and timestamp

### DIFF
--- a/3dp_lib/dashboard_log_util.js
+++ b/3dp_lib/dashboard_log_util.js
@@ -214,7 +214,7 @@ export function initLogRenderer(containerEl) {
       const errBox = document.getElementById("notification-history");
       if (errBox) {
         const clone = p.cloneNode(true);
-        clone.className = "notification-entry";
+        clone.className = `notification-entry log-${entry.level}`;
         errBox.appendChild(clone);
       }
     }
@@ -300,7 +300,7 @@ function writeLogsToContainer(logs, container, className) {
   container.innerHTML = "";
   logs.forEach(e => {
     const p = document.createElement("p");
-    p.className = className;
+    p.className = `${className} log-${e.level}`;
     p.textContent = `[${e.timestamp}] ${e.msg}`;
     container.appendChild(p);
   });
@@ -321,11 +321,16 @@ export function flushNormalLogsToDom() {
  * 通知ログを再描画
  */
 export function flushNotificationLogsToDom() {
+  const logs = logManager.getNotifications();
   writeLogsToContainer(
-    logManager.getNotifications(),
+    logs,
     document.getElementById("notification-history"),
     "notification-entry"
   );
+  if (logs.length) {
+    const tsField = document.querySelector('[data-field="lastNotificationTimestamp"] .value');
+    if (tsField) tsField.textContent = logs[logs.length - 1].timestamp;
+  }
 }
 
 /* ============================================================================
@@ -371,4 +376,6 @@ export function pushLog(msg, level = "info", notify = false) {
  */
 export function pushNotificationLog(msg, level = "info") {
   pushLog(msg, level, true);
+  const tsField = document.querySelector('[data-field="lastNotificationTimestamp"] .value');
+  if (tsField) tsField.textContent = getCurrentTimestamp();
 }

--- a/3dp_lib/dashboard_ui.js
+++ b/3dp_lib/dashboard_ui.js
@@ -243,6 +243,8 @@ function initAutoScrollHandlers() {
 function initTabHandlers() {
   tabReceived.addEventListener("click", () => {
     lastActiveTab = "received";
+    tabReceived.classList.add("active");
+    tabNotification.classList.remove("active");
     receivedBox.classList.remove("hidden");
     tsReceivedEl.classList.remove("hidden");
     notifBox.classList.add("hidden");
@@ -254,6 +256,8 @@ function initTabHandlers() {
 
   tabNotification.addEventListener("click", () => {
     lastActiveTab = "notification";
+    tabNotification.classList.add("active");
+    tabReceived.classList.remove("active");
     receivedBox.classList.add("hidden");
     tsReceivedEl.classList.add("hidden");
     notifBox.classList.remove("hidden");

--- a/3dp_monitor.css
+++ b/3dp_monitor.css
@@ -487,10 +487,23 @@ input:checked + .slider:before {
   justify-content: space-between;
   margin-bottom: 5px;
 }
-.tabs button {
-  margin-right: 5px;
+.log-card .tabs {
+  display: flex;
+  border-bottom: 1px solid #ccc;
+}
+.log-card .tabs button {
+  margin-right: 2px;
   font-size: 12px;
-  padding: 2px 4px;
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  border-bottom: none;
+  background: #eee;
+  border-radius: 4px 4px 0 0;
+  cursor: pointer;
+}
+.log-card .tabs button.active {
+  background: #fff;
+  font-weight: bold;
 }
 .log-controls button {
   font-size: 12px;
@@ -560,8 +573,6 @@ input:checked + .slider:before {
 #notification-history .notification-entry {
   font-family: Consolas, monospace;
   font-size: 90%;
-  padding: 3px;
-  border-bottom: 1px solid #ccc;
 }
 
 /* ---------------------------------------------------------------
@@ -597,10 +608,8 @@ input:checked + .slider:before {
 .initial-log { background: #eef; }
 .state-log { background-color: #dfd; }
 .notification-entry {
-  background-color: #ffe9e9;
-  padding: 4px 8px;
-  margin-bottom: 4px;
-  border-radius: 3px;
+  margin: 0;
+  padding: 2px 0;
 }
 
 


### PR DESCRIPTION
## Summary
- style log tabs like tabs
- tighten spacing of notification log
- color-code notification entries per log level
- mark active tab on click
- update last notification timestamp automatically

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684d18c1ba40832fa4c977ba39bab3e3