### PR TITLE
Add testing guide and Vitest setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   - 対応機種はK1C / K1 Max で動作確認をしています。
   - ほかの機種にも対応可能であれば対応させたいので、ご協力くださるかたどうかよろしくお願いいたします。
 
+The console should display echoed JSON via the new ConnectionManager.
 ## インストール
 1. このリポジトリをダウンロードします。
    - **Git**: `git clone https://github.com/pumpCurry/3dpmon.git`
@@ -52,6 +53,14 @@ To try the new Vite-based dashboard:
 2. In one terminal run `npm run mock` to start a local echo server.
 3. In another terminal run `npm run dev` and open `http://localhost:5173`.
 The console should display echoed JSON via the new ConnectionManager.
+## Run tests
+Unit tests are executed with [Vitest](https://vitest.dev/).
+
+1. Install Node packages: `npm install`
+2. Run `npm test`
+
+See [docs/develop/tests.md](docs/develop/tests.md) for coverage goals and additional details.
+
 
 ## License
 3dpmon is distributed under the **Modified BSD License (3-clause BSD License)**. Copyright is held by **pumpCurry** of *5r4ce2*. For details, visit [https://542.jp/](https://542.jp/). You can reach out via X (Twitter) at [@pcb](https://twitter.com/pcb).

--- a/docs/develop/step2_review.md
+++ b/docs/develop/step2_review.md
@@ -1,0 +1,51 @@
+## ステップ②レビューまとめ
+
+| 観点               | 状態 | コメント |
+| ---------------- | -- | -------------------------------------------------------------- |
+| **構造**           | ◯  | `src/core/ConnectionManager.js` / `EventBus.js` / `utils/hash.js` 追加済み。API シグネチャは要件通り。 |
+| **WebSocket 動作** | ◯  | `npm run mock`＋`npm run dev` で Echo フレーム確認。 |
+| **ユニットテスト**      | △  | `vitest` が **`ws` ESM 解決エラー**で failure。`crypto.subtle` も Node18 で Experimental 警告。 |
+| **CI**           | ✕  | GitHub Actions 未設定。 |
+| **ドキュメント**       | ✕  | テスト仕様書が未作成。 |
+
+**結論**
+
+* **テストと CI が RED** のため、まだ “All Green” ではない。
+* 以下の **修正＋増強手順** を適用してからステップ③へ進むことを推奨。
+
+---
+
+## ステップ② ― 修正 & 増強手順書
+
+### 2.1 作業概要
+
+| タスクID | 内容 |
+| ----- | ---------------------------------------- |
+| T2-1  | `vitest.config.js` 追加、Node 環境指定 |
+| T2-2  | `utils/hash.js` を `node:crypto` ベース実装へ変更 |
+| T2-3  | `__mocks__/ws.js` を作成し Vitest で自動スタブ |
+| T2-4  | ユニットテスト `tests/connection.test.js` 追加 |
+| T2-5  | GitHub Actions CI（`ci.yml`）を追加 |
+| T2-6  | **テスト仕様書** `docs/develop/tests.md` を新規作成 |
+| T2-7  | README に “Run tests” セクションリンクを追加 |
+
+### 2.2 具体手順
+
+詳細コマンドやコード例は `step2_connection_manager.md` を参照。主な流れは以下の通り。
+1. `vitest` と `sinon` を devDependencies へ追加し、`vitest.config.js` を作成する。
+2. `utils/hash.js` を Node.js `createHash` ベースに書き換える。
+3. テスト用 `WebSocket` モックを `tests/__mocks__/ws.js` に配置し、Vitest から自動読み込みするよう `tests/setup.js` を用意。
+4. `ConnectionManager` の挙動を確認するユニットテスト `tests/connection.test.js` を実装。
+5. `.github/workflows/ci.yml` を追加し、push/pull_request 時に `npm test` を実行。
+6. テスト仕様書 `docs/develop/tests.md` を作成し、カバレッジ 80%以上を成功基準として明記。
+7. README から当仕様書へリンクし、開発者がテストを実行しやすいよう説明を補足。
+
+### 2.3 完了チェックリスト
+
+- [ ] `npm test` 全緑 & カバレッジ表示
+- [ ] `npm run dev` 問題なし
+- [ ] `ci.yml` で GitHub 上も PASS
+- [ ] `docs/develop/tests.md` 追加
+- [ ] README 更新
+
+以上を満たした状態を “ステップ②完了 (All Green)” と呼称する。

--- a/docs/develop/tests.md
+++ b/docs/develop/tests.md
@@ -1,0 +1,18 @@
+# 3dpmon v2 ― テスト仕様書
+
+## 1. 目的
+ConnectionManager・カード群の退行バグを早期検出する。
+
+## 2. テストレイヤ
+| レイヤ | ツール | 対象 |
+|-------|-------|-----|
+| 単体 | Vitest | utils, core |
+| 結合 | Vitest+Mock WS | ConnectionManager ↔ EventBus |
+| E2E | Playwright (Step⑧) | UI/カード相互作用 |
+
+## 3. 命名規約
+`tests/<module>.test.js`
+
+## 4. 成功基準
+- `npm test` 緑 100%
+- カバレッジ 80% 以上

--- a/tests/__mocks__/ws.js
+++ b/tests/__mocks__/ws.js
@@ -1,11 +1,47 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 WebSocket モッククラス
+ * @file ws.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * -----------------------------------------------------------
+ * @module tests/__mocks__/ws
+ *
+ * 【機能内容サマリ】
+ * - Vitest 環境で WebSocket 通信を模倣する
+ *
+ * 【公開クラス一覧】
+ * - {@link WebSocketMock}：簡易 WebSocket モック
+ *
+ * @version 1.390.540 (PR #247)
+ * @since   1.390.540 (PR #247)
+ * @lastModified 2025-06-28 19:55:55
+ * -----------------------------------------------------------
+ * @todo
+ * - なし
+ */
+
 export default class WebSocketMock {
   constructor(url) {
     this.url = url;
+    // すぐに open イベントを発火して接続済み状態を模倣
     setTimeout(() => this.onopen?.(), 5);
   }
+
+  /**
+   * メッセージ送信をエコーとして扱い、即時 onmessage を発火する。
+   *
+   * @param {string} msg - 送信フレーム
+   * @returns {void}
+   */
   send(msg) {
     setTimeout(() => this.onmessage?.({ data: msg }), 5);
   }
+
+  /**
+   * 接続を閉じたことを通知する。
+   *
+   * @returns {void}
+   */
   close() {
     this.onclose?.();
   }

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 Vitest セットアップモジュール
+ * @file setup.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * -----------------------------------------------------------
+ * @module tests/setup
+ *
+ * 【機能内容サマリ】
+ * - テスト実行時に WebSocket モックを登録する
+ *
+ * 【公開関数一覧】
+ * - なし（実行時副作用のみ）
+ *
+ * @version 1.390.540 (PR #247)
+ * @since   1.390.540 (PR #247)
+ * @lastModified 2025-06-28 19:55:55
+ * -----------------------------------------------------------
+ * @todo
+ * - なし
+ */
+
+// Vitest 起動時に WebSocket モジュールをモック化する
+vi.mock('ws', async () => ({
+  default: (await import('./__mocks__/ws.js')).default
+}));

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -6,11 +6,13 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     include: ['tests/**/*.test.js'],
+    setupFiles: ['tests/setup.js'],
     coverage: { reporter: ['text', 'lcov'] }
   },
   resolve: {
     alias: {
-      '@core': path.resolve(__dirname, 'src/core')
+      '@core': path.resolve(__dirname, 'src/core'),
+      '@shared': path.resolve(__dirname, 'src/shared')
     }
   }
 });


### PR DESCRIPTION
## Summary
- document step2 review and testing approach
- add testing instructions in README
- provide new testing guide in docs
- mock WebSocket via setup file
- extend Vitest config

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc9c92174832f9a4bcd025bedef9a