### PR TITLE
Fix notification template placeholders

### DIFF
--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -20,9 +20,9 @@
  * - {@link restartAggregatorTimer}：集約ループ再開
  * - {@link stopAggregatorTimer}：集約ループ停止
  *
-* @version 1.390.404 (PR #182)
+* @version 1.390.415 (PR #183)
 * @since   1.390.193 (PR #86)
-* @lastModified 2025-06-22 16:22:48
+* @lastModified 2025-06-22 17:10:30
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -225,7 +225,12 @@ export function ingestData(data) {
       const key = Math.round(r * 100);
       if (nozzle >= maxNozz * r && !notifiedTempMilestones.has(`nozzle${key}`)) {
         notifiedTempMilestones.add(`nozzle${key}`);
-        notificationManager.notify(`tempNearNozzle${key}`, { ratio: r, currentTemp: nozzle, maxTemp: maxNozz });
+        notificationManager.notify(`tempNearNozzle${key}`, {
+          ratio: r,
+          ratioPct: Math.round(r * 100),
+          currentTemp: nozzle,
+          maxTemp: maxNozz
+        });
       }
     });
   }
@@ -234,7 +239,12 @@ export function ingestData(data) {
       const key = Math.round(r * 100);
       if (bed >= maxBed * r && !notifiedTempMilestones.has(`bed${key}`)) {
         notifiedTempMilestones.add(`bed${key}`);
-        notificationManager.notify(`tempNearBed${key}`, { ratio: r, currentTemp: bed, maxTemp: maxBed });
+        notificationManager.notify(`tempNearBed${key}`, {
+          ratio: r,
+          ratioPct: Math.round(r * 100),
+          currentTemp: bed,
+          maxTemp: maxBed
+        });
       }
     });
   }

--- a/3dp_lib/dashboard_notification_defaults.js
+++ b/3dp_lib/dashboard_notification_defaults.js
@@ -14,9 +14,9 @@
  * - {@link DEFAULT_SOUND}：既定サウンドファイル名
  * - {@link defaultNotificationMap}：通知設定マップ
  *
