### PR TITLE
Fix resume for print timers

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -17,9 +17,9 @@
  * - {@link persistPrintResume}：印刷再開用データを保存
  * - {@link initializeAutoSave}：自動保存タイマーを開始
  *
- * @version 1.390.386 (PR #174)
+ * @version 1.390.395 (PR #178)
  * @since   1.390.193 (PR #86)
- * @lastModified 2025-06-22 11:44:37
+ * @lastModified 2025-06-22 13:28:24
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -376,10 +376,26 @@ const persistKeys = [
  * @description
  *  localStorage に保存された印刷再開データを読み出し、
  *  storedData の computedValue として復元します。
+ *
+ * @param {number|null} currentPrintId -
+ *   現在進行中の印刷ID。null の場合は ID 照合を行わず復元します。
  */
-export function restorePrintResume() {
+export function restorePrintResume(currentPrintId = null) {
   const host = currentHostname;
   if (!host) return;
+
+  let savedId = null;
+  try {
+    const rawId = localStorage.getItem(`pd_${host}_prevPrintID`);
+    if (rawId != null) savedId = JSON.parse(rawId);
+  } catch (e) {
+    console.warn("restorePrintResume: prevPrintID パース失敗", e);
+  }
+
+  if (currentPrintId !== null && savedId !== null && currentPrintId !== savedId) {
+    console.debug("restorePrintResume: 印刷ID不一致のため復元をスキップ");
+    return;
+  }
 
   persistKeys.forEach(key => {
     const raw = localStorage.getItem(`pd_${host}_${key}`);

--- a/3dp_lib/dashboard_msg_handler.js
+++ b/3dp_lib/dashboard_msg_handler.js
@@ -17,9 +17,9 @@
  * - {@link processData}：データ部処理
  * - {@link processError}：エラー処理
  *
-* @version 1.390.381 (PR #171)
+* @version 1.390.395 (PR #178)
 * @since   1.390.214 (PR #95)
-* @lastModified 2025-06-22 05:18:34
+* @lastModified 2025-06-22 13:28:24
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -140,7 +140,8 @@ export function handleMessage(data) {
     });
 
     restartAggregatorTimer();
-    restorePrintResume();
+    const curId = Number(data.printStartTime || 0) || null;
+    restorePrintResume(curId);
 
     // 保存済み履歴と現在印刷を表示
     const baseUrlStored = `http://${getDeviceIp()}:80`;


### PR DESCRIPTION
## Summary
- ensure resume data matches current print ID
- check current print ID when restoring timers

## Testing
- `node -c 3dp_lib/3dp_dashboard_init.js`
- `node -c 3dp_lib/dashboard_msg_handler.js`


------
https://chatgpt.com/codex/tasks/task_e_685785c3c6f8832fb884c3fedd040210