### PR TITLE
Add video link update for print history

### DIFF
--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -204,6 +204,10 @@ function handleSocketMessage(event) {
       const baseUrl = `http://${getDeviceIp()}:80`;
       printManager.refreshHistory(fetchStoredData, baseUrl);
     }
+    if (Array.isArray(data.elapseVideoList)) {
+      const baseUrl = `http://${getDeviceIp()}:80`;
+      printManager.updateVideoList(data.elapseVideoList, baseUrl);
+    }
   } catch (e) {
     pushLog("印刷履歴処理中にエラーが発生: " + e.message, "error");
     console.error("[ws.onmessage] 印刷履歴処理エラー:", e);

--- a/3dp_lib/dashboard_msg_handler.js
+++ b/3dp_lib/dashboard_msg_handler.js
@@ -83,6 +83,10 @@ export function handleMessage(data) {
       // fetchStoredData() will give us latestStoredData which contains this data
       printManager.refreshHistory(fetchStoredData, baseUrl);
     }
+    if (Array.isArray(data.elapseVideoList)) {
+      const baseUrl = `http://${getDeviceIp()}`;
+      printManager.updateVideoList(data.elapseVideoList, baseUrl);
+    }
 
 
     // restoreAggregatorState() のあとでキー初期化 → 以降は必ず storedData[key] が存在

--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -19,7 +19,9 @@ import {
   loadPrintCurrent,
   savePrintCurrent,
   loadPrintHistory,
-  savePrintHistory
+  savePrintHistory,
+  loadPrintVideos,
+  savePrintVideos
 } from "./dashboard_storage.js";
 
 import { formatEpochToDateTime } from "./dashboard_utils.js";
@@ -173,6 +175,22 @@ export function saveHistory(jobs) {
 }
 
 /**
+ * 保存済みの動画マップを取得する。
+ * @returns {Record<string, string>}
+ */
+export function loadVideos() {
+  return loadPrintVideos();
+}
+
+/**
+ * 動画マップを保存する。
+ * @param {Record<string, string>} map
+ */
+export function saveVideos(map) {
+  savePrintVideos(map);
+}
+
+/**
  * 保存済みジョブ配列を履歴テーブル用の簡易 raw 形式に変換します。
  *
  * @param {Array<Object>} jobs - loadHistory() で取得した履歴配列
@@ -193,6 +211,7 @@ export function jobsToRaw(jobs) {
       usagematerial: job.materialUsedMm,
       printfinish:   finishEpoch ? 1 : 0,
       filemd5:       "",
+      ...(job.videoUrl !== undefined && { videoUrl: job.videoUrl }),
       ...(job.preparationTime      !== undefined && { preparationTime:      job.preparationTime }),
       ...(job.firstLayerCheckTime   !== undefined && { firstLayerCheckTime:   job.firstLayerCheckTime }),
       ...(job.pauseTime             !== undefined && { pauseTime:             job.pauseTime }),
@@ -387,6 +406,11 @@ export async function refreshHistory(
   const jobs = Array.from(mergedMap.values())
     .sort((a, b) => b.id - a.id)
     .slice(0, MAX_HISTORY);
+
+  const videoMap = loadVideos();
+  jobs.forEach(j => {
+    if (videoMap[j.id]) j.videoUrl = videoMap[j.id];
+  });
   saveHistory(jobs);
 
   // 現在印刷中ジョブの更新があれば再描画
@@ -407,6 +431,41 @@ export async function refreshHistory(
     .sort((a, b) => b.id - a.id)
     .slice(0, MAX_HISTORY);
   renderHistoryTable(mergedRaw, baseUrl);
+}
+
+/**
+ * 動画リストをマージし履歴に適用する。
+ * @param {Array<Object>} videoArray
+ * @param {string} baseUrl
+ */
+export function updateVideoList(videoArray, baseUrl) {
+  if (!Array.isArray(videoArray) || !videoArray.length) return;
+  const map = { ...loadVideos() };
+  let updated = false;
+  videoArray.forEach(v => {
+    if (!v.id) return;
+    const url = `${baseUrl}/downloads/video/${v.id}.mp4`;
+    if (map[v.id] !== url) {
+      map[v.id] = url;
+      updated = true;
+    }
+  });
+  if (updated) saveVideos(map);
+
+  const jobs = loadHistory();
+  let changed = false;
+  jobs.forEach(job => {
+    const url = map[job.id];
+    if (url && job.videoUrl !== url) {
+      job.videoUrl = url;
+      changed = true;
+    }
+  });
+  if (changed) {
+    saveHistory(jobs);
+    const raw = jobsToRaw(jobs);
+    renderHistoryTable(raw, baseUrl);
+  }
 }
 
 /**
@@ -449,6 +508,7 @@ export function renderHistoryTable(rawArray, baseUrl) {
         : "—";
     const finish    = raw.printfinish ? "✔︎" : "";
     const md5       = raw.filemd5 || "—";
+    const videoLink = raw.videoUrl ? `<a href="${raw.videoUrl}" target="_blank" rel="noopener">📹</a>` : "";
     const tr = document.createElement("tr");
     tr.innerHTML = `
       <td>
@@ -475,6 +535,7 @@ export function renderHistoryTable(rawArray, baseUrl) {
       <td>${umaterial}</td>
       <td>${finish}</td>
       <td>${md5}</td>
+      <td>${videoLink}</td>
     `;
     tbody.appendChild(tr);
 

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -316,3 +316,23 @@ export function savePrintHistory(history) {
     history.slice(0, MAX_HISTORY);
   saveUnifiedStorage();
 }
+
+/**
+ * 印刷動画マップを取得する。
+ *
+ * @returns {Record<string, string>} id をキーとした動画 URL マップ
+ */
+export function loadPrintVideos() {
+  return monitorData.appSettings.printManager?.videos || {};
+}
+
+/**
+ * 印刷動画マップを保存する。
+ *
+ * @param {Record<string, string>} map - id をキーとした動画 URL マップ
+ */
+export function savePrintVideos(map) {
+  monitorData.appSettings.printManager ??= {};
+  monitorData.appSettings.printManager.videos = map;
+  saveUnifiedStorage();
+}

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -681,10 +681,11 @@
                 <th data-key="usagematerial">使用量（mm）</th>
                 <th data-key="printfinish">is成功?</th>
                 <th data-key="filemd5">ファイルMD5</th>
+                <th data-key="video">動画</th>
             </tr>
           </thead>
           <tbody>
-          <tr><td colspan='13'>データ読み込み待ち</td></tr>
+          <tr><td colspan='14'>データ読み込み待ち</td></tr>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
## Summary
- support saving print video info in storage
- merge and display videos in history
- refresh history when elapseVideoList arrives
- add `動画` column in history table

## Testing
- `node --check 3dp_lib/dashboard_printmanager.js`
- `node --check 3dp_lib/dashboard_connection.js`
- `node --check 3dp_lib/dashboard_msg_handler.js`
- `node --check 3dp_lib/dashboard_storage.js`

------
https://chatgpt.com/codex/tasks/task_e_684d2adc34d0832fbcd8550b5dc65ece