### PR TITLE
Fix material usage display

### DIFF
--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -20,9 +20,9 @@
  * - {@link restartAggregatorTimer}：集約ループ再開
  * - {@link stopAggregatorTimer}：集約ループ停止
  *
- * @version 1.390.323 (PR #145)
+ * @version 1.390.332 (PR #150)
  * @since   1.390.193 (PR #86)
- * @lastModified 2025-06-20 14:41:39
+ * @lastModified 2025-06-20 17:00:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -110,7 +110,8 @@ export function ingestData(data) {
   const { value: bedRaw                    } = getMergedValueWithSource("bedTemp0",        data);
   const { value: maxBedRaw                 } = getMergedValueWithSource("maxBedTemp",      data);
   const { value: matStatRaw                } = getMergedValueWithSource("materialStatus",  data);
-  const { value: matLenRaw                 } = getMergedValueWithSource("materialLength", data);
+  const { value: matLenRaw                 } =
+    getMergedValueWithSource("materialLength", data, "usagematerial");
 
   // —— キー初期化 ——  
   // まだ storedData に存在しないフィールドは rawValue=null で準備

--- a/3dp_lib/dashboard_ui_mapping.js
+++ b/3dp_lib/dashboard_ui_mapping.js
@@ -17,9 +17,9 @@
  * - {@link PRINT_STATE_EVENT}：状態イベント表
  * - {@link dashboardMapping}：フィールドマッピング
  *
- * @version 1.390.317 (PR #143)
+ * @version 1.390.332 (PR #150)
  * @since   1.390.193 (PR #86)
- * @lastModified 2025-06-19 22:38:18
+ * @lastModified 2025-06-20 17:00:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -217,7 +217,7 @@ export const dashboardMapping = {
   completionElapsedTime: { elementKey: "completionElapsedTime",   process: v => v != null ? { value: utils.formatDuration(v), unit: "" } : NO_VAL },
 
   // --- 材料関連 ---
-  usedMaterialLength:    { elementKey: "materialLength",          process: v => ({ value: v.toLocaleString(), unit: "mm" }) },
+  usedMaterialLength:    { elementKey: "materialLength",          process: v => ({ value: String(v), unit: "mm" }) },
   materialDetect:        { elementKey: "materialDetect",          process: v => ({ value: utils.formatBinary(v), unit: "" }) },
   materialStatus:        { elementKey: "materialStatus",          process: v => mapValue(MATERIAL_STATUS_MAP, v) },
 


### PR DESCRIPTION
## Summary
- handle `usagematerial` field as printer-reported material usage
- use raw printer value for material usage display

## Testing
- `node -c 3dp_lib/dashboard_aggregator.js`
- `node -c 3dp_lib/dashboard_ui_mapping.js`

------
https://chatgpt.com/codex/tasks/task_e_685549ed46b4832f897446d709ec482f