### PR TITLE
Implement DashboardManager and integrate into App

### DIFF
--- a/src/core/App.js
+++ b/src/core/App.js
@@ -12,17 +12,17 @@
  * 【公開クラス一覧】
  * - {@link App}：アプリケーションメインクラス
  *
-* @version 1.390.563 (PR #259)
+* @version 1.390.576 (PR #260)
 * @since   1.390.531 (PR #1)
-* @lastModified 2025-06-29 13:09:40
+* @lastModified 2025-06-30 12:00:00
  * -----------------------------------------------------------
  * @todo
- * - ConnectionManager の実装
- * - DashboardManager の実装
+* - ConnectionManager の高度化
+* - DashboardManager のカード連携
  */
 
-import TitleBar from '@cards/Bar_Title.js';
-import SideMenu from '@cards/Bar_SideMenu.js';
+import { ConnectionManager } from './ConnectionManager.js';
+import DashboardManager from './DashboardManager.js';
 import { bus } from './EventBus.js';
 
 /**
@@ -35,19 +35,10 @@ export class App {
   constructor(rootSelector) {
     /** @type {HTMLElement|null} */
     this.root = document.querySelector(rootSelector);
+    this.cm = new ConnectionManager(bus);
+    this.db = new DashboardManager(bus, this.cm);
     if (this.root) {
-      this.titleBar = new TitleBar(bus);
-      this.titleBar.mount(this.root);
-      this.titleBar.setTabs([
-        { id: 'd1', label: 'Dummy1', color: '#f66' },
-        { id: 'd2', label: 'Dummy2', color: '#6f6' },
-        { id: 'd3', label: 'Dummy3', color: '#66f' }
-      ]);
-
-      this.sideMenu = new SideMenu(bus);
-      this.sideMenu.mount(this.root);
-      bus.on('menu:global', () => this.sideMenu.open());
-      bus.on('menu:close', () => this.sideMenu.close());
+      this.db.render(this.root);
     }
   }
 }

--- a/src/core/DashboardManager.js
+++ b/src/core/DashboardManager.js
@@ -1,0 +1,73 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 ダッシュボード管理クラス
+ * @file DashboardManager.js
+ * -----------------------------------------------------------
+ * @module core/DashboardManager
+ *
+ * 【機能内容サマリ】
+ * - タイトルバーとサイドメニューを生成しカード領域を描画
+ *
+ * 【公開クラス一覧】
+ * - {@link DashboardManager}：ダッシュボード統括クラス
+ *
+ * @version 1.390.576 (PR #260)
+ * @since   1.390.576 (PR #260)
+ * @lastModified 2025-06-30 12:00:00
+ * -----------------------------------------------------------
+ * @todo
+ * - カード動的ロードと配置永続化
+ */
+
+import TitleBar from '@cards/Bar_Title.js';
+import SideMenu from '@cards/Bar_SideMenu.js';
+
+/**
+ * ダッシュボード全体を管理するクラス。
+ */
+export default class DashboardManager {
+  /**
+   * @param {Object} bus - EventBus インスタンス
+   * @param {Object} cm - ConnectionManager インスタンス
+   */
+  constructor(bus, cm) {
+    /** @type {Object} */
+    this.bus = bus;
+    /** @type {Object} */
+    this.cm = cm;
+    /** @type {HTMLElement|null} */
+    this.root = null;
+    /** @type {HTMLElement|null} */
+    this.main = null;
+    /** @type {TitleBar|null} */
+    this.titleBar = null;
+    /** @type {SideMenu|null} */
+    this.sideMenu = null;
+  }
+
+  /**
+   * ルート要素へダッシュボードを描画する。
+   *
+   * @param {HTMLElement} root - 描画先ルート要素
+   * @returns {void}
+   */
+  render(root) {
+    this.root = root;
+    if (!this.root) return;
+
+    this.titleBar = new TitleBar(this.bus);
+    this.titleBar.mount(this.root);
+    this.titleBar.setTabs([
+      { id: 'd1', label: 'Dummy1', color: '#f66' }
+    ]);
+
+    this.sideMenu = new SideMenu(this.bus);
+    this.sideMenu.mount(this.root);
+    this.bus.on('menu:global', () => this.sideMenu && this.sideMenu.open());
+    this.bus.on('menu:close', () => this.sideMenu && this.sideMenu.close());
+
+    this.main = document.createElement('main');
+    this.main.className = 'dashboard-main';
+    this.root.appendChild(this.main);
+  }
+}

--- a/src/startup.js
+++ b/src/startup.js
@@ -8,9 +8,9 @@
  * 【機能内容サマリ】
  * - アプリ初期化処理を呼び出すエントリポイント
  *
- * @version 1.390.549 (PR #252)
- * @since   1.390.536 (PR #245)
- * @lastModified 2025-06-28 20:00:00
+* @version 1.390.576 (PR #260)
+* @since   1.390.536 (PR #245)
+* @lastModified 2025-06-30 12:00:00
  * -----------------------------------------------------------
  * @todo
  * - AuthGate と App モジュールの統合
@@ -19,8 +19,6 @@
 
 /* eslint-env browser */
 import { App } from './core/App.js';
-import { bus } from '@core/EventBus.js';
-import { ConnectionManager } from '@core/ConnectionManager.js';
 
 console.log('[startup] bootstrap v2 skeleton');
 
@@ -31,14 +29,6 @@ console.log('[startup] bootstrap v2 skeleton');
  * @returns {Promise<void>} 処理完了を示す Promise
  */
 async function main() {
-  const cm = new ConnectionManager(bus);
-  const id = await cm.add({ ip: '127.0.0.1', wsPort: 9999 });
-  cm.connect(id);
-
-  bus.on('cm:message', ({ id: cid, data }) => {
-    console.log('[cm]', cid, data);
-  });
-
   new App('#app-root');
 }
 

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,0 +1,30 @@
+// @vitest-environment happy-dom
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 App 結合テスト
+ * @file app.test.js
+ * -----------------------------------------------------------
+ * @module tests/app
+ *
+ * 【機能内容サマリ】
+ * - App 初期化時に DashboardManager が描画されるか検証
+ *
+ * @version 1.390.576 (PR #260)
+ * @since   1.390.576 (PR #260)
+ * @lastModified 2025-06-30 12:00:00
+ */
+
+import { describe, it, beforeEach, expect } from 'vitest';
+import { App } from '@core/App.js';
+
+describe('App', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="root"></div>';
+  });
+
+  it('renders title bar on initialization', () => {
+    new App('#root');
+    expect(document.querySelector('.title-bar')).not.toBeNull();
+    expect(document.querySelector('main.dashboard-main')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add DashboardManager class that renders the title bar and side menu
- update App to create ConnectionManager and DashboardManager
- simplify startup script
- add new test verifying App renders dashboard elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861d7c26798832f998b07ff7aca5992