### PR TITLE
Add filament management modal and log spool usage

### DIFF
--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -24,7 +24,7 @@
  * - {@link deleteSpool}：スプール削除
  * - {@link useFilament}：使用量反映
  *
- * @version 1.390.226 (PR #101)
+ * @version 1.390.228 (PR #102)
  * @since   1.390.193 (PR #86)
 */
 
@@ -158,13 +158,34 @@ export function deleteSpool(id) {
   saveUnifiedStorage();
 }
 
+/**
+ * スプール使用履歴を追加するヘルパー。
+ *
+ * @private
+ * @param {Object} spool - 対象スプール
+ * @param {number} lengthMm - 使用した長さ [mm]
+ * @param {string} jobId - 関連ジョブID
+ * @returns {void}
+ */
+function logUsage(spool, lengthMm, jobId) {
+  monitorData.usageHistory.push({
+    usageId: Date.now(),
+    spoolId: spool.id,
+    jobId,
+    startedAt: Date.now(),
+    usedLength: lengthMm,
+    currentLength: spool.remainingLengthMm
+  });
+  saveUnifiedStorage();
+}
+
 export function useFilament(lengthMm, jobId = "") {
   const s = getCurrentSpool();
   if (!s) return;
   s.remainingLengthMm = Math.max(0, s.remainingLengthMm - lengthMm);
   s.printCount = (s.printCount || 0) + 1;
   s.usedLengthLog.push({ jobId, used: lengthMm });
-  saveUnifiedStorage();
+  logUsage(s, lengthMm, jobId);
 }
 
 /**

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -1264,6 +1264,7 @@
   <!-- スクリプト読み込み -->
   <script type="module" src="3dp_lib/3dp_dashboard_main.js"></script>
   <script type="module" src="3dp_lib/dashboard_spool_ui.js"></script>
+  <script type="module" src="3dp_lib/dashboard_filament_manager.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement a Filament Manager popup with tabs for history, current spool, inventory, and presets
- log spool usage to `monitorData.usageHistory`
- load Filament Manager script from the main HTML

## Testing
- `git rev-list --count HEAD`


------
https://chatgpt.com/codex/tasks/task_e_68521a54ce2c832fad57fd2727d8348c