### PR TITLE
Fix createFilamentPreview error when reset button hidden

### DIFF
--- a/3dp_lib/dashboard_filament_view.js
+++ b/3dp_lib/dashboard_filament_view.js
@@ -13,7 +13,7 @@
  * 【公開関数一覧】
  * - {@link createFilamentPreview}：プレビューを生成
  *
- * @version 1.390.193 (PR #86)
+ * @version 1.390.209 (PR #93)
  * @since   1.390.193 (PR #86)
  *
  * ------
@@ -1171,12 +1171,14 @@ export function createFilamentPreview(mount, opts) {
   }
 
   /* --- リセット --- */
-  btnReset.addEventListener('click', () => {
-    rotX = o.initialRotX;
-    rotY = o.initialRotY;
-    rotZ = o.initialRotZ;
-    redraw();
-  });
+  if (btnReset) {
+    btnReset.addEventListener('click', () => {
+      rotX = o.initialRotX;
+      rotY = o.initialRotY;
+      rotZ = o.initialRotZ;
+      redraw();
+    });
+  }
 
   /* 初回描画 */
   redraw();


### PR DESCRIPTION
## Summary
- prevent `btnReset` null reference when `showResetButton` is disabled
- update module version

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685100242300832fb16de31bc6e4f297