### PR TITLE
Isolate history per device

### DIFF
--- a/3dp_lib/dashboard_data.js
+++ b/3dp_lib/dashboard_data.js
@@ -24,6 +24,8 @@
  * @property {Object.<string,StoredDatum>} storedData  表示・UI 用データ
  * @property {Object}                runtimeData  揮発性データ（heartbeat など）
  * @property {Array<Object>}         historyData  印刷履歴
+ * @property {{current:Object|null, history:Array<Object>, videos:Object}} printStore
+ *   履歴や動画を保持するストア
  */
 
 /**
@@ -68,7 +70,12 @@ export function setCurrentHostname(host) {
     monitorData.machines[host] = {
       storedData: {},   // 監視データ（加工前の値や変換値など）
       runtimeData: {},  // 現在の温度・状態など、常に上書きされる値
-      historyData: []   // 印刷履歴などの配列データ
+      historyData: [],  // 印刷履歴などの配列データ
+      printStore: {     // 履歴や動画の永続保存先
+        current: null,
+        history: [],
+        videos: {}
+      }
     };
   }
 }
@@ -103,7 +110,12 @@ export const monitorData = {
     [PLACEHOLDER_HOSTNAME]: {
       storedData: {},
       runtimeData: {},
-      historyData: []
+      historyData: [],
+      printStore: {
+        current: null,
+        history: [],
+        videos: {}
+      }
     }
   },
   filamentSpools: [],

--- a/3dp_lib/dashboard_filemanager.js
+++ b/3dp_lib/dashboard_filemanager.js
@@ -3,8 +3,10 @@
  * プリント履歴データの保存と表示を担当する。
  */
 
+import { currentHostname } from "./dashboard_data.js";
+
 const containerId = 'filemanager-history';
-const STORAGE_KEY = '3dp-filemanager-history';
+const STORAGE_KEY_PREFIX = '3dp-filemanager-history-';
 const MAX_HISTORY = 150;
 
 /**
@@ -14,6 +16,9 @@ const MAX_HISTORY = 150;
  * @property {number} starttime      開始時刻の UNIX タイムスタンプ（秒）
  * @property {number} [usagematerial] 使用量（mm）
  * @property {string} [thumbnail]    サムネイル URL
+ * @property {string} hostname       ホスト名
+ * @property {string} ip             IP アドレス
+ * @property {number} updatedEpoch   情報更新時刻(秒)
  */
 
 /**
@@ -29,10 +34,14 @@ const MAX_HISTORY = 150;
  * @param {HistoryEntry[]} historyList - 整形済み履歴エントリ配列
  * @param {VideoEntry[]}   videoList   - 関連動画エントリ配列
  */
+function _storageKey() {
+  return `${STORAGE_KEY_PREFIX}${currentHostname || 'default'}`;
+}
+
 function _saveHistoryData(historyList, videoList) {
   const data = { historyList, elapseVideoList: videoList };
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    localStorage.setItem(_storageKey(), JSON.stringify(data));
   } catch (e) {
     console.warn('[FileManager] saveHistoryData failed:', e);
   }
@@ -48,7 +57,7 @@ function _saveHistoryData(historyList, videoList) {
  * }}
  */
 function _loadHistoryData() {
-  const raw = localStorage.getItem(STORAGE_KEY);
+  const raw = localStorage.getItem(_storageKey());
   if (!raw) return { historyList: [], elapseVideoList: [] };
   try {
     const data = JSON.parse(raw);

--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -110,6 +110,10 @@ export function parseRawHistoryEntry(raw, baseUrl) {
   const filamentColor       = raw.filamentColor;
   const filamentType        = raw.filamentType;
 
+  const hostname            = currentHostname || "";
+  const ip                  = getDeviceIp();
+  const updatedEpoch        = Math.floor(Date.now() / 1000);
+
   return {
     id,
     rawFilename,
@@ -126,7 +130,10 @@ export function parseRawHistoryEntry(raw, baseUrl) {
     pauseTime,
     filamentId,
     filamentColor,
-    filamentType
+    filamentType,
+    hostname,
+    ip,
+    updatedEpoch
   };
 }
 

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -282,7 +282,9 @@ export function estimateLocalStorageUsageBytes() {
  * @returns {Object|null} ジョブオブジェクト、未設定時は null
  */
 export function loadPrintCurrent() {
-  return monitorData.appSettings.printManager?.current || null;
+  const host = currentHostname;
+  const machine = host ? monitorData.machines[host] : null;
+  return machine?.printStore.current || null;
 }
 
 /**
@@ -291,8 +293,11 @@ export function loadPrintCurrent() {
  * @param {Object|null} job - 保存するジョブオブジェクト（null 許容）
  */
 export function savePrintCurrent(job) {
-  monitorData.appSettings.printManager ??= {};
-  monitorData.appSettings.printManager.current = job;
+  const host = currentHostname;
+  if (!host) return;
+  const machine = monitorData.machines[host];
+  if (!machine) return;
+  machine.printStore.current = job;
   saveUnifiedStorage();
 }
 
@@ -302,7 +307,9 @@ export function savePrintCurrent(job) {
  * @returns {Array<Object>} 履歴配列
  */
 export function loadPrintHistory() {
-  return monitorData.appSettings.printManager?.history || [];
+  const host = currentHostname;
+  const machine = host ? monitorData.machines[host] : null;
+  return machine?.printStore.history || [];
 }
 
 /**
@@ -311,9 +318,11 @@ export function loadPrintHistory() {
  * @param {Array<Object>} history - 保存対象の履歴配列
  */
 export function savePrintHistory(history) {
-  monitorData.appSettings.printManager ??= {};
-  monitorData.appSettings.printManager.history =
-    history.slice(0, MAX_HISTORY);
+  const host = currentHostname;
+  if (!host) return;
+  const machine = monitorData.machines[host];
+  if (!machine) return;
+  machine.printStore.history = history.slice(0, MAX_HISTORY);
   saveUnifiedStorage();
 }
 
@@ -323,7 +332,9 @@ export function savePrintHistory(history) {
  * @returns {Record<string, string>} id をキーとした動画 URL マップ
  */
 export function loadPrintVideos() {
-  const map = monitorData.appSettings.printManager?.videos || {};
+  const host = currentHostname;
+  const machine = host ? monitorData.machines[host] : null;
+  const map = machine?.printStore.videos || {};
   // デバッグ用: 現在保持している動画マップ件数をログに残す
   pushLog(`[loadPrintVideos] マップ読込件数: ${Object.keys(map).length}`);
   console.debug("[loadPrintVideos] map", map);
@@ -336,8 +347,11 @@ export function loadPrintVideos() {
  * @param {Record<string, string>} map - id をキーとした動画 URL マップ
  */
 export function savePrintVideos(map) {
-  monitorData.appSettings.printManager ??= {};
-  monitorData.appSettings.printManager.videos = map;
+  const host = currentHostname;
+  if (!host) return;
+  const machine = monitorData.machines[host];
+  if (!machine) return;
+  machine.printStore.videos = map;
   // デバッグ用: 保存する動画マップの件数をログに記録
   pushLog(`[savePrintVideos] マップ保存件数: ${Object.keys(map).length}`);
   console.debug("[savePrintVideos] map", map);


### PR DESCRIPTION
## Summary
- track print history and videos per host
- include host metadata in history entries
- keep FileManager data keyed by hostname

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e30241524832f91d6fd8c7c87c08d