### PR TITLE
Fix dashboard modules inclusion

### DIFF
--- a/3dp_lib/3dp_dashboard_main.js
+++ b/3dp_lib/3dp_dashboard_main.js
@@ -14,7 +14,7 @@
  * 【公開関数一覧】
  * - なし（エントリポイントとして即時実行）
  *
- * @version 1.390.203 (PR #90)
+ * @version 1.390.229 (PR #103)
  * @since   1.390.193 (PR #86)
  */
 
@@ -38,6 +38,10 @@ import { notificationManager } from "./dashboard_notification_manager.js";
 
 import { initUIEventHandlers } from "./dashboard_ui.js";
 import { initStorageUI } from "./dashboard_storage_ui.js";
+// 以下2モジュールは DOMContentLoaded 後の UI 初期化で使用するため
+// 副作用目的で読み込む
+import "./dashboard_spool_ui.js";
+import "./dashboard_filament_manager.js";
 
 // ——— グローバル例外ハンドリング ———
 window.addEventListener("unhandledrejection", evt => {

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -1263,8 +1263,6 @@
 
   <!-- スクリプト読み込み -->
   <script type="module" src="3dp_lib/3dp_dashboard_main.js"></script>
-  <script type="module" src="3dp_lib/dashboard_spool_ui.js"></script>
-  <script type="module" src="3dp_lib/dashboard_filament_manager.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load only `3dp_dashboard_main.js` from HTML
- include spool and filament manager modules from `3dp_dashboard_main.js`

## Testing
- `node -c 3dp_lib/3dp_dashboard_main.js`


------
https://chatgpt.com/codex/tasks/task_e_68521d2368b0832fbde05b6a33a06b95