### PR TITLE
Add filament preset editor with persistence

### DIFF
--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -25,7 +25,7 @@
  * - {@link loadPrintCurrent}：現ジョブ読込
  * - {@link savePrintCurrent}：現ジョブ保存
  *
- * @version 1.390.226 (PR #101)
+* @version 1.390.245 (PR #110)
  * @since   1.390.193 (PR #86)
  */
 
@@ -154,6 +154,8 @@ export function restoreUnifiedStorage() {
         monitorData.usageHistory = data.usageHistory;
       if (Array.isArray(data.filamentInventory))
         monitorData.filamentInventory = data.filamentInventory;
+      if (Array.isArray(data.filamentPresets))
+        monitorData.filamentPresets = data.filamentPresets;
       if ("currentSpoolId" in data)
         monitorData.currentSpoolId = data.currentSpoolId;
       _lastSavedJson = saved;


### PR DESCRIPTION
## Summary
- allow editing filament presets from the manager modal
- store customized presets via `saveUnifiedStorage`
- restore presets on page load

## Testing
- `node --check 3dp_lib/dashboard_filament_manager.js`
- `node --check 3dp_lib/dashboard_storage.js`


------
https://chatgpt.com/codex/tasks/task_e_6852463e4aec832f918b4cce43136dc8