### PR TITLE
Add pop-up G-code sender

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -17,9 +17,9 @@
  * - {@link persistPrintResume}：印刷再開用データを保存
  * - {@link initializeAutoSave}：自動保存タイマーを開始
  *
-* @version 1.390.462 (PR #211)
+* @version 1.390.488 (PR #222)
 * @since   1.390.193 (PR #86)
-* @lastModified 2025-06-25 20:25:42
+* @lastModified 2025-06-27 23:37:32
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -78,7 +78,11 @@ import {
 import { notificationManager } from "./dashboard_notification_manager.js";
 import { persistAggregatorState,stopAggregatorTimer } from "./dashboard_aggregator.js";
 import { showAlert } from "./dashboard_notification_manager.js";
-import { initSendRawJson, initTestRawJson } from "./dashboard_send_command.js";
+import {
+  initSendRawJson,
+  initSendGcode,
+  initTestRawJson
+} from "./dashboard_send_command.js";
 
 let filamentPreview = null;
 /**
@@ -347,6 +351,7 @@ export function initializeDashboard({
 
   // (19) JSONコマンド送信機能
   initSendRawJson();
+  initSendGcode();
   initTestRawJson();
 }
 

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -299,11 +299,10 @@
           <div class="cmd-group">
             <button id="btn-history-list">履歴一覧取得</button>
             <button id="btn-file-list">ファイル一覧取得</button>
+            <button id="btn-send-gcode">G-code送信</button>
             <button id="btn-send-raw-json">JSONコマンド送信</button>
           </div>
           <div class="cmd-group">
-            <label>受信JSON:</label>
-            <input id="cmd-test-json" type="text" />
             <button id="btn-test-raw-json">JSONコマンドテスト</button>
           </div>
           <div class="control-temp-area">


### PR DESCRIPTION
## Summary
- implement `sendGcodeCommand` to send custom G-code JSON
- add `initSendGcode` for a pop-up G-code sender
- unify JSON command test UI with a pop-up input
- wire new function in dashboard initialization
- update operation panel HTML layout

## Testing
- `node -c 3dp_lib/dashboard_connection.js`
- `node -c 3dp_lib/dashboard_send_command.js`
- `node -c 3dp_lib/3dp_dashboard_init.js`

------
https://chatgpt.com/codex/tasks/task_e_685eabe56310832fa1a229707065f6b4