### PR TITLE
Fix missing import for hostname reset

### DIFF
--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -24,9 +24,9 @@
  * - {@link updateConnectionUI}：UI 状態更新
  * - {@link simulateReceivedJson}：受信データシミュレート
  *
- * @version 1.390.435 (PR #196)
- * @since   1.390.193 (PR #86)
- * @lastModified 2025-06-22 18:28:52
+* @version 1.390.441 (PR #200)
+* @since   1.390.193 (PR #86)
+* @lastModified 2025-06-22 19:59:49
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -37,7 +37,8 @@
 import {
   monitorData,
   currentHostname,
-  PLACEHOLDER_HOSTNAME
+  PLACEHOLDER_HOSTNAME,
+  setCurrentHostname
 } from "./dashboard_data.js";
 import { pushLog } from "./dashboard_log_util.js";
 import { aggregatorUpdate } from "./dashboard_aggregator.js";


### PR DESCRIPTION
## Summary
- update dashboard_connection version info
- import `setCurrentHostname` to prevent ReferenceError

## Testing
- `node --check 3dp_lib/dashboard_connection.js`


------
https://chatgpt.com/codex/tasks/task_e_6857e1e08fc0832fabb6279ab026400a