### PR TITLE
Add quick controls for feedrate and flow rate

### DIFF
--- a/3dp_monitor.css
+++ b/3dp_monitor.css
@@ -565,6 +565,18 @@ body {
   text-align: center;
   min-width: 70px;
 }
+.quick-buttons {
+  display: flex;
+  gap: 2px;
+  flex-wrap: wrap;
+  margin-left: 2px;
+}
+.quick-buttons button,
+.send-btn {
+  font-family: "Arial Narrow", "sun serif";
+  font-size: 12px;
+  margin-left: 2px;
+}
 .fan-lights-row {
   display: flex;
   flex-wrap: wrap;

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -500,48 +500,64 @@
               </div>
             </div>
 
-            <!-- ─────────── 印刷速度スライダー ─────────── -->
-            <div class="slider-box">
-              <div style="font-weight:bold;">印刷速度</div>
-              <div>現在:
-                <span data-field="curFeedratePct">
-                  <span class="value">--</span><span class="unit">%</span>
-                </span>
+            <!-- ─────────── 印刷速度・フロー率 ─────────── -->
+            <div class="temp-row" style="margin-top:5px;">
+              <div class="temp-box">
+                <div style="font-weight:bold;">印刷速度</div>
+                <div>現在:
+                  <span data-field="curFeedratePct">
+                    <span class="value">--</span><span class="unit">%</span>
+                  </span>
+                </div>
+                <div class="control-row">
+                  <input type="range"
+                         id="feedrateSlider"
+                         data-field="curFeedratePct"
+                         step="1"
+                         min="0" max="200" />
+                  <input type="number"
+                         id="feedrateInput"
+                         data-field="curFeedratePct"
+                         min="0" max="200"
+                         step="1"
+                         style="width:4em" />
+                  <button id="feedrateSendBtn" class="send-btn">⏎</button>
+                  <div class="quick-buttons">
+                    <button class="feedrate-preset" data-value="50">50%</button>
+                    <button class="feedrate-preset" data-value="80">80%</button>
+                    <button class="feedrate-preset" data-value="100">等速</button>
+                    <button class="feedrate-preset" data-value="120">120%</button>
+                    <button class="feedrate-preset" data-value="150">150%</button>
+                  </div>
+                </div>
               </div>
-              <div class="control-row">
-                <input type="range"
-                       id="feedrateSlider"
-                       data-field="curFeedratePct"
-                       step="1" 
-                       min="0" max="200" />
-                <input type="number"
-                       id="feedrateInput"
-                       data-field="curFeedratePct"
-                       min="0" max="200"
-                       step="1" 
-                       style="width:4em" />
-              </div>
-            </div>
-            
-            <!-- ─────────── フロー率スライダー ─────────── -->
-            <div class="slider-box">
-              <div style="font-weight:bold;">フロー率</div>
-              <div>現在:
-                <span data-field="curFlowratePct">
-                  <span class="value">--</span><span class="unit">%</span>
-                </span>
-              </div>
-              <div class="control-row">
-                <input type="range"
-                       id="flowrateSlider"
-                       data-field="curFlowratePct"
-                       step="1"
-                       min="0" max="200" />
-                <input type="number"
-                       id="flowrateInput"
-                       data-field="curFlowratePct"
-                       min="0" max="200"
-                       style="width:4em" />
+
+              <div class="temp-box">
+                <div style="font-weight:bold;">フロー率</div>
+                <div>現在:
+                  <span data-field="curFlowratePct">
+                    <span class="value">--</span><span class="unit">%</span>
+                  </span>
+                </div>
+                <div class="control-row">
+                  <input type="range"
+                         id="flowrateSlider"
+                         data-field="curFlowratePct"
+                         step="1"
+                         min="0" max="200" />
+                  <input type="number"
+                         id="flowrateInput"
+                         data-field="curFlowratePct"
+                         min="0" max="200"
+                         style="width:4em" />
+                  <button id="flowrateSendBtn" class="send-btn">⏎</button>
+                  <div class="quick-buttons">
+                    <button class="flowrate-preset" data-value="90">90%</button>
+                    <button class="flowrate-preset" data-value="100">100%</button>
+                    <button class="flowrate-preset" data-value="103">103%</button>
+                    <button class="flowrate-preset" data-value="106">106%</button>
+                  </div>
+                </div>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- add temp-style boxes for feedrate and flowrate
- provide quick preset buttons
- implement send buttons with 3 second cooldown
- style quick buttons and send buttons
- update JS version information

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68516bfee998832fa950a5d74382ca0f