### PR TITLE
Improve timer resume and autosave

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -294,7 +294,8 @@ const persistKeys = [
   "predictedFinishEpoch",
   "estimatedRemainingTime",
   "tsCompleteStart",
-  "printFinishTime"
+  "printFinishTime",
+  "prevPrintID"
 ];
 
 /**
@@ -349,7 +350,7 @@ export function persistPrintResume() {
 
  
 /** 自動保存間隔（ミリ秒） */
-const AUTO_SAVE_INTERVAL_MS = 10 * 1000; // 10秒
+const AUTO_SAVE_INTERVAL_MS = 3 * 60 * 1000; // 3分
 
 /**
  * autoSaveAll:


### PR DESCRIPTION
## Summary
- persist previous print ID for resume
- handle idle states when calculating completion elapsed time
- autosave every 3 minutes

## Testing
- `node -c 3dp_lib/dashboard_aggregator.js`
- `node -c 3dp_lib/3dp_dashboard_init.js`

------
https://chatgpt.com/codex/tasks/task_e_684d61c92934832fb488c04e72f923a4