### PR TITLE
Add prep/check time columns in print history

### DIFF
--- a/3dp_monitor.css
+++ b/3dp_monitor.css
@@ -975,6 +975,8 @@ input:checked + .slider:before {
 #print-history-table td[data-key="id"],
 #print-history-table td[data-key="size"],
 #print-history-table td[data-key="usagetime"],
+#print-history-table td[data-key="preptime"],
+#print-history-table td[data-key="checktime"],
 #print-history-table td[data-key="usagematerial"],
 #file-list-table td[data-key="number"],
 #file-list-table td[data-key="layer"],

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -759,6 +759,9 @@
                 <th data-key="size">サイズ</th>
                 <th data-key="ctime">作成時間</th>
                 <th data-key="starttime">開始時間</th>
+                <th data-key="endtime">終了時間</th>
+                <th data-key="preptime">印刷前準備</th>
+                <th data-key="checktime">印刷中確認</th>
                 <th data-key="usagetime">使用時間</th>
                 <th data-key="usagematerial">使用量（mm）</th>
                 <th data-key="printfinish">is成功?</th>
@@ -770,7 +773,7 @@
             </tr>
           </thead>
           <tbody>
-          <tr><td colspan='17'>データ読み込み待ち</td></tr>
+          <tr><td colspan='20'>データ読み込み待ち</td></tr>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
## Summary
- add end time, prep time and first layer check time columns in print history table
- show usage time with h/m/s formatting and mm suffix for material
- support sorting with raw seconds via data attribute

## Testing
- `node --check 3dp_lib/dashboard_utils.js`
- `node --check 3dp_lib/dashboard_printmanager.js`


------
https://chatgpt.com/codex/tasks/task_e_6857661c1c1c832f839faf32c9b982c8