### PR TITLE
Implement step2 testing setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test

--- a/docs/develop/step2_connection_manager.md
+++ b/docs/develop/step2_connection_manager.md
@@ -1,0 +1,122 @@
+## ステップ② ― ConnectionManager 実装 & 単体 WebSocket 通信
+
+この文書はステップ②で実装した内容とレビュー結果をまとめたものです。
+
+### 1. レビュー結果
+
+| 評価項目 | 結果 | コメント |
+| --- | --- | --- |
+| **構造** | ◯ | `/src/core/ConnectionManager.js`, `EventBus.js`, `utils/hash.js` が追加され、API シグネチャは仕様通り。 |
+| **エコー通信** | ◯ | `npm run mock` → `dev` で `{\"hello\":\"world\"}` が往復することを確認。 |
+| **ESM & Vite 統合** | △ | 接続テストは動くが、`@shared/utils/hash.js` のパスが Vite alias 未登録 (`vite.config.js` 追加済)。 |
+| **Vitest テスト** | ✕ | `npm test` が **module not found (`ws`, ESM)** エラーで落ちる。Windows/Nix 共に再現。 |
+| **CI 連携** | ✕ | GitHub Actions にはジョブ未追加。 |
+
+### 2. 問題点の原因と対策
+
+| 症状 | 原因 | 解決策 |
+| --- | --- | --- |
+| **1. Vitest が `ws` を解決できない** | `workspace:devDependencies` にはあるが、Vitest は ESM-only モジュールを *CJS で stub* しようとして失敗。 | ① `vitest.config.js` に `define:{global: {}}` と `test.environment:"node"`<br>② `ws` を `--no-external=ws` でバンドル or `vi.mock('ws', …)` でスタブ |
+| **2. crypto.subtle が Node18 で Experimental** | hash.js で `crypto.subtle` を使用 | `import { createHash } from 'node:crypto';` ⇒ `createHash('sha1').update(buf).digest('hex');` へ置換 |
+| **3. tests/ ディレクトリがリポジトリ外** | `tests` が `.gitignore` されている | `.gitkeep` を置き、**サンプルテストを常設** |
+| **4. CI ジョブが無い** | actions 未設定 | `ci.yml` を追加し `npm ci && npm test` を実行。`services: websocket-mock` で `ws` コンテナを起動するか、`mock-printer` を node プロセスで前起動。 |
+
+### 3. 修正版設計 & 作業手順
+
+1. 依存追加
+   ```bash
+   npm i -D vitest @vitest/ui
+   npm i -D sinon
+   ```
+2. `vitest.config.js`
+   ```js
+   import { defineConfig } from 'vitest/config';
+
+   export default defineConfig({
+     test: {
+       environment: 'node',
+       globals: true,
+       include: ['tests/**/*.test.js'],
+       coverage: { reporter: ['text', 'lcov'] }
+     },
+     resolve: { alias: { '@core': '/src/core' } }
+   });
+   ```
+3. `utils/hash.js` 修正
+   ```js
+   import { createHash } from 'node:crypto';
+
+   export function sha1Hex(str) {
+     return createHash('sha1').update(str).digest('hex');
+   }
+   ```
+4. モック WebSocket（テスト用スタブ）
+   ```js
+   // tests/__mocks__/ws.js
+   export default class WebSocketMock {
+     constructor(url) {
+       this.url = url;
+       setTimeout(() => this.onopen?.(), 5);
+     }
+     send(msg) { setTimeout(() => this.onmessage?.({ data: msg }), 5); }
+     close() { this.onclose?.(); }
+   }
+   ```
+5. サンプルテスト `tests/connection.test.js`
+   ```js
+   import { ConnectionManager } from '@core/ConnectionManager.js';
+   import { bus } from '@core/EventBus.js';
+
+   vi.mock('ws', () => ({
+     default: (await import('./__mocks__/ws.js')).default
+   }));
+
+   describe('ConnectionManager', () => {
+     it('opens, echoes and closes', async () => {
+       const cm = new ConnectionManager(bus);
+       const id = await cm.add({ ip: '127.0.0.1', wsPort: 9999 });
+       await cm.connect(id);
+       expect(cm.getState(id)).toBe('open');
+
+       const p = new Promise(r => bus.on('cm:message', r));
+       cm.send(id, { ping: 1 });
+       const frame = await p;
+       expect(frame.data).toEqual({ ping: 1 });
+
+       cm.close(id);
+       expect(cm.getState(id)).toBe('closed');
+     });
+   });
+   ```
+6. npm scripts 更新
+   ```jsonc
+   "scripts": {
+     "dev": "vite",
+     "mock": "node src/core/mock-printer.ws.js",
+     "test": "vitest run",
+     "test:ui": "vitest --ui"
+   }
+   ```
+7. GitHub Actions (`.github/workflows/ci.yml`)
+   ```yaml
+   name: CI
+   on: [push, pull_request]
+   jobs:
+     test:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v4
+         - uses: actions/setup-node@v4
+           with: { node-version: 18 }
+         - run: npm ci
+         - run: npm test
+   ```
+8. 完了チェック
+   * `npm test` 緑
+   * Coverage ≥ 80 %
+   * `npm run dev` で "Hello skeleton" 表示
+   * `mock-printer.ws.js` を立てなくてもテストが動く
+
+---
+
+以上がステップ②で行う内容の要約である。これらを適用することで v2 開発の基盤が整う。

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "mock": "node src/core/mock-printer.ws.js",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest run",
+    "test:ui": "vitest --ui"
   },
   "engines": { "node": ">=18" },
   "dependencies": {},
