### PR TITLE
Modify stage preview decorations

### DIFF
--- a/3dp_lib/dashboard_stage_preview.js
+++ b/3dp_lib/dashboard_stage_preview.js
@@ -114,10 +114,13 @@ function initXYPreview() {
   const rightWing = document.createElement("div");
   rightWing.className = "stage-wing right";
   container.appendChild(rightWing);
-  // 下のつまみ
-  const tab = document.createElement("div");
-  tab.className = "stage-tab";
-  container.appendChild(tab);
+  // 下のつまみ（左右それぞれ）
+  const leftTab = document.createElement("div");
+  leftTab.className = "stage-tab left";
+  container.appendChild(leftTab);
+  const rightTab = document.createElement("div");
+  rightTab.className = "stage-tab right";
+  container.appendChild(rightTab);
 
   // 履歴用ドット生成
   for (let i = 0; i < maxDots; i++) {

--- a/3dp_monitor.css
+++ b/3dp_monitor.css
@@ -815,29 +815,32 @@ input:checked + .slider:before {
 .stage-wing {
   position: absolute;
   bottom: 0;
-  width: 40px;
-  height: 30px;
+  width: 35px;
+  height: 20px;
   background: #555;
   clip-path: polygon(0 100%, 100% 100%, 50% 0);
+  border: 1px solid #666;
+  z-index: -1;
 }
 .stage-wing.left {
-  left: -30px;
+  left: -20px;
   transform: rotateY(180deg);
 }
 .stage-wing.right {
-  right: -30px;
+  right: -20px;
 }
 .stage-tab {
   position: absolute;
   bottom: -10px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 40px;
+  width: 20px;
   height: 15px;
   background: #555;
   border-radius: 4px 4px 0 0;
-  border: 1px solid #333;
+  border: 1px solid #666;
+  z-index: -1;
 }
+.stage-tab.left { left: 10%; transform: translateX(0%); }
+.stage-tab.right { right: 10%; transform: translateX(0%); }
 
 /* XYZ axis indicators */
 .axis {


### PR DESCRIPTION
## Summary
- tweak CSS for preview wing/tab sizes and placement
- create left/right stage tabs in JS
- position stage tabs relative to stage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684d17053234832fae4a145f867eeba9