### PR TITLE
Add registered filament tab

### DIFF
--- a/3dp_lib/dashboard_filament_manager.js
+++ b/3dp_lib/dashboard_filament_manager.js
@@ -13,13 +13,18 @@
  * 【公開関数一覧】
  * - {@link showFilamentManager}：管理モーダルを開く
  *
-* @version 1.390.247 (PR #111)
+* @version 1.390.259 (PR #117)
 * @since   1.390.228 (PR #102)
 */
 "use strict";
 
 import { monitorData } from "./dashboard_data.js";
-import { getCurrentSpool, getSpools } from "./dashboard_spool.js";
+import {
+  getCurrentSpool,
+  getSpools,
+  addSpool,
+  updateSpool
+} from "./dashboard_spool.js";
 import {
   getInventory,
   setInventoryQuantity,
@@ -27,6 +32,8 @@ import {
 } from "./dashboard_filament_inventory.js";
 import { FILAMENT_PRESETS } from "./dashboard_filament_presets.js";
 import { saveUnifiedStorage } from "./dashboard_storage.js";
+import { showSpoolDialog } from "./dashboard_spool_ui.js";
+import { createFilamentPreview } from "./dashboard_filament_view.js";
 
 let styleInjected = false;
 
@@ -51,6 +58,12 @@ function injectStyles() {
     .filament-manager-content th,.filament-manager-content td{border:1px solid #ddd;padding:4px;font-size:12px;}
     .filament-manager-content .inv-qty-input{width:60px;text-align:right;}
     .filament-manager-content .inv-adjust{margin:0 2px;padding:0 4px;}
+    .filament-manager-content .search-form{display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px;}
+    .filament-manager-content .search-form select,
+    .filament-manager-content .search-form input{padding:2px;font-size:12px;}
+    .registered-container{display:flex;gap:8px;}
+    .registered-preview{flex:0 0 120px;}
+    .registered-table th{cursor:pointer;}
   `;
   const style = document.createElement("style");
   style.textContent = css;
@@ -161,6 +174,275 @@ function createInventoryContent() {
   });
   table.appendChild(tbody);
   div.appendChild(table);
+  return div;
+}
+
+/**
+ * 登録済みフィラメント一覧タブを生成する。
+ * 検索フォームと一覧テーブルを備え、編集・追加操作が可能。
+ *
+ * @private
+ * @returns {HTMLElement} DOM 要素
+ */
+function createRegisteredContent() {
+  const div = document.createElement("div");
+  div.className = "filament-manager-content";
+
+  const addBtn = document.createElement("button");
+  addBtn.textContent = "新規登録";
+  addBtn.style.fontSize = "12px";
+  addBtn.style.marginBottom = "4px";
+
+  const form = document.createElement("form");
+  form.className = "search-form";
+  const brandSel = document.createElement("select");
+  const matSel = document.createElement("select");
+  const colorSel = document.createElement("select");
+  const nameIn = document.createElement("input");
+  nameIn.placeholder = "名称";
+  const searchBtn = document.createElement("button");
+  searchBtn.textContent = "検索";
+  form.append(brandSel, matSel, colorSel, nameIn, searchBtn);
+
+  const countSpan = document.createElement("div");
+  countSpan.style.fontSize = "12px";
+  countSpan.style.margin = "4px 0";
+
+  const wrap = document.createElement("div");
+  wrap.className = "registered-container";
+  const prevBox = document.createElement("div");
+  prevBox.className = "registered-preview";
+  wrap.appendChild(prevBox);
+
+  const table = document.createElement("table");
+  table.className = "registered-table";
+  const thead = document.createElement("thead");
+  thead.innerHTML =
+    "<tr><th data-sort='brand'>ブランド</th><th data-sort='material'>材質</th>" +
+    "<th data-sort='colorName'>色名</th><th data-sort='name'>名称</th>" +
+    "<th data-sort='reelSubName'>サブ名称</th>" +
+    "<th data-sort='count'>使用数</th><th data-sort='last'>最終利用日時</th><th>コマンド</th></tr>";
+  table.appendChild(thead);
+  const tbody = document.createElement("tbody");
+  table.appendChild(tbody);
+  wrap.appendChild(table);
+
+  div.append(addBtn, form, countSpan, wrap);
+
+  const preview = createFilamentPreview(prevBox, {
+    filamentDiameter: 1.75,
+    filamentTotalLength: 336000,
+    filamentCurrentLength: 336000,
+    filamentColor: "#22C55E",
+    widthPx: 120,
+    heightPx: 120,
+    showSlider: false,
+    disableInteraction: true,
+    showOverlayLength: true,
+    showOverlayPercent: true
+  });
+
+  let sortKey = "";
+  let sortAsc = true;
+
+  function buildMaps() {
+    const map = {};
+    (monitorData.usageHistory || []).forEach(h => {
+      const m = map[h.spoolId] || { count: 0, last: 0 };
+      m.count += 1;
+      const t = Number(h.startedAt || 0);
+      if (t > m.last) m.last = t;
+      map[h.spoolId] = m;
+    });
+    return map;
+  }
+
+  function fillOptions(spools) {
+    const brands = new Set();
+    const mats = new Set();
+    const colors = new Set();
+    spools.forEach(sp => {
+      if (sp.manufacturerName) brands.add(sp.manufacturerName);
+      else if (sp.brand) brands.add(sp.brand);
+      if (sp.materialName) mats.add(sp.materialName);
+      else if (sp.material) mats.add(sp.material);
+      if (sp.colorName) colors.add(sp.colorName);
+    });
+    brandSel.innerHTML = "<option value=''>ブランド</option>";
+    [...brands].forEach(b => {
+      const o = document.createElement("option");
+      o.value = b;
+      o.textContent = b;
+      brandSel.appendChild(o);
+    });
+    matSel.innerHTML = "<option value=''>材質</option>";
+    [...mats].forEach(m => {
+      const o = document.createElement("option");
+      o.value = m;
+      o.textContent = m;
+      matSel.appendChild(o);
+    });
+    colorSel.innerHTML = "<option value=''>色名</option>";
+    [...colors].forEach(c => {
+      const o = document.createElement("option");
+      o.value = c;
+      o.textContent = c;
+      colorSel.appendChild(o);
+    });
+  }
+
+  function applyFilter(spools) {
+    return spools.filter(sp => {
+      if (brandSel.value) {
+        const b = sp.manufacturerName || sp.brand || "";
+        if (b !== brandSel.value) return false;
+      }
+      if (matSel.value) {
+        const m = sp.materialName || sp.material || "";
+        if (m !== matSel.value) return false;
+      }
+      if (colorSel.value) {
+        if (sp.colorName !== colorSel.value) return false;
+      }
+      if (nameIn.value) {
+        const n = `${sp.name || ""}${sp.reelName || ""}${sp.reelSubName || ""}`;
+        if (!n.includes(nameIn.value)) return false;
+      }
+      return true;
+    });
+  }
+
+  function sortList(list) {
+    if (!sortKey) return list;
+    return list.sort((a, b) => {
+      let va = "";
+      let vb = "";
+      switch (sortKey) {
+        case "brand":
+          va = a.manufacturerName || a.brand || "";
+          vb = b.manufacturerName || b.brand || "";
+          break;
+        case "material":
+          va = a.materialName || a.material || "";
+          vb = b.materialName || b.material || "";
+          break;
+        case "colorName":
+          va = a.colorName || "";
+          vb = b.colorName || "";
+          break;
+        case "name":
+          va = a.name || a.reelName || "";
+          vb = b.name || b.reelName || "";
+          break;
+        case "reelSubName":
+          va = a.reelSubName || "";
+          vb = b.reelSubName || "";
+          break;
+        case "count":
+          va = usageMap[a.id]?.count || 0;
+          vb = usageMap[b.id]?.count || 0;
+          break;
+        case "last":
+          va = usageMap[a.id]?.last || 0;
+          vb = usageMap[b.id]?.last || 0;
+          break;
+        default:
+          break;
+      }
+      if (va === vb) return 0;
+      const cmp = va > vb ? 1 : -1;
+      return sortAsc ? cmp : -cmp;
+    });
+  }
+
+  function render() {
+    const spools = getSpools();
+    usageMap = buildMaps();
+    fillOptions(spools);
+    const list = sortList(applyFilter(spools));
+    tbody.innerHTML = "";
+    list.forEach(sp => {
+      const tr = document.createElement("tr");
+      const brand = sp.manufacturerName || sp.brand || "";
+      const mat = sp.materialName || sp.material || "";
+      const colorCell = document.createElement("td");
+      colorCell.innerHTML = `<span style='color:${sp.filamentColor || sp.color || "#000"}'>■</span>${sp.colorName || ""}`;
+      const name = sp.name || sp.reelName || "";
+      const sub = sp.reelSubName || "";
+      const usage = usageMap[sp.id]?.count || 0;
+      const last = usageMap[sp.id]?.last
+        ? new Date(usageMap[sp.id].last).toLocaleString()
+        : "";
+      tr.innerHTML = `<td>${brand}</td><td>${mat}</td>`;
+      tr.appendChild(colorCell);
+      tr.innerHTML += `<td>${name}</td><td>${sub}</td><td>${usage}</td><td>${last}</td>`;
+      const cmd = document.createElement("td");
+      const edit = document.createElement("button");
+      edit.textContent = "編集";
+      edit.addEventListener("click", async () => {
+        const res = await showSpoolDialog(sp);
+        if (res) {
+          updateSpool(sp.id, res);
+          render();
+        }
+      });
+      cmd.appendChild(edit);
+      tr.appendChild(cmd);
+      tr.addEventListener("click", () => {
+        preview.setState({
+          filamentDiameter: sp.filamentDiameter,
+          filamentTotalLength: sp.totalLengthMm,
+          filamentCurrentLength: sp.remainingLengthMm,
+          filamentColor: sp.filamentColor || sp.color,
+          reelOuterDiameter: sp.reelOuterDiameter,
+          reelThickness: sp.reelThickness,
+          reelWindingInnerDiameter: sp.reelWindingInnerDiameter,
+          reelCenterHoleDiameter: sp.reelCenterHoleDiameter,
+          reelBodyColor: sp.reelBodyColor,
+          reelFlangeTransparency: sp.reelFlangeTransparency,
+          reelWindingForegroundColor: sp.reelWindingForegroundColor,
+          reelCenterHoleForegroundColor: sp.reelCenterHoleForegroundColor,
+          reelName: sp.name || "",
+          reelSubName: sp.reelSubName || "",
+          materialName: sp.materialName || sp.material || "",
+          materialColorName: sp.colorName || "",
+          materialColorCode: sp.filamentColor || sp.color || "",
+          manufacturerName: sp.manufacturerName || sp.brand || ""
+        });
+      });
+      tbody.appendChild(tr);
+    });
+    countSpan.textContent = `一覧：(${list.length}/${spools.length}件)`;
+  }
+
+  let usageMap = buildMaps();
+
+  thead.addEventListener("click", ev => {
+    const th = ev.target.closest("th");
+    if (!th || !th.dataset.sort) return;
+    if (sortKey === th.dataset.sort) {
+      sortAsc = !sortAsc;
+    } else {
+      sortKey = th.dataset.sort;
+      sortAsc = true;
+    }
+    render();
+  });
+
+  form.addEventListener("submit", ev => {
+    ev.preventDefault();
+    render();
+  });
+
+  addBtn.addEventListener("click", async () => {
+    const res = await showSpoolDialog();
+    if (res) {
+      addSpool(res);
+      render();
+    }
+  });
+
+  render();
   return div;
 }
 
@@ -413,11 +695,19 @@ export function showFilamentManager() {
 
   const tabBar = document.createElement("div");
   tabBar.className = "filament-manager-tabs";
-  const tabs = ["使用記録簿", "現在のスプール", "在庫", "プリセット", "集計レポート"];
+  const tabs = [
+    "使用記録簿",
+    "現在のスプール",
+    "在庫",
+    "登録済みフィラメント",
+    "プリセット",
+    "集計レポート"
+  ];
   const contents = [
     createHistoryContent(),
     createCurrentSpoolContent(),
     createInventoryContent(),
+    createRegisteredContent(),
     createPresetContent(),
     createReportContent()
   ];


### PR DESCRIPTION
## Summary
- expand filament manager with new 'Registered Filaments' tab
- show search form and sortable list
- allow adding/editing spools via existing dialog
- style for search form and preview area

## Testing
- `node -c 3dp_lib/dashboard_filament_manager.js`
- `git rev-list --count HEAD`

------
https://chatgpt.com/codex/tasks/task_e_68523dab987c832f9a8f0e134e0145af