### PR TITLE
Enhance filament change dialog

### DIFF
--- a/3dp_lib/dashboard_filament_change.js
+++ b/3dp_lib/dashboard_filament_change.js
@@ -13,13 +13,14 @@
  * 【公開関数一覧】
  * - {@link showFilamentChangeDialog}：交換ダイアログ表示
  *
- * @version 1.390.239 (PR #105)
+ * @version 1.390.243 (PR #109)
  * @since   1.390.230 (PR #104)
 */
 "use strict";
 
 import { getSpools, setCurrentSpoolId } from "./dashboard_spool.js";
-import { consumeInventory } from "./dashboard_filament_inventory.js";
+import { consumeInventory, getInventoryItem } from "./dashboard_filament_inventory.js";
+import { monitorData } from "./dashboard_data.js";
 
 let styleInjected = false;
 
@@ -39,6 +40,10 @@ function injectStyles() {
   .fc-body{padding:8px;}
   .fc-buttons{display:flex;justify-content:flex-end;padding:8px;border-top:1px solid #ddd;gap:8px;}
   .fc-buttons button{padding:6px 12px;font-size:14px;}
+  .fc-carousel{display:flex;overflow-x:auto;gap:6px;margin-bottom:8px;}
+  .fc-item{flex:0 0 auto;padding:4px 8px;border:1px solid #ddd;border-radius:4px;cursor:pointer;background:#f4f4f5;font-size:12px;}
+  .fc-dropdown{width:100%;box-sizing:border-box;font-size:14px;margin-bottom:8px;}
+  .fc-preview{font-size:12px;margin-top:4px;}
   `;
   const style = document.createElement("style");
   style.textContent = css;
@@ -87,23 +92,113 @@ export function showFilamentChangeDialog() {
     dlg.innerHTML = `
       <div class="fc-header">フィラメント交換</div>
       <div class="fc-body">
-        <select id="fc-select" style="width:100%;box-sizing:border-box;font-size:14px;"></select>
+        <div id="fc-fav" class="fc-carousel"></div>
+        <div id="fc-recent" class="fc-carousel"></div>
+        <select id="fc-manufacturer" class="fc-dropdown"></select>
+        <select id="fc-filament" class="fc-dropdown"></select>
+        <div id="fc-preview" class="fc-preview"></div>
       </div>
       <div class="fc-buttons">
         <button id="fc-cancel">キャンセル</button>
-        <button id="fc-ok">決定</button>
+        <button id="fc-ok">このフィラメントに決定</button>
       </div>
     `;
 
-    const sel = dlg.querySelector("#fc-select");
+    const favEl = dlg.querySelector("#fc-fav");
+    const recentEl = dlg.querySelector("#fc-recent");
+    const manuSel = dlg.querySelector("#fc-manufacturer");
+    const filSel = dlg.querySelector("#fc-filament");
+    const prevEl = dlg.querySelector("#fc-preview");
+
     const spools = getSpools();
-    spools.forEach(sp => {
-      const opt = document.createElement("option");
-      opt.value = sp.id;
-      opt.textContent = `${sp.name} (${sp.remainingLengthMm}/${sp.totalLengthMm} mm)`;
-      if (sp.isActive) opt.selected = true;
-      sel.appendChild(opt);
+    let selectedSpool = spools.find(s => s.isActive) || spools[0] || null;
+
+    function renderManufacturerOptions() {
+      const makers = [...new Set(spools.map(sp => sp.manufacturerName || sp.brand))];
+      manuSel.innerHTML = '<option value="">メーカー選択</option>';
+      makers.forEach(m => {
+        const o = document.createElement('option');
+        o.value = m;
+        o.textContent = m || '(不明)';
+        manuSel.appendChild(o);
+      });
+      if (selectedSpool) {
+        manuSel.value = selectedSpool.manufacturerName || selectedSpool.brand;
+      }
+    }
+
+    function renderFilamentOptions() {
+      const maker = manuSel.value;
+      filSel.innerHTML = '';
+      spools.filter(sp => !maker || (sp.manufacturerName || sp.brand) === maker)
+        .forEach(sp => {
+          const o = document.createElement('option');
+          o.value = sp.id;
+          o.textContent = sp.name;
+          filSel.appendChild(o);
+        });
+      if (selectedSpool) filSel.value = selectedSpool.id;
+    }
+
+    function updateInfo(sp) {
+      if (!sp) { prevEl.textContent = ''; return; }
+      const inv = sp.presetId ? getInventoryItem(sp.presetId) : null;
+      prevEl.textContent = inv ? `在庫: ${inv.quantity}` : '在庫: -';
+      updatePreview(sp);
+    }
+
+    function setupCarousel(list, container) {
+      container.innerHTML = '';
+      list.forEach(sp => {
+        const d = document.createElement('div');
+        d.className = 'fc-item';
+        d.textContent = sp.name;
+        d.dataset.id = sp.id;
+        container.appendChild(d);
+      });
+    }
+
+    const favList = spools.filter(sp => sp.isFavorite);
+    const recentIds = [];
+    monitorData.usageHistory.slice(-16).reverse().forEach(u => {
+      if (!recentIds.includes(u.spoolId)) recentIds.push(u.spoolId);
     });
+    const recentList = recentIds.map(id => spools.find(s => s.id === id)).filter(Boolean);
+
+    setupCarousel(favList, favEl);
+    setupCarousel(recentList, recentEl);
+
+    favEl.addEventListener('click', e => {
+      const id = e.target.dataset.id;
+      if (!id) return;
+      selectedSpool = spools.find(s => s.id === id);
+      renderManufacturerOptions();
+      renderFilamentOptions();
+      updateInfo(selectedSpool);
+    });
+    recentEl.addEventListener('click', e => {
+      const id = e.target.dataset.id;
+      if (!id) return;
+      selectedSpool = spools.find(s => s.id === id);
+      renderManufacturerOptions();
+      renderFilamentOptions();
+      updateInfo(selectedSpool);
+    });
+
+    manuSel.addEventListener('change', () => {
+      renderFilamentOptions();
+      selectedSpool = spools.find(s => s.id === filSel.value) || null;
+      updateInfo(selectedSpool);
+    });
+
+    filSel.addEventListener('change', () => {
+      selectedSpool = spools.find(s => s.id === filSel.value) || null;
+      updateInfo(selectedSpool);
+    });
+
+    renderManufacturerOptions();
+    renderFilamentOptions();
+    if (selectedSpool) updateInfo(selectedSpool);
 
     document.body.appendChild(overlay);
 
@@ -113,12 +208,10 @@ export function showFilamentChangeDialog() {
     });
 
     dlg.querySelector("#fc-ok").addEventListener("click", () => {
-      const id = sel.value;
-      const spool = spools.find(s => s.id === id);
-      if (spool) {
-        setCurrentSpoolId(id);
-        if (spool.presetId) consumeInventory(spool.presetId, 1);
-        updatePreview(spool);
+      if (selectedSpool) {
+        setCurrentSpoolId(selectedSpool.id);
+        if (selectedSpool.presetId) consumeInventory(selectedSpool.presetId, 1);
+        updatePreview(selectedSpool);
       }
       overlay.remove();
       resolve(true);


### PR DESCRIPTION
## Summary
- extend filament change dialog with favorite/recent carousels and two-step dropdown
- show selected filament preview and inventory count
- log spool change info in `dashboard_spool.js`
- add favorite flag support to spools

## Testing
- `git rev-list --count HEAD`


------
https://chatgpt.com/codex/tasks/task_e_68523f6decf0832fa5e5a1daf7a33b60