### PR TITLE
Add reset button for temperature graph

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -44,7 +44,8 @@ import {
 } from "./dashboard_camera_ctrl.js";
 import {
   initTemperatureGraph,
-  updateTemperatureGraphFromStoredData
+  updateTemperatureGraphFromStoredData,
+  resetTemperatureGraphView
 } from "./dashboard_chart.js";
 import { FileManager } from "./dashboard_filemanager.js";
 import { createFilamentPreview } from "./dashboard_filament_view.js";
@@ -197,6 +198,10 @@ export function initializeDashboard({
   updateTemperatureGraphFromStoredData(
     monitorData.machines[currentHostname].storedData
   );
+
+  // (10.5) 温度グラフのズームリセットボタン
+  document.getElementById("temp-graph-reset-button")
+    ?.addEventListener("click", resetTemperatureGraphView);
 
   // (11) ページロード時の自動接続
   // 起動時は接続先が設定されているときだけ AutoConnect

--- a/3dp_lib/dashboard_chart.js
+++ b/3dp_lib/dashboard_chart.js
@@ -150,6 +150,20 @@ export function resetTemperatureGraph() {
   isFirstRender = true;
 }
 
+/**
+ * 温度グラフのズームおよびパン表示のみを初期状態へ戻します。
+ * データ内容は保持したまま、Chart.js Zoom プラグインが有効であれば
+ * resetZoom() を実行してスケールをリセットします。
+ *
+ * @returns {void}
+ */
+export function resetTemperatureGraphView() {
+  if (tempChart) {
+    // resetZoom が存在する場合のみ呼び出し
+    tempChart.resetZoom?.();
+  }
+}
+
 // ==============================
 // グラフ更新処理
 // ==============================

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -488,7 +488,10 @@
     <!-- 右側：温度グラフ -->
     <div class="graph-wrapper" style="flex: 1 1 auto; margin-left: 10px;">
       <div class="card" id="temp-graph-card">
-        <h2 class="card-title">温度グラフ (過去15分)</h2>
+        <div style="display:flex; align-items:center;">
+          <h2 class="card-title">温度グラフ (過去15分)</h2>
+          <button id="temp-graph-reset-button" style="font-size:12px; margin-left:4px;">リセット</button>
+        </div>
         <div style="position: relative; width: 100%; height: 300px;">
           <canvas id="temp-graph-canvas" style="width:100%; height:300px;"></canvas>
         </div>


### PR DESCRIPTION
## Summary
- add new reset button next to the temperature graph title
- export `resetTemperatureGraphView` to reset only zoom/pan
- wire up the reset button in initialization script

## Testing
- `git diff --check`

------
https://chatgpt.com/codex/tasks/task_e_684ea95bcc0c832fba7d46c3044cae10