### PR TITLE
Fix camera reconnect bug and add troubleshooting note

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -17,9 +17,9 @@
  * - {@link persistPrintResume}：印刷再開用データを保存
  * - {@link initializeAutoSave}：自動保存タイマーを開始
  *
-* @version 1.390.451 (PR #205)
- * @since   1.390.193 (PR #86)
-* @lastModified 2025-06-23 18:57:23
+* @version 1.390.462 (PR #211)
+* @since   1.390.193 (PR #86)
+* @lastModified 2025-06-25 20:25:42
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -282,7 +282,8 @@ export function initializeDashboard({
   
   // (12) ページロード時のカメラ起動
   if (monitorData.appSettings.cameraToggle && monitorData.appSettings.wsDest) {
-    setTimeout(startCameraStream(), 1500);
+    // startCameraStream は参照を渡し遅延実行させる
+    setTimeout(startCameraStream, 1500);
   }
 
   // (12.5) 保存済みの履歴と現在印刷を表示

--- a/3dp_lib/dashboard_camera_ctrl.js
+++ b/3dp_lib/dashboard_camera_ctrl.js
@@ -18,9 +18,9 @@
  * - {@link stopCameraStream}：カメラストリーム停止
  * - {@link handleCameraError}：接続エラー処理
  *
-* @version 1.390.366 (PR #159)
+* @version 1.390.462 (PR #211)
 * @since   1.390.193 (PR #86)
-* @lastModified 2025-06-22 05:21:50
+* @lastModified 2025-06-25 20:25:42
 * -----------------------------------------------------------
  * @todo
  * - none
@@ -257,6 +257,8 @@ function _connectImgStream(host) {
     updateCameraConnectionUI("connected");
     pushLog("カメラ接続成功", "success");
     notificationManager.notify("cameraConnected");
+    // MJPEG ストリームでは onload がフレーム毎に発火するため一度で解除
+    cameraImg.onload = null;
   };
 
   // 読み込みエラー

--- a/docs/en/feature_realtime_display.md
+++ b/docs/en/feature_realtime_display.md
@@ -11,3 +11,6 @@ This section describes the real-time monitoring features in 3dpmon. By combining
 - Click the camera image in the monitor card to enlarge it.
 - Hover over the temperature graph to show the current value as a tooltip.
 - To reset the temperature history, open the Settings card and choose **Reset Graph**.
+
+## Troubleshooting
+- If the camera repeatedly reconnects and the browser becomes sluggish, an ad-block extension may be blocking the stream. Temporarily disable the extension or whitelist the site to confirm.


### PR DESCRIPTION
## Summary
- remove repeated `onload` events in `dashboard_camera_ctrl.js`
- fix delayed camera startup timer
- document possible ad-block interference

## Testing
- `node --check 3dp_lib/dashboard_camera_ctrl.js`
- `node --check 3dp_lib/3dp_dashboard_init.js`


------
https://chatgpt.com/codex/tasks/task_e_685bdc5de120832f86e58e1d8c7a8b4b