### PR TITLE
Fix spool history snapshot

### DIFF
--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -22,9 +22,9 @@
  * - {@link saveVideos}：動画一覧保存
  * - {@link jobsToRaw}：内部モデル→生データ変換
  *
- * @version 1.390.363 (PR #160)
- * @since   1.390.197 (PR #88)
- * @lastModified 2025-06-21 15:00:00
+* @version 1.390.371 (PR #167)
+* @since   1.390.197 (PR #88)
+* @lastModified 2025-06-22 05:35:58
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -721,10 +721,14 @@ export function renderHistoryTable(rawArray, baseUrl) {
     const remainTexts = [];
     spoolInfos.forEach((info, idx) => {
       const sp = getSpoolById(info.spoolId) || null;
-      const matColor = sp ? (matColors[sp.material] || '#EEE') : '#EEE';
-      const colorBox = sp ? `<span class="filament-color-box" style="color:${sp.filamentColor};">■</span>` : '■';
-      const matTag   = sp ? `<span class="material-tag" style="background:${matColor};">${sp.material}</span>` : '';
-      let text = sp ? `${colorBox} ${matTag} ${sp.name}/${sp.colorName}` : '(不明)';
+      const mat = info.material || sp?.material || '';
+      const matColor = mat ? (matColors[mat] || '#EEE') : '#EEE';
+      const color = info.filamentColor || sp?.filamentColor || '#000';
+      const colorBox = `<span class="filament-color-box" style="color:${color};">■</span>`;
+      const matTag   = mat ? `<span class="material-tag" style="background:${matColor};">${mat}</span>` : '';
+      const name = info.spoolName || sp?.name || '';
+      const colName = info.colorName || sp?.colorName || '';
+      let text = name || colName ? `${colorBox} ${matTag} ${name}/${colName}` : '(不明)';
       if (idx === 0) {
         const editId = info.spoolId || raw.filamentId;
         if (editId) text += ` <button class="spool-edit" data-id="${editId}">修正</button>`;

--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -27,9 +27,9 @@
  * - {@link reserveFilament}：使用量予約
  * - {@link finalizeFilamentUsage}：使用量確定
  *
- * @version 1.390.365 (PR #163)
- * @since   1.390.193 (PR #86)
- * @lastModified 2025-06-22 04:36:19
+* @version 1.390.371 (PR #167)
+* @since   1.390.193 (PR #86)
+* @lastModified 2025-06-22 05:35:58
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -388,6 +388,10 @@ export function reserveFilament(lengthMm, jobId = "") {
  * @param {number} lengthMm - 実使用量 [mm]
  * @param {string} [jobId=""] - 印刷ジョブID
  * @returns {void}
+ * @description
+ * 使用完了時点のスプール情報を履歴にスナップショットとして保存する。
+ * スプール名や色を後から変更しても当時の状態を保持するため、
+ * name/color/material などのメタ情報を同時に記録する。
  */
 export function finalizeFilamentUsage(lengthMm, jobId = "") {
   const s = getCurrentSpool();
@@ -410,6 +414,10 @@ export function finalizeFilamentUsage(lengthMm, jobId = "") {
       entry.filamentInfo ??= [];
       entry.filamentInfo.push({
         spoolId: s.id,
+        spoolName: s.name,
+        colorName: s.colorName,
+        filamentColor: s.filamentColor,
+        material: s.material,
         spoolCount: s.printCount,
         expectedRemain: s.remainingLengthMm
       });


### PR DESCRIPTION
## Summary
- preserve spool metadata per print
- prefer recorded snapshot when rendering history

## Testing
- `node -c 3dp_lib/dashboard_spool.js`
- `node -c 3dp_lib/dashboard_printmanager.js`


------
https://chatgpt.com/codex/tasks/task_e_685716ebea04832f99c3f876d17a6fb7