### PR TITLE
Fix duplicate notifications on reconnect

### DIFF
--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -24,9 +24,9 @@
  * - {@link updateConnectionUI}：UI 状態更新
  * - {@link simulateReceivedJson}：受信データシミュレート
  *
-* @version 1.390.471 (PR #217)
+* @version 1.390.474 (PR #216)
 * @since   1.390.451 (PR #205)
-* @lastModified 2025-06-25 22:10:00
+* @lastModified 2025-06-25 22:45:32
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -38,7 +38,8 @@ import {
   monitorData,
   currentHostname,
   PLACEHOLDER_HOSTNAME,
-  setCurrentHostname
+  setCurrentHostname,
+  setNotificationSuppressed
 } from "./dashboard_data.js";
 import { pushLog } from "./dashboard_log_util.js";
 import { aggregatorUpdate } from "./dashboard_aggregator.js";
@@ -358,6 +359,8 @@ function handleSocketError(error, host) {
  */
 function handleSocketClose(host) {
   pushLog("WebSocket接続が閉じられました。", "warn");
+  // 切断直後は通知を抑制する
+  setNotificationSuppressed(true);
   const st = getState(host);
 
   // Heartbeat停止...

--- a/3dp_lib/dashboard_data.js
+++ b/3dp_lib/dashboard_data.js
@@ -20,9 +20,9 @@
  * - {@link setStoredData}：storedData に値格納
  * - {@link getDisplayValue}：表示用値取得
  *
- * @version 1.390.352 (PR #156)
+ * @version 1.390.474 (PR #216)
  * @since   1.390.193 (PR #86)
- * @lastModified 2025-06-21 07:41:35
+ * @lastModified 2025-06-25 22:45:26
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -77,6 +77,26 @@ export const PLACEHOLDER_HOSTNAME = "_$_NO_MACHINE_$_";
  * @type {string|null}
  */
 export let currentHostname = null;
+
+/**
+ * 通知抑制状態フラグ
+ *
+ * true の間は NotificationManager.notify() による通知を抑制します。
+ * 接続処理中や機器未選択時に誤通知が発生するのを防止する目的で使用します。
+ * @type {boolean}
+ */
+export let notificationSuppressed = true;
+
+/**
+ * setNotificationSuppressed:
+ * 通知抑制状態を更新します。
+ *
+ * @param {boolean} flag - true で通知抑制、false で通知許可
+ * @returns {void}
+ */
+export function setNotificationSuppressed(flag) {
+  notificationSuppressed = flag;
+}
 
 /**
  * createEmptyMachineData:

--- a/3dp_lib/dashboard_msg_handler.js
+++ b/3dp_lib/dashboard_msg_handler.js
@@ -17,9 +17,9 @@
  * - {@link processData}：データ部処理
  * - {@link processError}：エラー処理
  *
-* @version 1.390.439 (PR #199)
+* @version 1.390.474 (PR #216)
 * @since   1.390.214 (PR #95)
-* @lastModified 2025-06-22 18:59:29
+* @lastModified 2025-06-25 22:45:32
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -32,6 +32,7 @@ import {
   currentHostname,
   setCurrentHostname,
   PLACEHOLDER_HOSTNAME,
+  setNotificationSuppressed,
   setStoredData,
 } from "./dashboard_data.js";
 import {
@@ -110,6 +111,9 @@ export function handleMessage(data) {
   // (1a) 初回ホスト設定
   if ((currentHostname === null || currentHostname === PLACEHOLDER_HOSTNAME) && data.hostname) {
 
+    // 初期化中は通知を抑制する
+    setNotificationSuppressed(true);
+
     // --- ストレージ＆ホスト初期化 ---
     restoreUnifiedStorage();
     setCurrentHostname(data.hostname);
@@ -181,6 +185,9 @@ export function handleMessage(data) {
     printManager.renderPrintCurrent(
       document.getElementById("print-current-container")
     );
+
+    // 初期化完了、通知抑制を解除
+    setNotificationSuppressed(false);
 
   }
 

--- a/3dp_lib/dashboard_notification_manager.js
+++ b/3dp_lib/dashboard_notification_manager.js
@@ -18,16 +18,20 @@
  * - {@link NotificationManager}：通知管理クラス
  * - {@link notificationManager}：共有インスタンス
  *
-* @version 1.390.451 (PR #205)
+* @version 1.390.474 (PR #216)
 * @since   1.390.193 (PR #86)
-* @lastModified 2025-06-23 18:52:08
+* @lastModified 2025-06-25 22:45:32
  * -----------------------------------------------------------
  * @todo
  * - none
 */
 "use strict";
 
-import { currentHostname, monitorData } from "./dashboard_data.js";
+import {
+  currentHostname,
+  monitorData,
+  notificationSuppressed
+} from "./dashboard_data.js";
 import { saveUnifiedStorage }           from "./dashboard_storage.js";
 import { audioManager }                 from "./dashboard_audio_manager.js";
 import { defaultNotificationMap }       from "./dashboard_notification_defaults.js";
@@ -312,9 +316,9 @@ export class NotificationManager {
    * @function notify
    * @param {string} type
    * @param {object} [payload]
-   */
+  */
   notify(type, payload = {}) {
-    if (!this.enabled) return;
+    if (!this.enabled || notificationSuppressed) return;
     const def = this.map[type];
     if (!def?.enabled) return;
 


### PR DESCRIPTION
## Summary
- suppress notifications while initializing a connection
- add notification suppression flag to data model
- update NotificationManager to respect the flag
- reset flag on disconnect

## Testing
- `node --check 3dp_lib/dashboard_data.js`
- `node --check 3dp_lib/dashboard_notification_manager.js`
- `node --check 3dp_lib/dashboard_msg_handler.js`
- `node --check 3dp_lib/dashboard_connection.js`


------
https://chatgpt.com/codex/tasks/task_e_685bfcbcf614832fa6ab51d1b7cf0471