### PR TITLE
Fix history reload issues

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -37,7 +37,7 @@ import {
   flushNotificationLogsToDom,
   pushLog
 } from "./dashboard_log_util.js";
-import { updateConnectionUI, fetchStoredData, sendCommand, getDeviceIp } from "./dashboard_connection.js";
+import { updateConnectionUI } from "./dashboard_connection.js";
 import {
   startCameraStream,
   stopCameraStream
@@ -211,6 +211,19 @@ export function initializeDashboard({
     setTimeout(startCameraStream(), 1500);
   }
 
+  // (12.5) 保存済みの履歴と現在印刷を表示
+  const savedJobs = printManager.loadHistory();
+  if (savedJobs.length) {
+    const baseUrl = monitorData.appSettings.wsDest
+      ? `http://${monitorData.appSettings.wsDest}:80`
+      : "";
+    const raw = printManager.jobsToRaw(savedJobs);
+    printManager.renderHistoryTable(raw, baseUrl);
+  }
+  printManager.renderPrintCurrent(
+    document.getElementById("print-current-container")
+  );
+
   // (13) ファイルマネージャ初期化
   FileManager.init();
 
@@ -218,14 +231,7 @@ export function initializeDashboard({
   const historyBtn = document.getElementById("history-refresh-btn");
   if (historyBtn) {
     historyBtn.addEventListener("click", () => {
-      const ip = getDeviceIp();
-      // IP が取れない（未接続・まだデータ受信前など）はアラート
-      if (!ip) {
-        showAlert("プリンタに接続されていません。先に接続してください。", "warn");
-        return;
-      }
-      const baseUrl = `http://${ip}:80`;
-      printManager.refreshHistory(fetchStoredData, baseUrl);
+      document.getElementById("btn-history-list")?.click();
     });
   }
 

--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -202,7 +202,7 @@ function handleSocketMessage(event) {
     // （dashboard_printManager.js 側で実装）
     if (Array.isArray(data.historyList)) {
       const baseUrl = `http://${getDeviceIp()}:80`;
-      printManager.refreshHistory(fetchStoredData, baseUrl);
+      printManager.updateHistoryList(data.historyList, baseUrl);
     }
     if (Array.isArray(data.elapseVideoList)) {
       const baseUrl = `http://${getDeviceIp()}:80`;

--- a/3dp_lib/dashboard_msg_handler.js
+++ b/3dp_lib/dashboard_msg_handler.js
@@ -80,8 +80,7 @@ export function handleMessage(data) {
     // ── (1.a) プリンタから直接履歴が送られてきたら即パース＆描画 ──
     if (Array.isArray(data.historyList)) {
       const baseUrl = `http://${getDeviceIp()}`;
-      // fetchStoredData() will give us latestStoredData which contains this data
-      printManager.refreshHistory(fetchStoredData, baseUrl);
+      printManager.updateHistoryList(data.historyList, baseUrl);
     }
     if (Array.isArray(data.elapseVideoList)) {
       const baseUrl = `http://${getDeviceIp()}`;


### PR DESCRIPTION
## Summary
- show saved history and current job on startup
- merge history data via `updateHistoryList` from incoming messages
- keep table sort functional after manual refresh

## Testing
- `node --check 3dp_lib/3dp_dashboard_init.js`
- `node --check 3dp_lib/dashboard_printmanager.js`
- `node --check 3dp_lib/dashboard_connection.js`
- `node --check 3dp_lib/dashboard_msg_handler.js`


------
https://chatgpt.com/codex/tasks/task_e_684d33704fb0832f997dba7ae342aefc