### PR TITLE
Improve tab layout for logs and history

### DIFF
--- a/3dp_monitor.css
+++ b/3dp_monitor.css
@@ -485,7 +485,7 @@ input:checked + .slider:before {
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 5px;
+  margin-bottom: 0;
 }
 .log-card .tabs {
   display: flex;
@@ -504,6 +504,14 @@ input:checked + .slider:before {
 .log-card .tabs button.active {
   background: #fff;
   font-weight: bold;
+}
+.log-card .tab-content {
+  border: 1px solid #ccc;
+  border-top: none;
+  border-radius: 0 0 4px 4px;
+}
+.log-card .log-box {
+  border: none;
 }
 .log-controls button {
   font-size: 12px;
@@ -712,8 +720,30 @@ input:checked + .slider:before {
 }
 
 /* 2-tab panels */
-.print-history-card .tabs button.active { background:#444; color:#fff; }
-.print-history-card .tabs button { cursor:pointer; }
+.print-history-card .tabs {
+  display: flex;
+  border-bottom: 1px solid #ccc;
+}
+.print-history-card .tabs button {
+  margin-right: 2px;
+  font-size: 12px;
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  border-bottom: none;
+  background: #eee;
+  border-radius: 4px 4px 0 0;
+  cursor: pointer;
+}
+.print-history-card .tabs button.active {
+  background: #fff;
+  font-weight: bold;
+}
+.print-history-card .tab-content {
+  border: 1px solid #ccc;
+  border-top: none;
+  border-radius: 0 0 4px 4px;
+  padding: 0.5rem;
+}
 
 
 /* -------------------------------

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -605,11 +605,13 @@
         </div>
       </div>
 
-      <!-- ログ表示エリア -->
-      <div id="log" class="log-box"></div>
+      <div class="tab-content">
+        <!-- ログ表示エリア -->
+        <div id="log" class="log-box"></div>
 
-      <!-- 通知表示エリア (hidden 初期表示) -->
-      <div id="notification-history" class="log-box hidden"></div>
+        <!-- 通知表示エリア (hidden 初期表示) -->
+        <div id="notification-history" class="log-box hidden"></div>
+      </div>
     </div>
   </div>
 
@@ -633,8 +635,9 @@
       </div>
     </div>
 
-    <!-- ─── 印刷履歴タブ ─── -->
-    <div id="panel-print-history-tab">
+    <div class="tab-content">
+      <!-- ─── 印刷履歴タブ ─── -->
+      <div id="panel-print-history-tab">
   
       <h2 class="card-title">印刷履歴</h2>
       <div style="font-size:0.9em;">
@@ -688,10 +691,10 @@
           </tbody>
         </table>
       </div>
-    </div>
+      </div>
 
-    <!-- ─── ファイル一覧タブ ─── -->
-    <div id="panel-file-list" class="hidden">
+      <!-- ─── ファイル一覧タブ ─── -->
+      <div id="panel-file-list" class="hidden">
       <div>総ファイル数: <span id="file-list-total">0</span></div>
       <div class="filelist-container scrollable-body">
         <table id="file-list-table" class="fixed-header" style="width:100%; table-layout:auto;">
@@ -710,9 +713,9 @@
           <tbody></tbody>
         </table>
       </div>
-    </div>
+      </div>
 
-  </div>
+    </div>
 
 
   <div id="settings-card" class="card">


### PR DESCRIPTION
## Summary
- restyle log tabs so content shares a border
- make print history and file list buttons look like tabs
- wrap tab panels with `.tab-content` for unified borders

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d28eed4c8832fb41bca85fcf5f0eb