### PR TITLE
feat(core): step2 ConnectionManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,12 @@ This is a browser-based dashboard for monitoring the Clarity series of 3D printe
    On Windows you can also run `start.bat` to launch the server.
 5. Navigate to `http://localhost:8000/3dp_monitor.html` in your browser.
 
+## Development (v2 skeleton)
+To try the new Vite-based dashboard:
+1. Install Node packages: `npm install`
+2. In one terminal run `npm run mock` to start a local echo server.
+3. In another terminal run `npm run dev` and open `http://localhost:5173`.
+The console should display echoed JSON via the new ConnectionManager.
+
 ## License
 3dpmon is distributed under the **Modified BSD License (3-clause BSD License)**. Copyright is held by **pumpCurry** of *5r4ce2*. For details, visit [https://542.jp/](https://542.jp/). You can reach out via X (Twitter) at [@pcb](https://twitter.com/pcb).

--- a/docs/ADR/0001-connection-manager.md
+++ b/docs/ADR/0001-connection-manager.md
@@ -1,0 +1,16 @@
+# ADR-0001 ConnectionManager design choice
+
+We introduce an ES6 class `ConnectionManager` to manage multiple WebSocket connections.
+This ADR records the reason behind choosing a custom implementation instead of relying on existing libraries.
+
+## Status
+Accepted
+
+## Context
+The dashboard must handle multiple printers and reconnect automatically when the connection drops. Most lightweight libraries provide either minimal reconnection or heavy feature sets. We required a small footprint and tight integration with our EventBus.
+
+## Decision
+Implement our own `ConnectionManager` that keeps a registry of connections and forwards events through the EventBus. It handles exponential backoff up to 60 seconds.
+
+## Consequences
+This class becomes the core communication layer in v2. Unit tests ensure basic behavior, and the mock WebSocket server helps development.

--- a/package.json
+++ b/package.json
@@ -5,13 +5,17 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "mock": "node src/core/mock-printer.ws.js",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "engines": { "node": ">=18" },
   "dependencies": {},
   "devDependencies": {
     "vite": "^6.0.0",
-    "sass": "^1.80.0"
+    "sass": "^1.80.0",
+    "vitest": "^1.6.0",
+    "ws": "^8.17.0"
   }
 }

