### PR TITLE
Fix history refresh button and sorting

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -37,7 +37,7 @@ import {
   flushNotificationLogsToDom,
   pushLog
 } from "./dashboard_log_util.js";
-import { updateConnectionUI, fetchStoredData, sendCommand, getDeviceIp } from "./dashboard_connection.js";
+import { updateConnectionUI } from "./dashboard_connection.js";
 import {
   startCameraStream,
   stopCameraStream
@@ -218,14 +218,7 @@ export function initializeDashboard({
   const historyBtn = document.getElementById("history-refresh-btn");
   if (historyBtn) {
     historyBtn.addEventListener("click", () => {
-      const ip = getDeviceIp();
-      // IP が取れない（未接続・まだデータ受信前など）はアラート
-      if (!ip) {
-        showAlert("プリンタに接続されていません。先に接続してください。", "warn");
-        return;
-      }
-      const baseUrl = `http://${ip}:80`;
-      printManager.refreshHistory(fetchStoredData, baseUrl);
+      document.getElementById("btn-history-list")?.click();
     });
   }
 

--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -202,7 +202,7 @@ function handleSocketMessage(event) {
     // （dashboard_printManager.js 側で実装）
     if (Array.isArray(data.historyList)) {
       const baseUrl = `http://${getDeviceIp()}:80`;
-      printManager.refreshHistory(fetchStoredData, baseUrl);
+      printManager.updateHistoryList(data.historyList, baseUrl);
     }
     if (Array.isArray(data.elapseVideoList)) {
       const baseUrl = `http://${getDeviceIp()}:80`;

--- a/3dp_lib/dashboard_msg_handler.js
+++ b/3dp_lib/dashboard_msg_handler.js
@@ -80,8 +80,7 @@ export function handleMessage(data) {
     // ── (1.a) プリンタから直接履歴が送られてきたら即パース＆描画 ──
     if (Array.isArray(data.historyList)) {
       const baseUrl = `http://${getDeviceIp()}`;
-      // fetchStoredData() will give us latestStoredData which contains this data
-      printManager.refreshHistory(fetchStoredData, baseUrl);
+      printManager.updateHistoryList(data.historyList, baseUrl);
     }
     if (Array.isArray(data.elapseVideoList)) {
       const baseUrl = `http://${getDeviceIp()}`;


### PR DESCRIPTION
## Summary
- refresh button now triggers `btn-history-list` to fetch data from the printer
- merge received history list via new `updateHistoryList` and keep sort headers functional
- prevent duplicated sort handlers on history table

## Testing
- `node --check 3dp_lib/dashboard_printmanager.js`
- `node --check 3dp_lib/dashboard_msg_handler.js`
- `node --check 3dp_lib/dashboard_connection.js`
- `node --check 3dp_lib/3dp_dashboard_init.js`


------
https://chatgpt.com/codex/tasks/task_e_684d33704fb0832f997dba7ae342aefc