### PR TITLE
Fix video history persistence

### DIFF
--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -22,9 +22,9 @@
  * - {@link saveVideos}：動画一覧保存
  * - {@link jobsToRaw}：内部モデル→生データ変換
  *
-* @version 1.390.378 (PR #168)
+* @version 1.390.381 (PR #169)
 * @since   1.390.197 (PR #88)
-* @lastModified 2025-06-22 11:14:43
+* @lastModified 2025-06-22 11:23:44
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -650,6 +650,9 @@ export function updateVideoList(videoArray, baseUrl) {
   });
   if (changed) {
     saveHistory(jobs);
+    // 動画マップが更新されていない場合でも
+    // 履歴に動画URLが追加されたタイミングで保存を保証する
+    if (!updated) saveVideos(map);
   }
   if (updated || changed) {
     const raw = jobsToRaw(jobs);


### PR DESCRIPTION
## Summary
- ensure video history updates also save video map
- bump version comment in `dashboard_printmanager.js`

## Testing
- `node --check 3dp_lib/dashboard_printmanager.js`


------
https://chatgpt.com/codex/tasks/task_e_6857688c71f8832f96b62dc650ac9e4e