### PR TITLE
Implement splash screen with keypad

### DIFF
--- a/docs/develop/spec_step7_splash.md
+++ b/docs/develop/spec_step7_splash.md
@@ -1,0 +1,195 @@
+# 3dpmon v2 — ステップ⑦a
+
+### スプラッシュ&認証ゲート実装仕様書（Codex 用）
+
+| バージョン     | 日付         | 著者                  |
+| --------- | ---------- | ------------------- |
+| 0.1 Draft | 2025-07-xx | pumpCurry / ChatGPT |
+
+---
+
+## 1. ゴール
+
+1. アプリ起動時に**スプラッシュ画面**を表示
+2. 同画面内に **テンキー UI**（パスワード入力欄）
+
+   * **現フェーズは “パスワード未設定”** → テンキー全ボタン `disabled` 表示
+   * `Enter` ボタンだけ押下可能（あるいは **Enterキー**）
+3. `Enter` 押下後に **AuthGate** が `true` を返し、
+   **TitleBar + TabBar** を含む既存ダッシュボードが lazy-import される
+4. 単体テスト（Vitest）と E2E（Playwright）緑
+
+---
+
+## 2. 画面遷移 & 責任分界点
+
+```mermaid
+graph TD
+  Startup[startup.js] -->|mount| SplashScreen
+  SplashScreen -->|authOK event| AppRoot(core/App.js)
+  AppRoot --> TitleBar
+  AppRoot --> DashboardManager
+```
+
+| モジュール               | 主責務                                                  | 既存/新規        |
+| ------------------- | ---------------------------------------------------- | ------------ |
+| **startup.js**      | ルート要素に SplashScreen を mount                          | 既存 (変更)      |
+| **SplashScreen.js** | ロゴ + テンキー UI / 認証判定 / authOK emit                    | ★新規          |
+| **AuthGate.js**     | `getPasswordHash()` / `validate()` / `hasPassword()` | 既存 (拡張)      |
+| **Keypad.js**       | 再利用可能な置換式テンキー                                        | ★新規 (parts/) |
+| **App.js**          | ダッシュボード本体を lazy-import                               | 既存           |
+
+*Dashboard 以降は触らない。*
+
+---
+
+## 3. UX 詳細
+
+| 画面          | 要素              | 動作                                 |
+| ----------- | --------------- | ---------------------------------- |
+| **スプラッシュ**  | ロゴ SVG / App 名  | フェードイン 0.6 s                       |
+|             | テンキー (3×4)      | 数・Clear・Enter / 現在は `disabled`（灰色） |
+|             | ローディング円アニメ      | Enter 押下で数秒表示→フェードアウト              |
+| **ダッシュボード** | TitleBar+TabBar | 既存実装                               |
+
+Design token 例（SCSS 変数）
+
+```scss
+:root {
+  --splash-bg: #111;
+  --splash-logo: #68d;
+  --key-disabled: #444;
+  --key-enabled: #2d8;
+}
+```
+
+---
+
+## 4. ファイル/ディレクトリ
+
+```
+src/
+ ├ core/
+ │   └ AuthGate.js        # 拡張
+ ├ splash/
+ │   ├ SplashScreen.js    # ★
+ │   └ Keypad.js          # ★
+ ├ startup.js             # 変更
+styles/
+ ├ splash.scss            # ★
+tests/
+ ├ splash.test.js         # vitest
+ └ e2e_splash.spec.ts     # playwright
+```
+
+---
+
+## 5. 主要 API
+
+### SplashScreen.js
+
+```js
+export default class SplashScreen {
+  constructor(bus) { this.bus = bus; }
+  mount(root) { /* DOM生成 + fadeIn */ }
+  destroy() { /* remove */ }
+}
+```
+
+* エンター押下 ⇒ `bus.emit('auth:ok')`
+
+### AuthGate.js (変更点)
+
+```js
+export async function hasPassword() { return false; } // 未来拡張
+export async function validate(pwd) { return true; }  // 今は即 OK
+```
+
+---
+
+## 6. 実装ステップ（Codex へのタスクリスト）
+
+| # | 作業内容                                                                                 | ファイル                                 |
+| - | ------------------------------------------------------------------------------------ | ------------------------------------ |
+| 1 | 新規 `styles/splash.scss` 作成                                                           | basic flex center + fade             |
+| 2 | `src/splash/Keypad.js`                                                               | 3×4 ボタン: 数字=disabled, Enter=enabled  |
+| 3 | `src/splash/SplashScreen.js`                                                         | ロゴ + Keypad + listener               |
+| 4 | `core/AuthGate.js` 拡張                                                                | `hasPassword/validate` stub          |
+| 5 | `startup.js` で<br>`await import('./splash/SplashScreen.js')`                         | auth:ok ➜ `import('./core/App.js')` |
+| 6 | **Vitest** `splash.test.js`<br> - Splash mounts<br> - Enter emits auth:ok           |                                      |
+| 7 | **Playwright** `e2e_splash.spec.ts`<br> - ページロード→ロゴあり<br> - Enter → TitleBar visible |                                      |
+| 8 | `docs/develop/splash.md` 更新                                                          |                                      |
+
+---
+
+## 7. テスト詳細
+
+### 7.1 splash.test.js (Vitest + happy-dom)
+
+```js
+import { bus } from '@core/EventBus';
+import SplashScreen from '@splash/SplashScreen';
+import { vi } from 'vitest';
+
+it('emits auth:ok on Enter', () => {
+  const spy = vi.fn();
+  bus.on('auth:ok', spy);
+  const s = new SplashScreen(bus);
+  s.mount(document.body);
+  document.querySelector('button.enter').click();
+  expect(spy).toHaveBeenCalled();
+});
+```
+
+### 7.2 e2e_splash.spec.ts
+
+```ts
+import { test, expect } from '@playwright/test';
+test('splash -> dashboard', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('img', { name: /logo/i })).toBeVisible();
+  await page.getByRole('button', { name: /enter/i }).click();
+  await expect(page.getByRole('navigation')).toBeVisible(); // TitleBar
+});
+```
+
+---
+
+## 8. 受け入れ条件
+
+1. `npm run dev` → スプラッシュ + テンキー表示
+2. Enter→フェード→メニューバー描画
+3. Vitest 全緑・Playwright 全緑
+4. CI (GitHub Actions) 緑 / Codex タスク成功
+5. コードカバレッジ ≥ 80 %
+
+---
+
+## 9. 依頼テンプレ（Codex “task description”）
+
+```
+### Goal
+Implement SplashScreen + Keypad stub auth as per docs/develop/spec_step7_splash.md.
+Steps:
+1. Add styles/splash.scss
+2. Create src/splash/Keypad.js (disabled numeric buttons, enabled Enter)
+3. Create src/splash/SplashScreen.js (logo + keypad)
+4. Extend core/AuthGate.js (stub hasPassword/validate)
+5. Update startup.js to mount Splash, then lazy-load App on auth:ok
+6. Add vitest tests in tests/splash.test.js
+7. Add Playwright e2e in tests/e2e_splash.spec.ts
+8. Update docs.
+
+### Acceptance
+- npm run dev shows splash, Enter loads dashboard
+- tests & CI pass
+```
+
+---
+
+## 10. 備考
+
+*テンキー実装* は数行で OK（現フェーズは disabled）。
+後続フェーズで `hasPassword()` が true の場合、テンキー活性化 & SHA-256 検証へ拡張します。
+
+---

