### PR TITLE
Add printer model based stage preview

### DIFF
--- a/3dp_lib/dashboard_msg_handler.js
+++ b/3dp_lib/dashboard_msg_handler.js
@@ -16,9 +16,9 @@
  * - {@link processData}：データ部処理
  * - {@link processError}：エラー処理
  *
- * @version 1.390.193 (PR #86)
- * @since   1.390.193 (PR #86)
- */
+ * @version 1.390.214 (PR #95)
+ * @since   1.390.214 (PR #95)
+*/
 "use strict";
 
 import errorMap from "./3dp_errorcode.js";
@@ -40,7 +40,8 @@ import { handlePrintStateTransition } from "./dashboard_printstatus.js";
 import { parseCurPosition } from "./dashboard_utils.js";
 import {
   updateXYPreview,
-  updateZPreview
+  updateZPreview,
+  setPrinterModel
 } from "./dashboard_stage_preview.js";
 import { PRINT_STATE_CODE } from "./dashboard_ui_mapping.js";
 import { ingestData, restoreAggregatorState, restartAggregatorTimer } from "./dashboard_aggregator.js";
@@ -380,6 +381,10 @@ export function processData(data) {
       updateZPreview(pos.z);
       machine.runtimeData.curPosition = data.curPosition;
     }
+  }
+  // (2.7.1b) プリンタモデルに基づくプレビュー設定
+  if (data.model) {
+    setPrinterModel(String(data.model));
   }
   // (2.7.2) その他フィールド一括反映
   Object.entries(data).forEach(([k, v]) => setStoredData(k, v, true));


### PR DESCRIPTION
## Summary
- dynamically size stage preview based on printer model
- clamp z preview to printer limits
- detect printer model in message handler

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68516e78cdf8832fbbf203927e8a521a