### PR TITLE
Track spool ID in print records

### DIFF
--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -19,7 +19,7 @@
  * - {@link restartAggregatorTimer}：集約ループ再開
  * - {@link stopAggregatorTimer}：集約ループ停止
  *
- * @version 1.390.309 (PR #139)
+ * @version 1.390.313 (PR #140)
  * @since   1.390.193 (PR #86)
 */
 
@@ -558,6 +558,10 @@ export function aggregatorUpdate() {
       const jobId = job?.id ?? "";
       if (!isNaN(len) && len > 0 && spool.currentPrintID !== jobId) {
         // ここでフィラメント使用予定を登録し、残量計算を有効化する
+        const machine = monitorData.machines[currentHostname];
+        if (machine?.printStore?.current) {
+          machine.printStore.current.filamentId = spool.id;
+        }
         useFilament(len, jobId);
       }
     }

--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -24,7 +24,7 @@
  * - {@link deleteSpool}：スプール削除
  * - {@link useFilament}：使用量反映
  *
- * @version 1.390.301 (PR #137)
+ * @version 1.390.313 (PR #140)
  * @since   1.390.193 (PR #86)
 */
 
@@ -259,6 +259,10 @@ function logUsage(spool, lengthMm, jobId) {
 export function useFilament(lengthMm, jobId = "") {
   const s = getCurrentSpool();
   if (!s) return;
+  const machine = monitorData.machines[currentHostname];
+  if (machine?.printStore?.current) {
+    machine.printStore.current.filamentId = s.id;
+  }
   if (s.isPending) {
     logSpoolChange(s, jobId);
     s.isPending = false;


### PR DESCRIPTION
## Summary
- write active spool ID to job when recording filament usage
- ensure externally-started jobs also record spool ID
- bump file versions

## Testing
- `node --check 3dp_lib/dashboard_spool.js`
- `node --check 3dp_lib/dashboard_aggregator.js`
- ❌ `node` test for `jobsToRaw` (fails: document is not defined)

------
https://chatgpt.com/codex/tasks/task_e_685407e11a84832fbbf461bc9f91ef8e