### PR TITLE
Fix spin toggle UI and improve Z-axis visibility

### DIFF
--- a/3dp_lib/dashboard_stage_preview.js
+++ b/3dp_lib/dashboard_stage_preview.js
@@ -91,6 +91,9 @@ function initXYPreview() {
   const axisZ = document.createElement("div");
   axisZ.className = "axis z-axis";
   container.appendChild(axisZ);
+  const axisZCross = document.createElement("div");
+  axisZCross.className = "axis z-axis-cross";
+  container.appendChild(axisZCross);
   
   for (let i = 1; i <= gridCount; i++) {
     // 横線
@@ -286,33 +289,53 @@ function setCameraView() {
 
 // --- 新しい固定アングル ---
 function setFlatView() {
+  stopZSpin();
   stageRotX = 0;
   stageRotZ = 0;
   applyStageTransform();
 }
 
 function setTilt45View() {
+  stopZSpin();
   stageRotX = 45;
   stageRotZ = 0;
   applyStageTransform();
 }
 
 function setObliqueView() {
+  stopZSpin();
   stageRotX = 65;
   stageRotZ = 72.5;
   applyStageTransform();
 }
 
 let spinTimer = null;
-function toggleZSpin() {
+function updateSpinButton(active) {
+  const btn = document.getElementById("btn-stage-spin");
+  if (!btn) return;
+  if (active) {
+    btn.classList.add("stage-spin-active");
+  } else {
+    btn.classList.remove("stage-spin-active");
+  }
+}
+
+function stopZSpin() {
   if (spinTimer) {
     clearInterval(spinTimer);
     spinTimer = null;
+    updateSpinButton(false);
+  }
+}
+function toggleZSpin() {
+  if (spinTimer) {
+    stopZSpin();
   } else {
     spinTimer = setInterval(() => {
       stageRotZ = (stageRotZ + 2) % 360;
       applyStageTransform();
     }, 100);
+    updateSpinButton(true);
   }
 }
 
@@ -328,5 +351,6 @@ export {
   setFlatView,
   setTilt45View,
   setObliqueView,
-  toggleZSpin
+  toggleZSpin,
+  stopZSpin
 };

--- a/3dp_monitor.css
+++ b/3dp_monitor.css
@@ -902,8 +902,14 @@ input:checked + .slider:before {
 .z-axis {
   width: 40px;
   height: 3px;
-  background: blue;
-  transform: rotateX(-90deg) rotateZ(-90deg);
+  background: #4ea3ff;
+  transform: rotateX(-90deg) rotateZ(-90deg) translateZ(2px);
+}
+.z-axis-cross {
+  width: 40px;
+  height: 3px;
+  background: #4ea3ff;
+  transform: rotateX(-90deg) translateZ(2px);
 }
 
 /* stage rotation control buttons */
@@ -917,4 +923,8 @@ input:checked + .slider:before {
 }
 .stage-rotate-buttons button:last-child {
   margin-right: 0;
+}
+.stage-rotate-buttons .stage-spin-active {
+  background: #e5e7eb;
+  border: 1px solid #888;
 }


### PR DESCRIPTION
## Summary
- bump z-axis style to keep it visible when rotating
- disable spin mode when view preset buttons are clicked
- highlight spin button when active
- add cross arm to z-axis and brighten blue color

## Testing
- `node --check 3dp_lib/dashboard_stage_preview.js`


------
https://chatgpt.com/codex/tasks/task_e_684d2c730e90832f98c58eb8250aa217