@@ -16,6 +17,8 @@
     "vite": "^6.0.0",
     "sass": "^1.80.0",
     "vitest": "^1.6.0",
+    "@vitest/ui": "^1.6.0",
+    "sinon": "^17.0.1",
     "ws": "^8.17.0"
   }
 }

--- a/src/shared/utils/hash.js
+++ b/src/shared/utils/hash.js
@@ -12,9 +12,9 @@
  * 【公開関数一覧】
  * - {@link sha1Hex}：SHA-1 ハッシュ文字列を生成
  *
-* @version 1.390.536 (PR #245)
-* @since   1.390.536 (PR #245)
-* @lastModified 2025-06-28 19:30:39
+* @version 1.390.537 (PR #246)
+* @since   1.390.537 (PR #246)
+* @lastModified 2025-06-28 19:47:19
  * -----------------------------------------------------------
  * @todo
  * - なし
@@ -25,12 +25,10 @@
  * 与えられた文字列から SHA-1 ハッシュを生成して16進表現で返す。
  *
  * @param {string} str - ハッシュ化する文字列
- * @returns {Promise<string>} SHA-1 ハッシュの16進表現
+ * @returns {string} SHA-1 ハッシュの16進表現
  */
-export async function sha1Hex(str) {
-  const enc = new TextEncoder();
-  const data = enc.encode(str);
-  const digest = await crypto.subtle.digest('SHA-1', data);
-  const bytes = new Uint8Array(digest);
-  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+import { createHash } from 'node:crypto';
+
+export function sha1Hex(str) {
+  return createHash('sha1').update(str).digest('hex');
 }

--- a/tests/__mocks__/ws.js
+++ b/tests/__mocks__/ws.js
@@ -1,0 +1,12 @@
+export default class WebSocketMock {
+  constructor(url) {
+    this.url = url;
+    setTimeout(() => this.onopen?.(), 5);
+  }
+  send(msg) {
+    setTimeout(() => this.onmessage?.({ data: msg }), 5);
+  }
+  close() {
+    this.onclose?.();
+  }
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['tests/**/*.test.js'],
+    coverage: { reporter: ['text', 'lcov'] }
+  },
+  resolve: {
+    alias: {
+      '@core': path.resolve(__dirname, 'src/core')
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add vitest config with node environment
- use Node crypto for hash utility
- replace WebSocket server tests with mocked WebSocket
- document step2 ConnectionManager design
- configure GitHub Actions CI

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc7b98144832fb857ba9fc87d0555