### PR TITLE
Add quick send for nozzle/bed temp

### DIFF
--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -321,8 +321,9 @@
                 <div class="control-row">
                   <input type="range" id="nozzleTempSlider" data-field="targetNozzleTemp" min="0" max="0" step="1"/>
                   <input type="number" id="nozzleTempInput" data-field="targetNozzleTemp" min="0" max="0" style="width:4em" />
+                  <button id="nozzleTempSendBtn" class="send-btn">⏎</button>
+                  </div>
                 </div>
-              </div>
 
               <div class="temp-box">
                 <div style="font-weight:bold;">ベッド温度</div>
@@ -349,8 +350,9 @@
                 <div class="control-row">
                   <input type="range"  id="bedTempSlider" data-field="targetBedTemp0" min="0" max="0" step="1" />
                   <input type="number" id="bedTempInput"  data-field="targetBedTemp0" min="0" max="0" style="width:4em" />
+                  <button id="bedTempSendBtn" class="send-btn">⏎</button>
+                  </div>
                 </div>
-              </div>
 
               <div class="temp-box">
                 <div style="font-weight:bold;">箱内温度</div>
@@ -906,8 +908,9 @@
                 <div class="control-row">
                   <input type="range" id="nozzleTempSlider" data-field="targetNozzleTemp" min="0" max="0" step="1" />
                   <input type="number" id="nozzleTempInput" data-field="targetNozzleTemp" min="0" max="0" step="1" style="width:4em" />
+                  <button id="nozzleTempSendBtn" class="send-btn">⏎</button>
+                  </div>
                 </div>
-              </div>
 
               <div class="temp-box">
                 <div style="font-weight:bold;">ベッド温度</div>
@@ -934,8 +937,9 @@
                 <div class="control-row">
                   <input type="range"  id="bedTempSlider" data-field="targetBedTemp0" min="0" max="0" step="1" />
                   <input type="number" id="bedTempInput"  data-field="targetBedTemp0" min="0" max="0" step="1" style="width:4em" />
+                  <button id="bedTempSendBtn" class="send-btn">⏎</button>
+                  </div>
                 </div>
-              </div>
 
               <div class="temp-box">
                 <div style="font-weight:bold;">箱内温度</div>


### PR DESCRIPTION
## Summary
- add send button next to nozzle/bed temp controls in UI
- support new send buttons in JavaScript handlers with cooldown

## Testing
- `git rev-list --count HEAD`

------
https://chatgpt.com/codex/tasks/task_e_6851714b21b0832fbab2c7172c56b936