### PR TITLE
Add MD5 and print count to file list

### DIFF
--- a/3dp_monitor.css
+++ b/3dp_monitor.css
@@ -799,7 +799,8 @@ input:checked + .slider:before {
 #file-list-table td[data-key="number"],
 #file-list-table td[data-key="layer"],
 #file-list-table td[data-key="size"],
-#file-list-table td[data-key="expect"] {
+#file-list-table td[data-key="expect"],
+#file-list-table td[data-key="prints"] {
   text-align: right;
 }
 

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -709,6 +709,8 @@
               <th data-key="size">サイズ(バイト)</th>
               <th data-key="mtime">更新日時</th>
               <th data-key="expect">予定使用量(mm)</th>
+              <th data-key="prints">印刷回数</th>
+              <th data-key="md5">MD5</th>
             </tr>
           </thead>
           <tbody></tbody>


### PR DESCRIPTION
## Summary
- compute per-file print statistics from history
- display md5 hash and print count in file list

## Testing
- `node --check 3dp_lib/dashboard_printmanager.js`

------
https://chatgpt.com/codex/tasks/task_e_684e7925ebb4832fa4a4234952375ca6