### PR TITLE
Improve dashboard layout and card styling

### DIFF
--- a/3dp_monitor.css
+++ b/3dp_monitor.css
@@ -14,17 +14,17 @@ body {
 }
 .card {
   background: #fff;
-  padding: 10px;
-  border-radius: 4px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
-  margin-bottom: 10px;
+  padding: 6px;
+  border-radius: 3px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.15);
+  margin-bottom: 8px;
 }
 .card-title {
   background-color: #444;
   color: #fff;
   font-size: 14px;
-  margin: 0 0 8px 0;
-  padding: 4px 8px;
+  margin: 0 0 6px 0;
+  padding: 3px 6px;
   border-radius: 3px;
   display: inline-block;
 }
@@ -32,7 +32,56 @@ body {
   display: flex;
   gap: 10px;
   flex-wrap: nowrap;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
+}
+
+/* プレビュー+状態+温度グラフのレイアウト調整 */
+.monitor-row {
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+
+.preview-wrapper {
+  flex: 0 0 310px;
+  max-width: 310px;
+  background-color: #f8f8f8;
+  padding: 6px;
+  box-sizing: border-box;
+}
+
+.preview-body {
+  width: 300px;
+  display: flex;
+  background-color: #fff;
+  padding: 6px;
+  border-radius: 3px;
+  gap: 6px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.15);
+}
+
+.info-wrapper {
+  flex: 1 1 350px;
+  max-width: 700px;
+  background-color: #f8f8f8;
+  padding: 6px;
+  box-sizing: border-box;
+  min-width: 200px;
+}
+
+.graph-wrapper {
+  flex: 1 1 340px;
+  max-width: 700px;
+}
+
+/* フィラメントプレビューヘッダ */
+.filament-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.filament-actions button {
+  margin-left: 4px;
 }
 
 /* ---------------------------------------------------------------
@@ -422,21 +471,7 @@ input:checked + .slider:before {
 /* ---------------------------------------------------------------
    プレビューエリア
 --------------------------------------------------------------- */
-.preview-wrapper {
-  border: 2px solid green;
-  padding: 10px;
-  background-color: #f8f8f8;
-  min-width: 300px;
-}
-.preview-header { margin-bottom: 8px; font-weight: bold; }
-.preview-body {
-  display: flex;
-  background-color: #fff;
-  padding: 8px;
-  border-radius: 4px;
-  gap: 10px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
-}
+.preview-header { margin-bottom: 6px; font-weight: bold; }
 .stage .grid-line { position: absolute; background-color: #777777; }
 .stage .grid-line.center { background-color: #999999; }
 .stage .grid-line.vertical { width: 1px; height: 100%; }
@@ -477,7 +512,6 @@ input:checked + .slider:before {
 /* ---------------------------------------------------------------
    機器情報＆ログエリア
 --------------------------------------------------------------- */
-.info-wrapper { border: 2px solid green; padding: 10px; background-color: #f8f8f8; min-width: 200px; }
 .info-card { flex: 1; min-width: 250px; }
 .log-card { flex: 2; min-width: 300px; }
 .log-card-header {

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -97,9 +97,9 @@
     </div>
 
     <!-- プレビュー・状態・温度グラフの行 (1.125~1.3で継承) -->
-    <div class="row">
+    <div class="row monitor-row">
       <!-- 左側：XY/Zプレビュー領域 -->
-      <div class="preview-wrapper">
+      <div class="card preview-wrapper">
         <div class="preview-header">
           <h2 class="card-title">ヘッド位置プレビュー</h2>
         </div>
@@ -153,13 +153,19 @@
 
           <!-- フィラメントプレビュー -->
           <div class="card" id="filament-preview-card" style="margin-top:10px;">
-            <h2 class="card-title">フィラメント</h2>
+            <div class="filament-header">
+              <h2 class="card-title">フィラメント</h2>
+              <div class="filament-actions">
+                <button id="filament-change-btn" class="btn" style="font-size:12px;">交換</button>
+                <button id="filament-list-btn" class="btn" style="font-size:12px;">一覧</button>
+              </div>
+            </div>
             <div id="filament-preview"></div>
           </div>
         </div>
 
       <!-- 中央：状態情報 -->
-      <div class="info-wrapper">
+      <div class="card info-wrapper">
         <div class="status-control-row">
           <div class="col1">
             <h2 class="card-title">状態</h2>
@@ -486,7 +492,7 @@
     </div>
 
     <!-- 右側：温度グラフ -->
-    <div class="graph-wrapper" style="flex: 1 1 auto; margin-left: 10px;">
+    <div class="graph-wrapper">
       <div class="card" id="temp-graph-card">
         <h2 class="card-title">温度グラフ (過去15分)</h2>
         <div style="position: relative; width: 100%; height: 300px;">


### PR DESCRIPTION
## Summary
- refine card appearance with smaller padding and shadows
- make main preview row responsive
- convert preview and status sections to card layout
- add filament actions buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ea80830f8832fb35de76c368d768f