### PR TITLE
feature/v2-step7b-theme-switch

### DIFF
--- a/docs/develop/step7b_theme_switch.md
+++ b/docs/develop/step7b_theme_switch.md
@@ -1,0 +1,176 @@
+### ⑦b ― テーマ切替（ライト／ダーク／「機器と同期」）実装仕様書
+
+> **ファイル名**: `docs/develop/step7b_theme_switch.md` へ追加し、
+> Codex / PR タイトル **`feature/v2-step7b-theme-switch`** で着手
+
+---
+
+## 1. ゴール
+
+1. **ハンバーガーメニュー**（TitleBar 右端）に
+
+   ```
+   ├ Theme ▸
+   │   ├ Light   (default)
+   │   ├ Dark
+   │   └ Match Printer   (model color)
+   └ … (既存メニュー)
+   ```
+2. クリックで **即時テーマ反映**（CSS 変数切替）
+3. **起動時**：
+
+   * `localStorage.theme` があればそれを適用
+   * 無ければ **Light**
+4. “Match Printer” はプリンタごとの `connection.color` を CSS Root に反映（将来拡張可）
+
+---
+
+## 2. ファイル構成追加
+
+```
+src/
+ ├ bars/Bar_Title.js      ← メニュー項目を追加
+ └ core/ThemeManager.js   ★新規
+styles/
+ └ themes.scss            ★新規（変数セット）
+tests/
+ ├ unit/theme.test.js     ★Vitest
+ └ e2e/theme.spec.ts      ★Playwright
+docs/develop/step7b_theme_switch.md
+```
+
+---
+
+## 3. ThemeManager API
+
+```js
+export const THEMES = ['light', 'dark', 'printer'];
+
+/**
+ * 現在テーマを返す
+ * @returns {'light'|'dark'|'printer'}
+ */
+export function getTheme();
+
+/**
+ * テーマを適用し、localStorage へ保存
+ * @param {'light'|'dark'|'printer'} t
+ */
+export function setTheme(t);
+
+/** 起動時に自動適用 (startup.js から呼ぶ) */
+export function initTheme();
+```
+
+* `printer` の場合は `--color-bg` 等を `connection.color` で上書き
+  （暫定：K1 = teal, K1-Max = orange）。
+
+---
+
+## 4. styles/themes.scss
+
+```scss
+:root[data-theme='light'] {
+  --color-bg: #ffffff;
+  --color-text: #1b1b1b;
+  --card-bg: #f2f2f2;
+}
+:root[data-theme='dark'] {
+  --color-bg: #181818;
+  --color-text: #fafafa;
+  --card-bg: #1a1a1a;
+}
+```
+
+`root.scss` で `@use "styles/themes" as *;`
+
+---
+
+## 5. Bar_Title.js – メニュー追加
+
+```js
+const themeSub = [
+  { id:'light',  label:'Light' },
+  { id:'dark',   label:'Dark'  },
+  { id:'printer',label:'Match Printer' }
+];
+
+menu.addSubMenu('Theme', themeSub, (id)=>{
+  ThemeManager.setTheme(id);
+});
+```
+
+* 既存ハンバーガーの dropdown 実装に合わせる
+* `ThemeManager.getTheme()` と照合してチェックマーク表示
+
+---
+
+## 6. 起動フロー変更
+
+```js
+import { initTheme } from './core/ThemeManager.js';
+initTheme();       // ← startup.js の一行目に追加
+```
+
+---
+
+## 7. ストレージ方式の選択
+
+| 方法                    | メリット      | デメリット            |
+| --------------------- | --------- | ---------------- |
+| **localStorage (採用)** | 単純・同期処理   | 同一ブラウザのみ／容量 5 MB |
+| `indexedDB`           | 将来大量設定に強い | async API・実装コスト  |
+| `file` (JSON インポート)   | バックアップ容易  | 手動操作必要           |
+
+\*設定 1 レコード（テーマ名）のみ→ **localStorage で十分**。
+今後プリンタ設定も保存する場合は `indexedDB` に切替できるよう **ThemeManager** 内部で
+
+> `export const store = { get(k), set(k,v) }`
+> のラッパーを用意しておく。
+
+---
+
+## 8. テスト仕様
+
+### 8.1 Vitest unit (`theme.test.js`)
+
+* `setTheme('dark')` → `document.documentElement.dataset.theme === 'dark'`
+* localStorage に書かれる
+* `initTheme()` が保存値を適用
+
+### 8.2 Playwright e2e (`theme.spec.ts`)
+
+1. 起動 → メニュー → **Dark** を選択
+2. `body` の背景色が `rgb(24, 24, 24)` になる
+3. Reload → Dark が保持される
+
+---
+
+## 9. CI 追加
+
+`tests/unit/theme.test.js` は既存 Vitest ジョブで実行される。
+Playwright ジョブに `theme.spec.ts` を追加するだけ。
+
+---
+
+## 10. 受け入れ基準 ✅
+
+* ハンバーガー → Theme → 3 つ表示
+* 選択即反映・リロード後も保持
+* Vitest / Playwright グリーン
+* Docs 追記完了（spec 反映）
+
+---
+
+### Codex 依頼例
+
+```
+Add theme switching (light/dark/printer) as per docs/develop/step7b_theme_switch.md:
+- implement core/ThemeManager.js
+- add styles/themes.scss + token overrides
+- extend Bar_Title.js dropdown
+- call initTheme in startup.js
+- unit & e2e tests
+```
+
+---

