### PR TITLE
Fix SCSS root import error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto eol=lf
+*.js text
+*.scss text
+*.html text
+*.css text

--- a/vite.config.js
+++ b/vite.config.js
@@ -29,9 +29,12 @@ export default defineConfig({
     preprocessorOptions: {
       scss: {
         additionalData: (content, filename) => {
+          const rel = path
+            .relative(path.dirname(filename), path.resolve(__dirname, 'styles/root.scss'))
+            .replace(/\\/g, '/');
           return filename.endsWith('styles/root.scss')
             ? content
-            : `@use 'styles/root';\n${content}`;
+            : `@use '${rel}';\n${content}`;
         }
       }
     }


### PR DESCRIPTION
## Summary
- add `.editorconfig` and `.gitattributes` to enforce UTF-8 LF line endings
- adjust Vite SCSS `additionalData` to use a relative path to `styles/root.scss`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68623ec35104832fa0f459e72748d6e0