### PR TITLE
Refine filament remaining updates

### DIFF
--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -20,9 +20,9 @@
  * - {@link restartAggregatorTimer}：集約ループ再開
  * - {@link stopAggregatorTimer}：集約ループ停止
  *
-* @version 1.390.362 (PR #161)
+* @version 1.390.366 (PR #164)
 * @since   1.390.193 (PR #86)
-* @lastModified 2025-06-21 23:51:50
+* @lastModified 2025-06-22 05:18:34
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -569,10 +569,11 @@ export function aggregatorUpdate() {
 
   // --- フィラメント残量の動的計算 ---
   const spool = getCurrentSpool();
-  if (spool) {
+  // usedMaterialLength 受信時だけ残量計算を更新
+  if (spool && storedData.usedMaterialLength?.isNew) {
     const st   = Number(storedData.state?.rawValue || 0);
     const prog = parseInt(storedData.printProgress?.rawValue || 0, 10);
-    const used = Number(storedData.usedMaterialLength?.rawValue ?? NaN);
+    const used = Number(storedData.usedMaterialLength.rawValue);
     let est  = Number(storedData.materialLength?.rawValue ?? NaN);
     if (isNaN(est)) {
       est = Number(storedData.materialLengthFallback?.rawValue ?? NaN);
@@ -627,6 +628,9 @@ export function aggregatorUpdate() {
       finalizeFilamentUsage(finalUsed, spool.currentPrintID);
       remain = spool.remainingLengthMm;
     }
+
+    // 小数点以下2桁に丸めて保持
+    remain = Math.round(remain * 100) / 100;
     setStoredData("filamentRemainingMm", remain, true);
   }
 

--- a/3dp_lib/dashboard_ui_mapping.js
+++ b/3dp_lib/dashboard_ui_mapping.js
@@ -17,9 +17,9 @@
  * - {@link PRINT_STATE_EVENT}：状態イベント表
  * - {@link dashboardMapping}：フィールドマッピング
  *
- * @version 1.390.332 (PR #150)
- * @since   1.390.193 (PR #86)
- * @lastModified 2025-06-20 17:00:00
+* @version 1.390.366 (PR #164)
+* @since   1.390.193 (PR #86)
+* @lastModified 2025-06-22 05:18:34
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -218,6 +218,7 @@ export const dashboardMapping = {
 
   // --- 材料関連 ---
   usedMaterialLength:    { elementKey: "materialLength",          process: v => ({ value: String(v), unit: "mm" }) },
+  filamentRemainingMm:  { elementKey: "filamentRemainingMm",    process: v => ({ value: String(v), unit: "mm" }) },
   materialDetect:        { elementKey: "materialDetect",          process: v => ({ value: utils.formatBinary(v), unit: "" }) },
   materialStatus:        { elementKey: "materialStatus",          process: v => mapValue(MATERIAL_STATUS_MAP, v) },
 


### PR DESCRIPTION
## Summary
- trigger filament updates only on new `usedMaterialLength`
- round remaining length to two decimals
- map `filamentRemainingMm` field to mm unit

## Testing
- `node --check 3dp_lib/dashboard_aggregator.js`
- `node --check 3dp_lib/dashboard_ui_mapping.js`


------
https://chatgpt.com/codex/tasks/task_e_685712f8a61c832fa910693875419e49