### PR TITLE
Fix duplicate spool info block

### DIFF
--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -22,9 +22,9 @@
  * - {@link saveVideos}：動画一覧保存
  * - {@link jobsToRaw}：内部モデル→生データ変換
  *
-* @version 1.390.392 (PR #177)
+* @version 1.390.401 (PR #179)
 * @since   1.390.197 (PR #88)
-* @lastModified 2025-06-22 13:18:53
+* @lastModified 2025-06-22 16:23:55
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -476,15 +476,28 @@ export async function refreshHistory(
   const state = Number(machine?.runtimeData?.state ?? 0);
   const printing = [PRINT_STATE_CODE.printStarted, PRINT_STATE_CODE.printPaused].includes(state);
   const curSpoolId = getCurrentSpoolId();
-  if (printing && curSpoolId && jobs[0] && !jobs[0].filamentId) {
-    jobs[0].filamentId = curSpoolId;
+  if (printing && curSpoolId && jobs[0]) {
     const sp = getSpoolById(curSpoolId);
     if (sp) {
+      if (!jobs[0].filamentId) jobs[0].filamentId = curSpoolId;
       if (!jobs[0].filamentColor && (sp.filamentColor || sp.color)) {
         jobs[0].filamentColor = sp.filamentColor || sp.color;
       }
       if (!jobs[0].filamentType && (sp.material || sp.materialName)) {
         jobs[0].filamentType = sp.material || sp.materialName;
+      }
+      // 履歴にスプール情報が存在しない場合は現在スプールを即時反映
+      jobs[0].filamentInfo ??= [];
+      if (!jobs[0].filamentInfo.some(info => info.spoolId === sp.id)) {
+        jobs[0].filamentInfo.push({
+          spoolId: sp.id,
+          spoolName: sp.name,
+          colorName: sp.colorName,
+          filamentColor: sp.filamentColor,
+          material: sp.material,
+          spoolCount: sp.printCount,
+          expectedRemain: sp.remainingLengthMm
+        });
       }
       if (!sp.currentPrintID) sp.currentPrintID = jobs[0].id;
     }


### PR DESCRIPTION
## Summary
- fix duplicate spool merge logic in refreshHistory
- update version metadata

## Testing
- `node --check 3dp_lib/dashboard_printmanager.js`


------
https://chatgpt.com/codex/tasks/task_e_6857aac69ea0832f9d0b95e68d79f495