### PR TITLE
Fix filament preview updates

### DIFF
--- a/3dp_lib/dashboard_filament_view.js
+++ b/3dp_lib/dashboard_filament_view.js
@@ -13,7 +13,7 @@
  * 【公開関数一覧】
  * - {@link createFilamentPreview}：プレビューを生成
  *
- * @version 1.390.209 (PR #93)
+ * @version 1.390.309 (PR #139)
  * @since   1.390.193 (PR #86)
  *
  * ------
@@ -1036,9 +1036,9 @@ export function createFilamentPreview(mount, opts) {
     /* ----- オーバーレイ情報更新 ----- */
     overlayLength.style.display  = o.showOverlayLength  ? 'block' : 'none';
     if (o.showOverlayLength) {
-      overlayLength.textContent = o.showLengthKg
-        ? `Length: ${(currentLen/1000).toFixed(1)}m / ${(o.filamentTotalLength/1000).toFixed(1)}m`
-        : `${(currentLen/1000).toFixed(1)}m`;
+      const cur = Math.round(currentLen).toLocaleString();
+      const tot = Math.round(o.filamentTotalLength).toLocaleString();
+      overlayLength.textContent = `${cur}mm / ${tot}mm`;
     }
 
     if (o.showLengthKg) {


### PR DESCRIPTION
## Summary
- use `materialLength` to track filament usage in `dashboard_aggregator`
- compute remaining filament using real-time usage
- display remaining/total length in mm on the filament preview

## Testing
- `node -c 3dp_lib/dashboard_aggregator.js`
- `node -c 3dp_lib/dashboard_filament_view.js`


------
https://chatgpt.com/codex/tasks/task_e_6853ec1a3d80832fbd7f4de086d8bbca