--- a/src/cards/Bar_Title.js
+++ b/src/cards/Bar_Title.js
@@ -22,6 +22,7 @@
  */
 
 import BaseBar from './BaseBar.js';
+import { setTheme, getTheme, THEMES } from '../core/ThemeManager.js';
 
 /**
  * タイトルバーを表すクラス。
@@ -55,11 +56,30 @@ export default class TitleBar extends BaseBar {
     const menu = document.createElement('button');
     menu.className = 'hamburger';
     menu.textContent = '≡';
-    // グローバルメニュー呼び出しまでの暫定実装
+    const list = document.createElement('ul');
+    list.className = 'theme-menu';
+    THEMES.forEach((id) => {
+      const li = document.createElement('li');
+      const btn = document.createElement('button');
+      btn.dataset.id = id;
+      btn.textContent = `${id.charAt(0).toUpperCase()}${id.slice(1)}`;
+      li.appendChild(btn);
+      list.appendChild(li);
+    });
     menu.addEventListener('click', () => {
-      this.bus.emit('menu:global');
+      list.classList.toggle('show');
+    });
+    list.addEventListener('click', (e) => {
+      const t = e.target;
+      if (t instanceof HTMLElement && t.dataset.id) {
+        setTheme(t.dataset.id);
+        this.#updateThemeMenu(list);
+        list.classList.remove('show');
+      }
     });
     this.el.appendChild(menu);
+    this.el.appendChild(list);
+    this.#updateThemeMenu(list);
 
     this.nav = document.createElement('nav');
     this.nav.className = 'tabs';
@@ -179,6 +199,21 @@ export default class TitleBar extends BaseBar {
       btn.classList.toggle('active', btn.dataset.id === this.activeId);
       btn.setAttribute('aria-selected', btn.dataset.id === this.activeId ? 'true' : 'false');
       btn.setAttribute('tabindex', btn.dataset.id === this.activeId ? '0' : '-1');
+    });
+  }
+
+  /**
+   * テーマメニューのチェックマークを更新する。
+   *
+   * @private
+   * @param {HTMLUListElement} list - テーマメニュー要素
+   * @returns {void}
+   */
+  #updateThemeMenu(list) {
+    const currentId = getTheme();
+    list.querySelectorAll('button').forEach((btn) => {
+      btn.textContent = `${btn.dataset.id.charAt(0).toUpperCase()}${btn.dataset.id.slice(1)}` +
+        (btn.dataset.id === currentId ? ' ✓' : '');
     });
   }
 }

