### PR TITLE
Fix alignment for operation panel

### DIFF
--- a/3dp_monitor.css
+++ b/3dp_monitor.css
@@ -67,12 +67,12 @@ body {
      col1, col2 の2列を並べるため最低幅を約660pxに固定
      グラフよりも後に折り返すよう order を調整
   ------------------------------------------------------------- */
-  flex: 0 0 660px; /* 幅は固定しグラフに余白を譲る */
-  max-width: 700px;
+  flex: 0 0 672px; /* col1+col2+gap にカードの左右パディング分を加味 */
+  max-width: 712px;
   background-color: #f8f8f8;
   padding: 6px;
   box-sizing: border-box;
-  min-width: 660px;
+  min-width: 672px;
   order: 0; /* 状態欄は1行表示を優先 */
 }
 


### PR DESCRIPTION
## Summary
- widen `.info-wrapper` so the status and operation panels can sit side by side

## Testing
- `npx --yes stylelint 3dp_monitor.css` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6857ab6d10a4832f874019cfb658a7c2