### PR TITLE
Add filament inventory management

### DIFF
--- a/3dp_lib/dashboard_data.js
+++ b/3dp_lib/dashboard_data.js
@@ -19,9 +19,9 @@
  * - {@link setStoredData}：storedData に値格納
  * - {@link getDisplayValue}：表示用値取得
  *
- * @version 1.390.193 (PR #86)
+ * @version 1.390.226 (PR #101)
  * @since   1.390.193 (PR #86)
- */
+*/
 
 "use strict";
 
@@ -156,6 +156,9 @@ export function setCurrentHostname(host) {
  *   },
  *   machines: Record<string, MachineData>,
  *   filamentSpools: Array<Object>,
+ *   filamentPresets: Array<Object>,
+ *   usageHistory: Array<Object>,
+ *   filamentInventory: Array<Object>,
  *   currentSpoolId: string|null
  * }}
  */
@@ -183,6 +186,8 @@ export const monitorData = {
   },
   filamentSpools: [],
   filamentPresets: FILAMENT_PRESETS,
+  usageHistory: [],
+  filamentInventory: [],
   currentSpoolId: null,
   temporaryBuffer: []
 };

--- a/3dp_lib/dashboard_filament_inventory.js
+++ b/3dp_lib/dashboard_filament_inventory.js
@@ -1,0 +1,119 @@
+/**
+ * @fileoverview
+ * 3Dプリンタ監視ツール 3dpmon 用 フィラメント在庫管理モジュール
+ * dashboard_filament_inventory.js
+ * (c) pumpCurry 2025
+ * -----------------------------------------------------------
+ * @module dashboard_filament_inventory
+ *
+ * 【機能内容サマリ】
+ * - フィラメントプリセット単位での在庫数管理
+ * - 在庫消費時の統計更新
+ *
+ * 【公開関数一覧】
+ * - {@link getInventory}：在庫配列取得
+ * - {@link getInventoryItem}：IDから在庫取得
+ * - {@link setInventoryQuantity}：在庫数設定
+ * - {@link adjustInventory}：在庫数増減
+ * - {@link consumeInventory}：消費登録
+ *
+ * @version 1.390.226 (PR #101)
+ * @since   1.390.226 (PR #101)
+ */
+
+"use strict";
+
+import { monitorData } from "./dashboard_data.js";
+import { saveUnifiedStorage } from "./dashboard_storage.js";
+
+/**
+ * 在庫一覧を取得する。
+ *
+ * @function getInventory
+ * @returns {Array<Object>} 在庫アイテム配列
+ */
+export function getInventory() {
+  return monitorData.filamentInventory;
+}
+
+/**
+ * 指定IDの在庫情報を返す。
+ *
+ * @function getInventoryItem
+ * @param {string} modelId - プリセットID
+ * @returns {Object|null} 在庫オブジェクト
+ */
+export function getInventoryItem(modelId) {
+  return monitorData.filamentInventory.find(v => v.modelId === modelId) || null;
+}
+
+/**
+ * 内部用：在庫アイテムを確保するヘルパー。
+ *
+ * @private
+ * @param {string} modelId - プリセットID
+ * @returns {Object} 新規または既存の在庫オブジェクト
+ */
+function ensureItem(modelId) {
+  let item = getInventoryItem(modelId);
+  if (!item) {
+    item = {
+      modelId,
+      quantity: 0,
+      isUnlimitedStock: false,
+      lastUsedAt: null,
+      totalUsedNum: 0
+    };
+    monitorData.filamentInventory.push(item);
+  }
+  return item;
+}
+
+/**
+ * 在庫数を設定する。
+ *
+ * @function setInventoryQuantity
+ * @param {string} modelId - プリセットID
+ * @param {number} quantity - 設定する在庫数
+ * @returns {number} 設定後の在庫数
+ */
+export function setInventoryQuantity(modelId, quantity) {
+  const item = ensureItem(modelId);
+  item.quantity = Number(quantity) || 0;
+  saveUnifiedStorage();
+  return item.quantity;
+}
+
+/**
+ * 在庫数を増減させる。
+ *
+ * @function adjustInventory
+ * @param {string} modelId - プリセットID
+ * @param {number} delta - 変化量（負数可）
+ * @returns {number} 更新後の在庫数
+ */
+export function adjustInventory(modelId, delta) {
+  const item = ensureItem(modelId);
+  item.quantity = (item.quantity || 0) + Number(delta);
+  saveUnifiedStorage();
+  return item.quantity;
+}
+
+/**
+ * スプール使用時に在庫を消費し統計を更新する。
+ *
+ * @function consumeInventory
+ * @param {string} modelId - プリセットID
+ * @param {number} [amount=1] - 使用本数
+ * @returns {number} 在庫更新後の数量
+ */
+export function consumeInventory(modelId, amount = 1) {
+  const item = ensureItem(modelId);
+  const a = Number(amount) || 1;
+  if (!item.isUnlimitedStock) item.quantity -= a;
+  item.totalUsedNum = (item.totalUsedNum || 0) + a;
+  item.lastUsedAt = Date.now().toString();
+  saveUnifiedStorage();
+  return item.quantity;
+}
+

--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -24,7 +24,7 @@
  * - {@link deleteSpool}：スプール削除
  * - {@link useFilament}：使用量反映
  *
- * @version 1.390.206 (PR #92)
+ * @version 1.390.226 (PR #101)
  * @since   1.390.193 (PR #86)
 */
 
@@ -32,6 +32,7 @@
 
 import { monitorData } from "./dashboard_data.js";
 import { saveUnifiedStorage } from "./dashboard_storage.js";
+import { consumeInventory } from "./dashboard_filament_inventory.js";
 
 // Material density [g/cm^3]
 export const MATERIAL_DENSITY = {
@@ -204,5 +205,8 @@ export function addSpoolFromPreset(preset, override = {}) {
     ...override
   };
   const spool = addSpool(data);
+  if (preset.presetId) {
+    consumeInventory(preset.presetId, 1);
+  }
   return spool;
 }

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -25,7 +25,7 @@
  * - {@link loadPrintCurrent}：現ジョブ読込
  * - {@link savePrintCurrent}：現ジョブ保存
  *
- * @version 1.390.193 (PR #86)
+ * @version 1.390.226 (PR #101)
  * @since   1.390.193 (PR #86)
  */
 
@@ -150,6 +150,10 @@ export function restoreUnifiedStorage() {
       if (data.machines)       monitorData.machines       = data.machines;
       if (Array.isArray(data.filamentSpools))
         monitorData.filamentSpools = data.filamentSpools.map(sp => applySpoolDefaults(sp));
+      if (Array.isArray(data.usageHistory))
+        monitorData.usageHistory = data.usageHistory;
+      if (Array.isArray(data.filamentInventory))
+        monitorData.filamentInventory = data.filamentInventory;
       if ("currentSpoolId" in data)
         monitorData.currentSpoolId = data.currentSpoolId;
       _lastSavedJson = saved;


### PR DESCRIPTION
## Summary
- support filament inventory arrays in `monitorData`
- load/save inventory in storage restoration
- manage inventory when adding spools
- new module `dashboard_filament_inventory.js` for inventory functions

## Testing
- `node -c 3dp_lib/dashboard_filament_inventory.js && node -c 3dp_lib/dashboard_data.js && node -c 3dp_lib/dashboard_spool.js && node -c 3dp_lib/dashboard_storage.js`

------
https://chatgpt.com/codex/tasks/task_e_685218aeaad4832f8f4ad76eeb6e11b6