### PR TITLE
Improve video list merge behavior

### DIFF
--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -521,8 +521,14 @@ export function updateHistoryList(
 
 /**
  * 動画リストをマージし履歴に適用する。
- * @param {Array<Object>} videoArray
- * @param {string} baseUrl
+ *
+ * - 動画マップまたは履歴が更新された場合、`renderHistoryTable()` を呼び出し
+ *   UI を即時更新する。
+ * - 動画マップに変更があった場合はログに "完了" が表示される。
+ *
+ * @param {Array<Object>} videoArray - 新規取得した動画情報の配列
+ * @param {string} baseUrl           - サーバーのベース URL
+ * @returns {void}
  */
 export function updateVideoList(videoArray, baseUrl) {
   if (!Array.isArray(videoArray) || !videoArray.length) return;
@@ -552,14 +558,16 @@ export function updateVideoList(videoArray, baseUrl) {
   });
   if (changed) {
     saveHistory(jobs);
+  }
+  if (updated || changed) {
     const raw = jobsToRaw(jobs);
     renderHistoryTable(raw, baseUrl);
   }
   pushLog(
-    `[updateVideoList] 保存データとマージ ${changed ? "完了" : "変更なし"}`,
+    `[updateVideoList] 保存データとマージ ${updated || changed ? "完了" : "変更なし"}`,
     "info"
   );
-  if (changed) {
+  if (updated || changed) {
     pushLog("[updateVideoList] UI へ反映しました", "info");
   }
 }


### PR DESCRIPTION
## Summary
- document how video map updates trigger table re-rendering
- re-render history table when videos or jobs change
- log when merges are applied

## Testing
- `git show -n 1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d50e52600832f9316e3bb1ebd0d98