### PR TITLE
Fix splash styles import

### DIFF
--- a/styles/root.scss
+++ b/styles/root.scss
@@ -25,4 +25,5 @@ body {
 @use "bar_title";
 @use "card_camera";
 @use "card_headpreview";
+@use "splash";
 


### PR DESCRIPTION
## Summary
- include `styles/splash.scss` via root stylesheet so splash screen styles load

## Testing
- `npm test`
- `npx playwright test` *(fails: cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_686219eb4ec8832f853ebc240ceae4bf