### PR TITLE
Add Codex setup guide and mocks for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Unit tests are executed with [Vitest](https://vitest.dev/).
 
 See [docs/develop/tests.md](docs/develop/tests.md) for coverage goals and additional details.
 
+## Codex Task Execution
+To run this project within OpenAI Codex tasks, set the setup script path to `run/codex/setup.sh` and enable internet access only for that step. Required environment variables are `NODE_ENV=ci` and `CI=true`. Details are described in [docs/develop/codex_setup.md](docs/develop/codex_setup.md).
+
 
 ## License
 3dpmon is distributed under the **Modified BSD License (3-clause BSD License)**. Copyright is held by **pumpCurry** of *5r4ce2*. For details, visit [https://542.jp/](https://542.jp/). You can reach out via X (Twitter) at [@pcb](https://twitter.com/pcb).

--- a/docs/develop/codex_setup.md
+++ b/docs/develop/codex_setup.md
@@ -1,0 +1,53 @@
+# Codex タスク実行ガイド
+
+このドキュメントでは Codex 環境上でテストを成功させるための設定手順をまとめます。Step② で発生した "RED" 状態の原因と対策を整理したものです。
+
+## 1. ステップ② "Codex 上で RED" の原因まとめ
+
+| 症状 | 原因 (Codex 環境) | ローカルとの差 |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `npm test` が失敗 | **依存解決が途中で停止**<br>‐ Universal イメージの Node 20 は OK だが **devDependencies がまだ未取得**<br>‐ `ws` や `vitest` が global に存在しない | ローカルでは `npm i` で取得済み |
+| crypto.subtle 警告 | Universal=Node 20 → `crypto.subtle` 依存は Experimental | ローカルで createHash に置換済みなら問題なし |
+| ネット遮断タスクで registry に到達できず install 失敗 | **setup script 未定義** で `npm ci` が動かない | ローカルはオンライン |
+
+> Codex はタスク開始時に指定された「セットアップスクリプト」だけがネットワークを許可します。ここで `npm ci` や `playwright install` を実行しないとテストが走りません。
+
+## 2. Codex 環境に入れるべき設定一覧
+
+| セクション | 推奨設定 | 理由 |
+| ---------------- | ------------------------------------------- | -------------------- |
+| **環境変数** | `NODE_ENV=ci` / `CI=true` | npm スクリプトで CI 挙動に切替 |
+| **シークレット** | (不要) | npm install のみにネット使用 |
+| **セットアップスクリプト** | `run/codex/setup.sh` | 依存取得 → テスト実行 |
+| **ドメイン許可** | `registry.npmjs.org` `registry.yarnpkg.com` | npm ci が通る最小構成 |
+| **許可 HTTP メソッド** | `GET`, `HEAD` | 依存ダウンロードのみ |
+| **インターネットアクセス** | **ON（setup 時のみ）** | テストラン時は OFF のまま |
+
+### 2-1. セットアップスクリプト例
+
+```bash
+#!/usr/bin/env bash
+# Codex setup script for 3dpmon
+set -euxo pipefail
+
+cd /workspace/3dpmon
+corepack enable
+npm ci --ignore-scripts
+npm run -s test || true
+```
+
+## 3. リポジトリ側の追加ファイル
+
+```
+/run/codex/setup.sh        ★セットアップスクリプト
+docs/develop/tests.md      ★テスト仕様書
+.github/workflows/ci.yml   ★GitHub CI
+tests/setup.js             ★Vitest WebSocket モック登録
+tests/__mocks__/ws.js
+tests/connection.test.js
+vitest.config.js
+```
+
+## 4. テスト仕様書リンク
+
+詳細なテスト方針は [docs/develop/tests.md](tests.md) を参照してください。

--- a/run/codex/setup.sh
+++ b/run/codex/setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Codex setup script for 3dpmon
+set -euxo pipefail
+
+cd /workspace/3dpmon
+
+# Ensure corepack and install dependencies
+corepack enable
+npm ci --ignore-scripts
+
+# Run tests once to compile modules
+npm run -s test || true

--- a/tests/__mocks__/ws.js
+++ b/tests/__mocks__/ws.js
@@ -28,6 +28,17 @@ export default class WebSocketMock {
   }
 
   /**
+   * addEventListener の簡易実装。対応する onXXX ハンドラへ登録する。
+   *
+   * @param {string} evt - イベント名
+   * @param {Function} fn - ハンドラ
+   * @returns {void}
+   */
+  addEventListener(evt, fn) {
+    this[`on${evt}`] = fn;
+  }
+
+  /**
    * メッセージ送信をエコーとして扱い、即時 onmessage を発火する。
    *
    * @param {string} msg - 送信フレーム

--- a/tests/connection.test.js
+++ b/tests/connection.test.js
@@ -1,8 +1,30 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 ConnectionManager 結合テスト
+ * @file connection.test.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * -----------------------------------------------------------
+ * @module tests/connection
+ *
+ * 【機能内容サマリ】
+ * - WebSocket モックを用いた ConnectionManager の送受信検証
+ *
+ * 【公開関数一覧】
+ * - なし（Vitest スイート）
+ *
+ * @version 1.390.540 (PR #247)
+ * @since   1.390.540 (PR #247)
+ * @lastModified 2025-06-28 19:55:55
+ * -----------------------------------------------------------
+ * @todo
+ * - なし
+ */
+
 import { describe, it, expect, vi } from 'vitest';
 import { ConnectionManager } from '@core/ConnectionManager.js';
 import { bus } from '@core/EventBus.js';
 
-vi.mock('ws', () => ({
+vi.mock('ws', async () => ({
   default: (await import('./__mocks__/ws.js')).default
 }));
 
@@ -10,7 +32,9 @@ describe('ConnectionManager', () => {
   it('opens, echoes and closes', async () => {
     const cm = new ConnectionManager(bus);
     const id = await cm.add({ ip: '127.0.0.1', wsPort: 9999 });
+    const openP = new Promise((r) => bus.on('cm:open', r));
     await cm.connect(id);
+    await openP;
     expect(cm.getState(id)).toBe('open');
 
     const p = new Promise((r) => bus.on('cm:message', r));
@@ -18,7 +42,9 @@ describe('ConnectionManager', () => {
     const frame = await p;
     expect(frame.data).toEqual({ ping: 1 });
 
+    const closeP = new Promise((r) => bus.on('cm:close', r));
     cm.close(id);
+    await closeP;
     expect(cm.getState(id)).toBe('closed');
   });
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -24,3 +24,8 @@
 vi.mock('ws', async () => ({
   default: (await import('./__mocks__/ws.js')).default
 }));
+
+// ConnectionManager がグローバルの WebSocket を利用するため、
+// テスト環境ではグローバルへモックを設定する
+import WebSocketMock from './__mocks__/ws.js';
+globalThis.WebSocket = WebSocketMock;


### PR DESCRIPTION
## Summary
- document Codex environment requirements
- add setup script for Codex usage
- improve Vitest WebSocket mocks and tests
- mention Codex flow in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fd04b278c832fb38ea14974431f2d