### PR TITLE
Improve history merge and storage

### DIFF
--- a/3dp_lib/dashboard_filemanager.js
+++ b/3dp_lib/dashboard_filemanager.js
@@ -5,6 +5,7 @@
 
 const containerId = 'filemanager-history';
 const STORAGE_KEY = '3dp-filemanager-history';
+const MAX_HISTORY = 150;
 
 /**
  * @typedef {Object} HistoryEntry
@@ -85,7 +86,23 @@ export const FileManager = {
   saveFromPrinterData({ historyList, elapseVideoList }) {
     const history = historyList?.rawValue || [];
     const videos  = elapseVideoList?.rawValue || [];
-    _saveHistoryData(history, videos);
+    const stored = _loadHistoryData();
+
+    const histMap = new Map(stored.historyList.map(h => [h.id, h]));
+    history.forEach(h => {
+      if (h && h.id != null) histMap.set(h.id, h);
+    });
+    const mergedHistory = Array.from(histMap.values())
+      .sort((a, b) => b.id - a.id)
+      .slice(0, MAX_HISTORY);
+
+    const videoMap = new Map(stored.elapseVideoList.map(v => [v.id, v]));
+    videos.forEach(v => {
+      if (v && v.id != null) videoMap.set(v.id, v);
+    });
+    const mergedVideos = Array.from(videoMap.values());
+
+    _saveHistoryData(mergedHistory, mergedVideos);
     this.render();
   },
 

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -62,7 +62,7 @@ function pushLog(msg, isErr = false) {
 /** localStorage へ保存するキー名 */
 const STORAGE_KEY = "3dp-monitor_1.400";
 /** 印刷履歴の最大保持件数 */
-const MAX_HISTORY = 50;
+const MAX_HISTORY = 150;
 
 /**
  * monitorData 全体を JSON にシリアライズし、localStorage に保存する。


### PR DESCRIPTION
## Summary
- merge printer history with existing data in FileManager
- keep up to 150 history entries in unified storage

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684d3e5727c0832f976cd1ae65ecbd79