-* @version 1.390.366 (PR #159)
+* @version 1.390.414 (PR #183)
 * @since   1.390.193 (PR #86)
-* @lastModified 2025-06-22 05:21:50
+* @lastModified 2025-06-22 17:10:30
 * -----------------------------------------------------------
 * @todo
 * - none
@@ -40,7 +40,7 @@ export const defaultNotificationMap = {
   printCompleted:   { talk: "{hostname} で印刷が完了しました ({now})",                             sound: DEFAULT_SOUND, enabled: true, level: "success" },
   printFailed:      { talk: "{hostname} の印刷が失敗しました ({now})",                             sound: DEFAULT_SOUND, enabled: true, level: "error"   },
   printPaused:      { talk: "{hostname} の印刷が一時停止しました ({now})",                         sound: DEFAULT_SOUND, enabled: true, level: "warn"    },
-  errorOccurred:    { talk: "{hostname} でエラー発生：コード${error_code}, キー${error_key}, メッセージ${error_msg} ({now})", sound: DEFAULT_SOUND, enabled: true, level: "error"   },
+  errorOccurred:    { talk: "{hostname} でエラー発生：コード{error_code}, キー{error_key}, メッセージ{error_msg} ({now})", sound: DEFAULT_SOUND, enabled: true, level: "error"   },
   errorResolved:    { talk: "{hostname} のエラーは解消しました ({now})",                           sound: DEFAULT_SOUND, enabled: true, level: "success" },
   filamentOut:      { talk: "{hostname} のフィラメントが切れました",                               sound: DEFAULT_SOUND, enabled: true, level: "warn"    },
   filamentReplaced: { talk: "{hostname} にフィラメントが補充されました",                         sound: DEFAULT_SOUND, enabled: true, level: "success" },
@@ -81,13 +81,13 @@ export const defaultNotificationMap = {
 
   // 80%
   tempNearNozzle80: {
-    talk: "警告：ノズル温度が上限 ${maxTemp}℃ に対し ${ratio * 100}% の ${currentTemp}℃ に達しています",
+    talk: "警告：ノズル温度が上限 {maxTemp}℃ に対し {ratioPct}% の {currentTemp}℃ に達しています",
     sound: DEFAULT_SOUND,
     enabled: true,
     level: "warn"
   },
   tempNearBed80: {
-    talk: "警告：ベッド温度が上限 ${maxTemp}℃ に対し ${ratio * 100}% の ${currentTemp}℃ に達しています",
+    talk: "警告：ベッド温度が上限 {maxTemp}℃ に対し {ratioPct}% の {currentTemp}℃ に達しています",
     sound: DEFAULT_SOUND,
     enabled: true,
     level: "warn"
@@ -95,13 +95,13 @@ export const defaultNotificationMap = {
 
   // 90%
   tempNearNozzle90: {
-    talk: "警告：ノズル温度が上限 ${maxTemp}℃ に対し ${ratio * 100}% の ${currentTemp}℃ に達しています",
+    talk: "警告：ノズル温度が上限 {maxTemp}℃ に対し {ratioPct}% の {currentTemp}℃ に達しています",
     sound: DEFAULT_SOUND,
     enabled: true,
     level: "warn"
   },
   tempNearBed90: {
-    talk: "警告：ベッド温度が上限 ${maxTemp}℃ に対し ${ratio * 100}% の ${currentTemp}℃ に達しています",
+    talk: "警告：ベッド温度が上限 {maxTemp}℃ に対し {ratioPct}% の {currentTemp}℃ に達しています",
     sound: DEFAULT_SOUND,
     enabled: true,
     level: "warn"
@@ -109,13 +109,13 @@ export const defaultNotificationMap = {
 
   // 95%
   tempNearNozzle95: {
-    talk: "警告：ノズル温度が上限 ${maxTemp}℃ に対し ${ratio * 100}% の ${currentTemp}℃ に達しています",
+    talk: "警告：ノズル温度が上限 {maxTemp}℃ に対し {ratioPct}% の {currentTemp}℃ に達しています",
     sound: DEFAULT_SOUND,
     enabled: true,
     level: "warn"
   },
   tempNearBed95: {
-    talk: "警告：ベッド温度が上限 ${maxTemp}℃ に対し ${ratio * 100}% の ${currentTemp}℃ に達しています",
+    talk: "警告：ベッド温度が上限 {maxTemp}℃ に対し {ratioPct}% の {currentTemp}℃ に達しています",
     sound: DEFAULT_SOUND,
     enabled: true,
     level: "warn"
@@ -123,13 +123,13 @@ export const defaultNotificationMap = {
 
   // 98%
   tempNearNozzle98: {
-    talk: "警告：ノズル温度が上限 ${maxTemp}℃ に対し ${ratio * 100}% の ${currentTemp}℃ に達しています",
+    talk: "警告：ノズル温度が上限 {maxTemp}℃ に対し {ratioPct}% の {currentTemp}℃ に達しています",
     sound: DEFAULT_SOUND,
     enabled: true,
     level: "error"
   },
   tempNearBed98: {
-    talk: "警告：ベッド温度が上限 ${maxTemp}℃ に対し ${ratio * 100}% の ${currentTemp}℃ に達しています",
+    talk: "警告：ベッド温度が上限 {maxTemp}℃ に対し {ratioPct}% の {currentTemp}℃ に達しています",
     sound: DEFAULT_SOUND,
     enabled: true,
     level: "error"
@@ -137,13 +137,13 @@ export const defaultNotificationMap = {
 
   // 100%
   tempNearNozzle100: {
-    talk: "警告：ノズル温度が上限 ${maxTemp}℃ に対し ${ratio * 100}% の ${currentTemp}℃ に達しています",
+    talk: "警告：ノズル温度が上限 {maxTemp}℃ に対し {ratioPct}% の {currentTemp}℃ に達しています",
     sound: DEFAULT_SOUND,
     enabled: true,
     level: "error"
   },
   tempNearBed100: {
-    talk: "警告：ベッド温度が上限 ${maxTemp}℃ に対し ${ratio * 100}% の ${currentTemp}℃ に達しています",
+    talk: "警告：ベッド温度が上限 {maxTemp}℃ に対し {ratioPct}% の {currentTemp}℃ に達しています",
     sound: DEFAULT_SOUND,
     enabled: true,
     level: "error"


### PR DESCRIPTION
## Summary
- fix template macros for error and temperature notifications
- compute ratioPct in aggregator

## Testing
- `node --check 3dp_lib/dashboard_notification_defaults.js`
- `node --check 3dp_lib/dashboard_aggregator.js`

------
https://chatgpt.com/codex/tasks/task_e_6857b9ef3494832fb4028df7611c2f21