### PR TITLE
Prevent duplicate error notifications

### DIFF
--- a/3dp_lib/dashboard_data.js
+++ b/3dp_lib/dashboard_data.js
@@ -20,9 +20,9 @@
  * - {@link setStoredData}：storedData に値格納
  * - {@link getDisplayValue}：表示用値取得
  *
- * @version 1.390.474 (PR #216)
- * @since   1.390.193 (PR #86)
- * @lastModified 2025-06-25 22:45:26
+* @version 1.390.496 (PR #225)
+* @since   1.390.193 (PR #86)
+* @lastModified 2025-06-28 12:00:48
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -107,7 +107,7 @@ export function setNotificationSuppressed(flag) {
 export function createEmptyMachineData() {
   return {
     storedData: {},
-    runtimeData: {},
+    runtimeData: { lastError: null },
     historyData: [],
     printStore: { current: null, history: [], videos: {} }
   };
@@ -127,7 +127,10 @@ export function ensureMachineData(host) {
     return;
   }
   machine.storedData  ??= {};
-  machine.runtimeData ??= {};
+  machine.runtimeData ??= { lastError: null };
+  if (!('lastError' in machine.runtimeData)) {
+    machine.runtimeData.lastError = null;
+  }
   machine.historyData ??= [];
   if (!machine.printStore) {
     machine.printStore = { current: null, history: [], videos: {} };


### PR DESCRIPTION
## Summary
- preserve `lastError` in runtime data
- dedupe error notifications in message handler

## Testing
- `node --check 3dp_lib/dashboard_msg_handler.js`
- `node --check 3dp_lib/dashboard_data.js`


------
https://chatgpt.com/codex/tasks/task_e_685f5a2630a8832f9c678ae0530542fc