--- a/src/core/ConnectionManager.js
+++ b/src/core/ConnectionManager.js
@@ -1,0 +1,156 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 WebSocket 接続管理クラス
+ * @file ConnectionManager.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * -----------------------------------------------------------
+ * @module core/ConnectionManager
+ *
+ * 【機能内容サマリ】
+ * - プリンタごとの WebSocket 接続を管理しイベントバスへ転送
+ * - 自動再接続機能を備える
+ *
+ * 【公開クラス一覧】
+ * - {@link ConnectionManager}：接続管理クラス
+ *
+* @version 1.390.536 (PR #245)
+* @since   1.390.536 (PR #245)
+* @lastModified 2025-06-28 19:30:39
+ * -----------------------------------------------------------
+ * @todo
+ * - DashboardManager 連携
+ */
+
+import { sha1Hex } from '@shared/utils/hash.js';
+
+/**
+ * WebSocket 接続を管理するクラス。
+ */
+export class ConnectionManager {
+  /** @type {Map<string, {socket: WebSocket|null, meta: Object, state: string, retry: number}>} */
+  #registry = new Map();
+
+  /**
+   * @param {Object} bus - EventBus インスタンス
+   */
+  constructor(bus) {
+    /** @type {Object} */
+    this.bus = bus;
+  }
+
+  /**
+   * 接続メタデータを追加する。まだソケットは接続しない。
+   *
+   * @param {{ip:string, wsPort:number, camPort?:number}} config - 接続設定
+   * @returns {Promise<string>} 生成された接続 ID
+   */
+  async add(config) {
+    const id = await sha1Hex(`${config.ip}:${config.wsPort}`);
+    this.#registry.set(id, { socket: null, meta: { ...config }, state: 'closed', retry: 0 });
+    return id;
+  }
+
+  /**
+   * 指定 ID の接続を開始する。
+   *
+   * @param {string} connectionId - 接続 ID
+   * @returns {Promise<void>} 処理完了を示す Promise
+   */
+  async connect(connectionId) {
+    const entry = this.#registry.get(connectionId);
+    if (!entry || entry.state === 'open' || entry.state === 'connecting') return;
+
+    entry.state = 'connecting';
+    const url = `ws://${entry.meta.ip}:${entry.meta.wsPort}`;
+    const ws = new WebSocket(url);
+    entry.socket = ws;
+
+    ws.addEventListener('open', () => {
+      entry.state = 'open';
+      entry.retry = 0;
+      this.bus.emit('cm:open', { id: connectionId });
+    });
+
+    ws.addEventListener('message', (evt) => {
+      try {
+        const data = JSON.parse(evt.data);
+        this.bus.emit('cm:message', { id: connectionId, data });
+      } catch (e) {
+        console.error('[cm] parse error', e);
+      }
+    });
+
+    ws.addEventListener('error', (e) => {
+      this.bus.emit('cm:error', { id: connectionId, error: e });
+    });
+
+    ws.addEventListener('close', () => {
+      entry.state = 'closed';
+      this.bus.emit('cm:close', { id: connectionId });
+      this.#scheduleReconnect(connectionId);
+    });
+  }
+
+  /**
+   * 接続済みソケットへ JSON を送信する。
+   *
+   * @param {string} connectionId - 接続 ID
+   * @param {Object} json - 送信する JSON オブジェクト
+   * @returns {void}
+   */
+  send(connectionId, json) {
+    const entry = this.#registry.get(connectionId);
+    if (entry && entry.socket && entry.state === 'open') {
+      entry.socket.send(JSON.stringify(json));
+    }
+  }
+
+  /**
+   * 手動で接続を閉じる。
+   *
+   * @param {string} connectionId - 接続 ID
+   * @returns {void}
+   */
+  close(connectionId) {
+    const entry = this.#registry.get(connectionId);
+    if (entry && entry.socket) {
+      entry.socket.close();
+    }
+  }
+
+  /**
+   * 現在の接続状態を取得する。
+   *
+   * @param {string} connectionId - 接続 ID
+   * @returns {'open'|'connecting'|'closed'} 接続状態
+   */
+  getState(connectionId) {
+    return this.#registry.get(connectionId)?.state ?? 'closed';
+  }
+
+  /**
+   * 登録されている接続メタ一覧を返す。
+   *
+   * @returns {Array<Object>} 接続メタ情報配列
+   */
+  list() {
+    return [...this.#registry.entries()].map(([id, { meta, state }]) => ({ id, ...meta, state }));
+  }
+
+  /**
+   * 再接続をスケジュールする内部メソッド。
+   *
+   * @private
+   * @param {string} connectionId - 接続 ID
+   * @returns {void}
+   */
+  #scheduleReconnect(connectionId) {
+    const entry = this.#registry.get(connectionId);
+    if (!entry) return;
+    entry.retry = Math.min(entry.retry + 1, 6);
+    const delay = Math.min(60000, 1000 * 2 ** entry.retry);
+    setTimeout(() => {
+      this.connect(connectionId);
+    }, delay);
+  }
+}

--- a/src/core/EventBus.js
+++ b/src/core/EventBus.js
@@ -1,0 +1,67 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 簡易イベントバスモジュール
+ * @file EventBus.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * -----------------------------------------------------------
+ * @module core/EventBus
+ *
+ * 【機能内容サマリ】
+ * - publish/subscribe 形式の簡易イベントバスを提供
+ *
+ * 【公開定数一覧】
+ * - {@link bus}：シングルトンのイベントバス
+ *
+* @version 1.390.536 (PR #245)
+* @since   1.390.536 (PR #245)
+* @lastModified 2025-06-28 19:30:39
+ * -----------------------------------------------------------
+ * @todo
+ * - なし
+ */
+
+/**
+ * 簡易 publish/subscribe イベントバス。
+ * コールバック登録と通知を行う。
+ *
+ * @constant {Object}
+ */
+export const bus = (() => {
+  /** @type {Map<string, Function[]>} */
+  const map = new Map();
+  return {
+    /**
+     * 指定イベントのリスナーを登録する。
+     *
+     * @param {string} evt - イベント名
+     * @param {Function} fn - コールバック関数
+     * @returns {void}
+     */
+    on(evt, fn) {
+      const list = map.get(evt) ?? [];
+      list.push(fn);
+      map.set(evt, list);
+    },
+    /**
+     * 指定イベントのリスナーを解除する。
+     *
+     * @param {string} evt - イベント名
+     * @param {Function} fn - コールバック関数
+     * @returns {void}
+     */
+    off(evt, fn) {
+      const list = map.get(evt) ?? [];
+      map.set(evt, list.filter(f => f !== fn));
+    },
+    /**
+     * イベントを発火し、登録されたリスナーへ通知する。
+     *
+     * @param {string} evt - イベント名
+     * @param {*} data - 任意のデータ
+     * @returns {void}
+     */
+    emit(evt, data) {
+      (map.get(evt) ?? []).forEach(f => f(data));
+    }
+  };
+})();

--- a/src/core/mock-printer.ws.js
+++ b/src/core/mock-printer.ws.js
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 モックプリンタ WebSocket サーバ
+ * @file mock-printer.ws.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * -----------------------------------------------------------
+ * @module core/mock-printer
+ *
+ * 【機能内容サマリ】
+ * - ローカル開発用の単純なエコー WebSocket サーバ
+ *
+ * 【公開関数一覧】
+ * - なし（実行スクリプト）
+ *
+* @version 1.390.536 (PR #245)
+* @since   1.390.536 (PR #245)
+* @lastModified 2025-06-28 19:30:39
+ * -----------------------------------------------------------
+ * @todo
+ * - 高度なテスト応答
+ */
+
+import { WebSocketServer } from 'ws';
+
+const wss = new WebSocketServer({ port: 9999 });
+
+wss.on('connection', (socket) => {
+  socket.on('message', (msg) => {
+    // 受信したメッセージをそのまま返すだけの単純なエコー
+    socket.send(msg.toString());
+  });
+});
+
+console.log('mock printer ws started on ws://127.0.0.1:9999');

--- a/src/shared/utils/hash.js
+++ b/src/shared/utils/hash.js
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 SHA-1 ハッシュ生成ユーティリティ
+ * @file hash.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * -----------------------------------------------------------
+ * @module shared/utils/hash
+ *
+ * 【機能内容サマリ】
+ * - 文字列から SHA-1 ダイジェストを生成し16進表現で返す
+ *
+ * 【公開関数一覧】
+ * - {@link sha1Hex}：SHA-1 ハッシュ文字列を生成
+ *
+* @version 1.390.536 (PR #245)
+* @since   1.390.536 (PR #245)
+* @lastModified 2025-06-28 19:30:39
+ * -----------------------------------------------------------
+ * @todo
+ * - なし
+ * @function sha1Hex
+ */
+
+/**
+ * 与えられた文字列から SHA-1 ハッシュを生成して16進表現で返す。
+ *
+ * @param {string} str - ハッシュ化する文字列
+ * @returns {Promise<string>} SHA-1 ハッシュの16進表現
+ */
+export async function sha1Hex(str) {
+  const enc = new TextEncoder();
+  const data = enc.encode(str);
+  const digest = await crypto.subtle.digest('SHA-1', data);
+  const bytes = new Uint8Array(digest);
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+}

--- a/src/startup.js
+++ b/src/startup.js
@@ -12,9 +12,9 @@
  * 【公開関数一覧】
  * - {@link main}：起動処理を実行
  *
- * @version 1.390.534 (PR #244)
- * @since   1.390.534 (PR #244)
- * @lastModified 2025-06-28 19:21:40
+* @version 1.390.536 (PR #245)
+* @since   1.390.536 (PR #245)
+* @lastModified 2025-06-28 19:30:39
  * -----------------------------------------------------------
  * @todo
  * - AuthGate と App モジュールの統合
@@ -22,6 +22,9 @@
  */
 
 /* eslint-env browser */
+import { bus } from '@core/EventBus.js';
+import { ConnectionManager } from '@core/ConnectionManager.js';
+
 console.log('[startup] bootstrap v2 skeleton');
 
 /**
@@ -34,6 +37,14 @@ console.log('[startup] bootstrap v2 skeleton');
 async function main() {
   const root = document.querySelector('#app-root');
   root.textContent = 'Hello, 3dpmon v2 skeleton!';
+
+  const cm = new ConnectionManager(bus);
+  const id = await cm.add({ ip: '127.0.0.1', wsPort: 9999 });
+  cm.connect(id);
+
+  bus.on('cm:message', ({ id: cid, data }) => {
+    console.log('[cm]', cid, data);
+  });
 }
 
 main();

--- a/tests/connection.test.js
+++ b/tests/connection.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { WebSocketServer } from 'ws';
+import { ConnectionManager } from '../src/core/ConnectionManager.js';
+import { bus } from '../src/core/EventBus.js';
+
+let server;
+
+beforeAll(() => {
+  server = new WebSocketServer({ port: 9999 });
+  server.on('connection', (socket) => {
+    socket.on('message', (msg) => {
+      socket.send(msg.toString());
+    });
+  });
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe('ConnectionManager', () => {
+  it('registry creation and message bridge', async () => {
+    const cm = new ConnectionManager(bus);
+    const id = await cm.add({ ip: '127.0.0.1', wsPort: 9999 });
+    expect(cm.list()).toHaveLength(1);
+    await cm.connect(id);
+    await new Promise((r) => setTimeout(r, 100));
+    const recv = [];
+    bus.on('cm:message', ({ data }) => recv.push(data));
+    cm.send(id, { test: 1 });
+    await new Promise((r) => setTimeout(r, 100));
+    expect(recv[0]).toEqual({ test: 1 });
+    cm.close(id);
+  });
+
+  it('reconnect attempt on close', async () => {
+    const cm = new ConnectionManager(bus);
+    const id = await cm.add({ ip: '127.0.0.1', wsPort: 9999 });
+    await cm.connect(id);
+    await new Promise((r) => setTimeout(r, 100));
+    server.clients.forEach((ws) => ws.close());
+    await new Promise((r) => setTimeout(r, 2500));
+    expect(['connecting', 'open', 'closed']).toContain(cm.getState(id));
+    cm.close(id);
+  });
+});


### PR DESCRIPTION
## Summary
- implement ConnectionManager class and supporting utilities
- add EventBus singleton and mock WebSocket server
- wire startup script to connect to localhost:9999
- create unit tests with Vitest
- document development instructions and ADR

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*
- `npm run preview` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc3920cc0832fa3ee1de16e3bd4f8