--- a/docs/develop/splash.md
+++ b/docs/develop/splash.md
@@ -1,0 +1,15 @@
+# SplashScreen 実装メモ
+
+`SplashScreen` は v2 ステップ⑦a で追加された起動画面です。ロゴとテンキー UI を表示し、Enter 押下でダッシュボードをロードします。
+
+## 構造
+- `SplashScreen.js`：ロゴ描画と `Keypad` 管理。`auth:ok` イベントを emit。
+- `Keypad.js`：3×4 ボタンのテンキークラス。現フェーズでは数字と Clear が無効。
+- `AuthGate.js`：`hasPassword()` と `validate()` をスタブ実装。
+
+## 動作
+1. `startup.js` から SplashScreen を mount。
+2. Enter 押下または Enter キー入力で `auth:ok` を発火。
+3. 既存 `App.js` を lazy-import し、TitleBar を含むダッシュボードが表示されます。
+
+Vitest と Playwright で基本動作を検証するテストを追加しました。

--- a/src/core/AuthGate.js
+++ b/src/core/AuthGate.js
@@ -13,9 +13,9 @@
  * 【公開関数一覧】
  * - {@link initAuth}：認証処理の初期化
  *
- * @version 1.390.531 (PR #1)
+ * @version 1.390.580 (PR #268)
  * @since   1.390.531 (PR #1)
- * @lastModified 2025-06-28 09:54:02
+ * @lastModified 2025-07-01 00:00:00
  * -----------------------------------------------------------
  * @todo
  * - PIN 認証画面の実装
@@ -31,5 +31,27 @@
  */
 export async function initAuth() {
   // TODO: 実際の認証ロジックを実装
+  return true;
+}
+
+/**
+ * パスワードが設定されているか返すスタブ。
+ *
+ * @async
+ * @returns {Promise<boolean>} 常に false を解決する Promise
+ */
+export async function hasPassword() {
+  return false;
+}
+
+/**
+ * パスワードを検証するスタブ実装。
+ *
+ * @async
+ * @param {string} pwd - 入力されたパスワード
+ * @returns {Promise<boolean>} 常に true を解決する Promise
+ */
+export async function validate(pwd) {
+  void pwd;
   return true;
 }

--- a/src/splash/Keypad.js
+++ b/src/splash/Keypad.js
@@ -1,0 +1,72 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 テンキー UI コンポーネント
+ * @file Keypad.js
+ * -----------------------------------------------------------
+ * @module splash/Keypad
+ *
+ * 【機能内容サマリ】
+ * - スプラッシュ画面で利用するテンキーを描画
+ * - 現フェーズでは全キーを disabled 表示し Enter のみ有効
+ *
+ * 【公開クラス一覧】
+ * - {@link Keypad}：テンキー UI クラス
+ *
+ * @version 1.390.580 (PR #268)
+ * @since   1.390.580 (PR #268)
+ * @lastModified 2025-07-01 00:00:00
+ * -----------------------------------------------------------
+ * @todo
+ * - パスワード入力機能の有効化
+ */
+
+/**
+ * テンキー UI クラス。
+ */
+export default class Keypad {
+  /**
+   * @param {Function} onEnter - Enter ボタン押下時のコールバック
+   */
+  constructor(onEnter) {
+    /** @type {HTMLElement|null} */
+    this.el = null;
+    /** @type {Function} */
+    this.onEnter = onEnter;
+  }
+
+  /**
+   * DOM を生成しルートへ追加する。
+   *
+   * @param {HTMLElement} root - 追加先ルート要素
+   * @returns {void}
+   */
+  mount(root) {
+    this.el = document.createElement('div');
+    this.el.className = 'keypad';
+    const labels = ['1','2','3','4','5','6','7','8','9','Clear','0','Enter'];
+    labels.forEach((label) => {
+      const btn = document.createElement('button');
+      btn.textContent = label;
+      if (label === 'Enter') {
+        btn.className = 'enter';
+        btn.addEventListener('click', () => this.onEnter());
+      } else {
+        btn.disabled = true;
+      }
+      this.el.appendChild(btn);
+    });
+    root.appendChild(this.el);
+  }
+
+  /**
+   * DOM を除去する。
+   *
+   * @returns {void}
+   */
+  destroy() {
+    if (this.el && this.el.parentNode) {
+      this.el.parentNode.removeChild(this.el);
+    }
+    this.el = null;
+  }
+}

--- a/src/splash/SplashScreen.js
+++ b/src/splash/SplashScreen.js
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 スプラッシュ画面モジュール
+ * @file SplashScreen.js
+ * -----------------------------------------------------------
+ * @module splash/SplashScreen
+ *
+ * 【機能内容サマリ】
+ * - 起動時のロゴ表示とテンキー UI 管理
+ * - Enter 押下で bus へ 'auth:ok' を通知
+ *
+ * 【公開クラス一覧】
+ * - {@link SplashScreen}：スプラッシュ画面クラス
+ *
+ * @version 1.390.580 (PR #268)
+ * @since   1.390.580 (PR #268)
+ * @lastModified 2025-07-01 00:00:00
+ * -----------------------------------------------------------
+ * @todo
+ * - ローディングアニメ追加
+ */
+
+import Keypad from './Keypad.js';
+
+/**
+ * スプラッシュ画面クラス。
+ */
+export default class SplashScreen {
+  /**
+   * @param {Object} bus - EventBus インスタンス
+   */
+  constructor(bus) {
+    /** @type {Object} */
+    this.bus = bus;
+    /** @type {HTMLElement|null} */
+    this.el = null;
+    /** @type {Keypad|null} */
+    this.keypad = null;
+  }
+
+  /**
+   * 画面を生成しルートへ追加する。
+   *
+   * @param {HTMLElement} root - 描画先ルート要素
+   * @returns {void}
+   */
+  mount(root) {
+    this.el = document.createElement('div');
+    this.el.className = 'splash-screen';
+
+    const logo = document.createElement('div');
+    logo.className = 'logo';
+    logo.textContent = '3dpmon';
+    logo.setAttribute('role', 'img');
+    logo.setAttribute('aria-label', 'logo');
+    this.el.appendChild(logo);
+
+    this.keypad = new Keypad(() => this.#enter());
+    this.keypad.mount(this.el);
+
+    root.appendChild(this.el);
+
+    this.el.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') this.#enter();
+    });
+  }
+
+  /**
+   * Enter アクション時に認証成功を通知する。
+   *
+   * @private
+   * @returns {void}
+   */
+  #enter() {
+    this.bus.emit('auth:ok');
+  }
+
+  /**
+   * DOM を除去する。
+   *
+   * @returns {void}
+   */
+  destroy() {
+    if (this.keypad) this.keypad.destroy();
+    if (this.el && this.el.parentNode) {
+      this.el.parentNode.removeChild(this.el);
+    }
+    this.el = null;
+  }
+}

--- a/src/startup.js
+++ b/src/startup.js
@@ -8,9 +8,9 @@
  * 【機能内容サマリ】
  * - アプリ初期化処理を呼び出すエントリポイント
  *
-* @version 1.390.576 (PR #260)
+* @version 1.390.580 (PR #268)
 * @since   1.390.536 (PR #245)
-* @lastModified 2025-06-30 12:00:00
+* @lastModified 2025-07-01 00:00:00
  * -----------------------------------------------------------
  * @todo
  * - AuthGate と App モジュールの統合
@@ -18,7 +18,7 @@
  */
 
 /* eslint-env browser */
-import { App } from './core/App.js';
+import { bus } from './core/EventBus.js';
 
 console.log('[startup] bootstrap v2 skeleton');
 
@@ -29,7 +29,15 @@ console.log('[startup] bootstrap v2 skeleton');
  * @returns {Promise<void>} 処理完了を示す Promise
  */
 async function main() {
-  new App('#app-root');
+  const root = document.querySelector('#app-root');
+  const { default: SplashScreen } = await import('./splash/SplashScreen.js');
+  const splash = new SplashScreen(bus);
+  splash.mount(root);
+  bus.on('auth:ok', async () => {
+    splash.destroy();
+    const { App } = await import('./core/App.js');
+    new App('#app-root');
+  });
 }
 
 main();

--- a/styles/splash.scss
+++ b/styles/splash.scss
@@ -1,0 +1,35 @@
+.splash-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: var(--splash-bg);
+  color: var(--splash-logo);
+  opacity: 0;
+  animation: fadeIn 0.6s forwards;
+}
+
+@keyframes fadeIn {
+  to { opacity: 1; }
+}
+
+.keypad {
+  margin-top: 16px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+
+.keypad button {
+  width: 64px;
+  height: 48px;
+}
+
+.keypad button:disabled {
+  background: var(--key-disabled);
+}
+
+.keypad button.enter {
+  background: var(--key-enabled);
+}

--- a/tests/e2e_splash.spec.ts
+++ b/tests/e2e_splash.spec.ts
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon E2E テスト (splash -> dashboard)
+ * @file e2e_splash.spec.ts
+ * -----------------------------------------------------------
+ * @module tests/e2e_splash
+ *
+ * 【機能内容サマリ】
+ * - SplashScreen 表示から Enter 操作で Dashboard が表示されるか検証
+ *
+ * @version 1.390.580 (PR #268)
+ * @since   1.390.580 (PR #268)
+ * @lastModified 2025-07-01 00:00:00
+ */
+
+import { test, expect } from '@playwright/test';
+
+test('splash -> dashboard', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('img', { name: /logo/i })).toBeVisible();
+  await page.getByRole('button', { name: /enter/i }).click();
+  await expect(page.getByRole('navigation')).toBeVisible();
+});

--- a/tests/splash.test.js
+++ b/tests/splash.test.js
@@ -1,0 +1,29 @@
+// @vitest-environment happy-dom
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 SplashScreen 単体テスト
+ * @file splash.test.js
+ * -----------------------------------------------------------
+ * @module tests/splash
+ *
+ * 【機能内容サマリ】
+ * - SplashScreen の Enter ボタンが auth:ok を発火するか検証
+ *
+ * @version 1.390.580 (PR #268)
+ * @since   1.390.580 (PR #268)
+ * @lastModified 2025-07-01 00:00:00
+ */
+
+import { it, expect, vi } from 'vitest';
+import { bus } from '@core/EventBus.js';
+import SplashScreen from '../src/splash/SplashScreen.js';
+
+it('emits auth:ok on Enter', () => {
+  const spy = vi.fn();
+  bus.on('auth:ok', spy);
+  const s = new SplashScreen(bus);
+  s.mount(document.body);
+  document.querySelector('button.enter').click();
+  expect(spy).toHaveBeenCalled();
+  s.destroy();
+});


### PR DESCRIPTION
## Summary
- implement splash screen spec
- add Keypad component
- add stub auth functions
- lazy load App after splash
- add styles
- add tests and docs

## Testing
- `npm test`
- `npx playwright test tests/e2e_splash.spec.ts` *(fails: executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_6861fe526388832fbc50bed149d44bfe