### PR TITLE
Fix history timer persistence on reload

### DIFF
--- a/3dp_lib/dashboard_msg_handler.js
+++ b/3dp_lib/dashboard_msg_handler.js
@@ -17,9 +17,9 @@
  * - {@link processData}：データ部処理
  * - {@link processError}：エラー処理
  *
-* @version 1.390.395 (PR #178)
+* @version 1.390.397 (PR #179)
 * @since   1.390.214 (PR #95)
-* @lastModified 2025-06-22 13:28:24
+* @lastModified 2025-06-22 13:45:39
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -404,6 +404,7 @@ export function processData(data) {
   // (2.7.4) 進捗100%以上で履歴登録
   if (Number(data.printProgress ?? 0) >= 100) {
     const entry = { ...data };
+    entry.id = Number(data.printStartTime || 0);
     const extraKeys = [
       "preparationTime",
       "firstLayerCheckTime",
@@ -424,6 +425,8 @@ export function processData(data) {
       if (data[k] != null) entry[k] = data[k];
     });
     machine.historyData.push(entry);
+    const baseUrl = `http://${getDeviceIp()}:80`;
+    printManager.updateHistoryList([entry], baseUrl);
   }
 
   // 次回比較用に保存


### PR DESCRIPTION
## Summary
- ensure progress>=100 saves history buffer and timer data immediately
- add `id` to buffered history entries so merging works
- bump version and lastModified

## Testing
- `node -c 3dp_lib/dashboard_msg_handler.js`
- `find 3dp_lib -name '*.js' | xargs -I{} node -c {}`

------
https://chatgpt.com/codex/tasks/task_e_6857895a4a4c832f82830bb56d55220a