### PR TITLE
Add AI monitoring switches

### DIFF
--- a/3dp_lib/dashboard_send_command.js
+++ b/3dp_lib/dashboard_send_command.js
@@ -284,10 +284,14 @@ export function initializeCommandPalette() {
 function initializeFanControls() {
   // ── トグルのみ 0/1 を送る
   const toggles = [
-    { id: "modelFanToggle2",    param: "fan" },           // モデルファン
-    { id: "backFanToggle2",     param: "fanCase" },       // ケースファン
-    { id: "sideFanToggle2",     param: "fanAuxiliary" },  // 側面ファン
-    { id: "ledToggle2",         param: "lightSw" }        // LED照明
+    { id: "modelFanToggle2",    param: "fan" },            // モデルファン
+    { id: "backFanToggle2",     param: "fanCase" },        // ケースファン
+    { id: "sideFanToggle2",     param: "fanAuxiliary" },   // 側面ファン
+    { id: "ledToggle2",         param: "lightSw" },        // LED照明
+    { id: "aiSwToggle",         param: "aiSw" },           // 印刷前自動調整
+    { id: "aiDetectionToggle",  param: "aiDetection" },    // 異常出力検知
+    { id: "aiFirstFloorToggle", param: "aiFirstFloor" },   // 初層出力確認
+    { id: "aiPausePrintToggle", param: "aiPausePrint" }    // 異常時一時停止
   ];
   toggles.forEach(({ id, param }) => {
     const el = document.getElementById(id);

--- a/3dp_lib/dashboard_ui_mapping.js
+++ b/3dp_lib/dashboard_ui_mapping.js
@@ -221,6 +221,10 @@ export const dashboardMapping = {
   fanAuxiliary:          { elementKey: "fanAuxiliary",         process: v => ({ value: utils.formatBinary(v), unit: "" }) },
   fanCase:               { elementKey: "fanCase",              process: v => ({ value: utils.formatBinary(v), unit: "" }) },
   lightSw:               { elementKey: "lightSw",              process: v => ({ value: utils.formatBinary(v), unit: "" }) },
+  aiSw:                  { elementKey: "aiSw",                 process: v => ({ value: utils.formatBinary(v), unit: "" }) },
+  aiDetection:           { elementKey: "aiDetection",          process: v => ({ value: utils.formatBinary(v), unit: "" }) },
+  aiFirstFloor:          { elementKey: "aiFirstFloor",         process: v => ({ value: utils.formatBinary(v), unit: "" }) },
+  aiPausePrint:          { elementKey: "aiPausePrint",         process: v => ({ value: utils.formatBinary(v), unit: "" }) },
 
   // --- FAN 風量強度 % ---
   modelFanPct:           { elementKey: "modelFanPct",          process: v => ({ value: parseInt(v,10), unit: "%" }) },

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -449,6 +449,56 @@
                 </div>
               </div>
             </div>
+            <div class="fan-lights-row">
+              <div class="fan-item">
+                <strong>印刷前自動調整</strong>
+                <label class="switch">
+                  <input type="checkbox" id="aiSwToggle" data-field="aiSw">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="aiSw">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+              <div class="fan-item">
+                <strong>異常出力検知</strong>
+                <label class="switch">
+                  <input type="checkbox" id="aiDetectionToggle" data-field="aiDetection">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="aiDetection">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+              <div class="fan-item">
+                <strong>初層出力確認</strong>
+                <label class="switch">
+                  <input type="checkbox" id="aiFirstFloorToggle" data-field="aiFirstFloor">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="aiFirstFloor">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+              <div class="fan-item">
+                <strong>異常時一時停止</strong>
+                <label class="switch">
+                  <input type="checkbox" id="aiPausePrintToggle" data-field="aiPausePrint">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="aiPausePrint">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+            </div>
 
             <!-- ─────────── 印刷速度スライダー ─────────── -->
             <div class="slider-box">
@@ -971,6 +1021,56 @@
                 </div>
                 <div>
                   <span data-field="materialStatus">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div class="fan-lights-row">
+              <div class="fan-item">
+                <strong>印刷前自動調整</strong>
+                <label class="switch">
+                  <input type="checkbox" id="aiSwToggle" data-field="aiSw">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="aiSw">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+              <div class="fan-item">
+                <strong>異常出力検知</strong>
+                <label class="switch">
+                  <input type="checkbox" id="aiDetectionToggle" data-field="aiDetection">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="aiDetection">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+              <div class="fan-item">
+                <strong>初層出力確認</strong>
+                <label class="switch">
+                  <input type="checkbox" id="aiFirstFloorToggle" data-field="aiFirstFloor">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="aiFirstFloor">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+              <div class="fan-item">
+                <strong>異常時一時停止</strong>
+                <label class="switch">
+                  <input type="checkbox" id="aiPausePrintToggle" data-field="aiPausePrint">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="aiPausePrint">
                     <span class="value">--</span><span class="unit"></span>
                   </span>
                 </div>


### PR DESCRIPTION
## Summary
- add new AI feature switch row to monitor UI
- send AI feature switch status just like LEDs
- map AI feature fields for live updates

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684f79922764832f8b0c5d4edcb7bc02