--- a/src/core/ThemeManager.js
+++ b/src/core/ThemeManager.js
@@ -1,0 +1,99 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 テーマ管理モジュール
+ * @file ThemeManager.js
+ * -----------------------------------------------------------
+ * @module core/ThemeManager
+ *
+ * 【機能内容サマリ】
+ * - Light/Dark/Printer のテーマ切替を管理
+ * - localStorage へ保存し起動時に復元
+ *
+ * 【公開関数一覧】
+ * - {@link initTheme}：保存値の自動適用
+ * - {@link setTheme}：テーマを適用し保存
+ * - {@link getTheme}：現在のテーマ取得
+ * - {@link store}：内部ストレージラッパー
+ *
+ * @version 1.390.597 (PR #276)
+ * @since   1.390.597 (PR #276)
+ * @lastModified 2025-07-01 12:00:00
+ * -----------------------------------------------------------
+ * @todo
+ * - プリンタごとの詳細カラー反映
+ */
+
+/* eslint-env browser */
+
+/**
+ * 使用可能なテーマ一覧。
+ * @constant {Array<'light'|'dark'|'printer'>}
+ */
+export const THEMES = ['light', 'dark', 'printer'];
+
+/**
+ * ストレージアクセス用ラッパー。
+ * 将来的に indexedDB 等へ差し替え可能とする。
+ *
+ * @constant {Object}
+ * @property {(k:string)=>string|null} get - 取得関数
+ * @property {(k:string,v:string)=>void} set - 保存関数
+ */
+export const store = {
+  get(k) {
+    return window.localStorage.getItem(k);
+  },
+  set(k, v) {
+    window.localStorage.setItem(k, v);
+  }
+};
+
+/**
+ * 現在適用されているテーマ名。
+ * @private
+ * @type {'light'|'dark'|'printer'}
+ */
+let current = 'light';
+
+/**
+ * 現在のテーマを取得する。
+ *
+ * @function getTheme
+ * @returns {'light'|'dark'|'printer'} テーマ名
+ */
+export function getTheme() {
+  return current;
+}
+
+/**
+ * 指定テーマを適用し保存する。
+ *
+ * @function setTheme
+ * @param {'light'|'dark'|'printer'} t - 適用するテーマ
+ * @returns {void}
+ */
+export function setTheme(t) {
+  if (!THEMES.includes(t)) return;
+  current = t;
+  document.documentElement.dataset.theme = t;
+  store.set('theme', t);
+
+  if (t === 'printer') {
+    const conn = window.connection ?? { model: 'K1' };
+    const color = conn.model === 'K1-Max' ? 'orange' : 'teal';
+    document.documentElement.style.setProperty('--color-bg', color);
+  } else {
+    document.documentElement.style.removeProperty('--color-bg');
+  }
+}
+
+/**
+ * 起動時に保存されたテーマを適用する。
+ *
+ * @function initTheme
+ * @returns {void}
+ */
+export function initTheme() {
+  const saved = store.get('theme');
+  setTheme(saved && THEMES.includes(saved) ? saved : 'light');
+}

--- a/src/startup.js
+++ b/src/startup.js
@@ -20,6 +20,7 @@
 /* eslint-env browser */
 // SCSS トークンおよび各カードのスタイルを取り込む
 import '../styles/root.scss';
+import { initTheme } from './core/ThemeManager.js';
 import { bus } from './core/EventBus.js';
 
 console.log('[startup] bootstrap v2 skeleton');
@@ -31,6 +32,7 @@ console.log('[startup] bootstrap v2 skeleton');
  * @returns {Promise<void>} 処理完了を示す Promise
  */
 async function main() {
+  initTheme();
   const root = document.querySelector('#app-root');
   const { default: SplashScreen } = await import('./splash/SplashScreen.js');
   const splash = new SplashScreen(bus);

--- a/styles/bar_title.scss
+++ b/styles/bar_title.scss
@@ -32,3 +32,28 @@
 .title-bar .tab.active {
   outline: 2px solid white;
 }
+
+.theme-menu {
+  position: absolute;
+  top: 40px;
+  right: 8px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  display: none;
+}
+
+.theme-menu.show {
+  display: block;
+}
+
+.theme-menu button {
+  background: none;
+  border: none;
+  color: var(--color-text);
+  padding: 4px 8px;
+  width: 100%;
+  text-align: left;
+}

--- a/styles/root.scss
+++ b/styles/root.scss
@@ -1,13 +1,14 @@
 /* 基本トークンのみ (追加は後工程) */
+@use "themes" as *;
 @use "bar_title";
 @use "card_camera";
 @use "card_headpreview";
 @use "splash";
 
 :root {
-  --color-bg: #0e0e0e;
-  --color-text: #fafafa;
-  --card-bg: #1a1a1a;
+  --color-bg: #ffffff;
+  --color-text: #1b1b1b;
+  --card-bg: #f2f2f2;
   --card-border: #c0c0c0;
   --border-radius: 8px;
 }

--- a/styles/themes.scss
+++ b/styles/themes.scss
@@ -1,0 +1,10 @@
+:root[data-theme='light'] {
+  --color-bg: #ffffff;
+  --color-text: #1b1b1b;
+  --card-bg: #f2f2f2;
+}
+:root[data-theme='dark'] {
+  --color-bg: #181818;
+  --color-text: #fafafa;
+  --card-bg: #1a1a1a;
+}

--- a/tests/e2e/theme.spec.ts
+++ b/tests/e2e/theme.spec.ts
@@ -1,0 +1,27 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon E2E テスト (theme switch)
+ * @file theme.spec.ts
+ * -----------------------------------------------------------
+ * @module tests/e2e_theme
+ *
+ * 【機能内容サマリ】
+ * - ハンバーガーメニューからテーマ変更が反映されるか検証
+ *
+ * @version 1.390.597 (PR #276)
+ * @since   1.390.597 (PR #276)
+ * @lastModified 2025-07-01 12:00:00
+ */
+
+import { test, expect } from '@playwright/test';
+
+test('switch to dark theme', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: '≡' }).click();
+  await page.getByRole('button', { name: 'Dark' }).click();
+  const bg = await page.evaluate(() => getComputedStyle(document.body).backgroundColor);
+  expect(bg).toBe('rgb(24, 24, 24)');
+  await page.reload();
+  const bg2 = await page.evaluate(() => getComputedStyle(document.body).backgroundColor);
+  expect(bg2).toBe('rgb(24, 24, 24)');
+});

--- a/tests/unit/theme.test.js
+++ b/tests/unit/theme.test.js
@@ -1,0 +1,38 @@
+// @vitest-environment happy-dom
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 ThemeManager 単体テスト
+ * @file theme.test.js
+ * -----------------------------------------------------------
+ * @module tests/theme
+ *
+ * 【機能内容サマリ】
+ * - テーマ適用と保存機能を検証
+ *
+ * @version 1.390.597 (PR #276)
+ * @since   1.390.597 (PR #276)
+ * @lastModified 2025-07-01 12:00:00
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { setTheme, getTheme, initTheme, store } from '@core/ThemeManager.js';
+
+describe('ThemeManager', () => {
+  beforeEach(() => {
+    document.documentElement.dataset.theme = '';
+    window.localStorage.clear();
+  });
+
+  it('setTheme updates dataset and storage', () => {
+    setTheme('dark');
+    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(store.get('theme')).toBe('dark');
+  });
+
+  it('initTheme restores saved value', () => {
+    store.set('theme', 'dark');
+    initTheme();
+    expect(getTheme()).toBe('dark');
+    expect(document.documentElement.dataset.theme).toBe('dark');
+  });
+});


### PR DESCRIPTION
## Summary
- implement ThemeManager with light/dark/printer themes
- provide theme variables in `styles/themes.scss`
- add dropdown theme menu in TitleBar
- apply stored theme on startup
- add unit and e2e tests
- document implementation in `step7b_theme_switch.md`

## Testing
- `npm test`
- `npx playwright test tests/e2e/theme.spec.ts` *(fails: Cannot find package '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_68631422f784832f859d8f87f580c938