### PR TITLE
Add spool ID fallback for running print

### DIFF
--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -24,7 +24,7 @@
  * - {@link deleteSpool}：スプール削除
  * - {@link useFilament}：使用量反映
  *
- * @version 1.390.313 (PR #140)
+ * @version 1.390.318 (PR #141)
  * @since   1.390.193 (PR #86)
 */
 
@@ -108,6 +108,24 @@ export function setCurrentSpoolId(id) {
     newSpool.currentJobStartLength = null;
     newSpool.currentJobExpectedLength = null;
     newSpool.isPending = true;
+    // ----- 印刷履歴更新処理 -----
+    // 起動直後にスプール情報が欠落している場合、
+    // 現在ジョブおよび履歴からフィラメントIDを補完する
+    if (machine.printStore) {
+      const curJob = machine.printStore.current;
+      if (curJob && !curJob.filamentId && curJob.id === printId) {
+        curJob.filamentId = newSpool.id;
+      }
+      const hist = machine.printStore.history;
+      if (Array.isArray(hist)) {
+        const entry = hist.find(h => h.id === printId && !h.filamentId);
+        if (entry) entry.filamentId = newSpool.id;
+      }
+    }
+    if (Array.isArray(machine.historyData)) {
+      const buf = machine.historyData.find(h => h.id === printId && !h.filamentId);
+      if (buf) buf.filamentId = newSpool.id;
+    }
   }
   saveUnifiedStorage();
 }

--- a/docs/en/dashboard_usage.md
+++ b/docs/en/dashboard_usage.md
@@ -67,6 +67,8 @@ settings.
   `addSpool()` to track vendors or custom materials.
 - Remaining length is updated automatically after each job and the 3D preview
   warns when filament runs out.
+- If a spool is selected before the job finishes and the history entry lacks
+  filament information, the selected spool is added automatically.
   ```html
   <div id="filament-preview"></div>
   <script src="3dp_lib/dashboard_filament_view.js"></script>


### PR DESCRIPTION
## Summary
- update spool manager version
- update spool assignment when spool selected mid-print
- document spool auto-recording in dashboard usage guide

## Testing
- `node --check 3dp_lib/dashboard_spool.js`

------
https://chatgpt.com/codex/tasks/task_e_6854a5a4fc5c832f86209faafba2cddc