### PR TITLE
Fix Vite cache permissions and Sass alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ Unit tests are executed with [Vitest](https://vitest.dev/).
 
 See [docs/develop/tests.md](docs/develop/tests.md) for coverage goals and additional details.
 
+### Troubleshooting
+If `npm run dev` fails with `EACCES: permission denied, rename` on Dropbox or
+other network drives, run `scripts/clear-vite.sh` to reset Vite's cache.
+
+
 ## Keyboard Shortcuts
 HeadPreviewCard supports the following keys:
 - **Space**: reset zoom to 1.0

--- a/docs/develop/debug_blank_screen.md
+++ b/docs/develop/debug_blank_screen.md
@@ -14,10 +14,12 @@ This document helps verify the front-end rendering pipeline when the browser onl
 
 1. **Startup pipeline**
    - After `npm run dev`, check the terminal output:
-     ```
-     VITE vX.Y.Z  ready in N ms
-     ➜  Local: http://localhost:5173/
-     ```
+    ```
+    VITE vX.Y.Z  ready in N ms
+    ➜  Local: http://localhost:5173/
+    ```
+    If an `EACCES: permission denied, rename` error occurs, run
+    `scripts/clear-vite.sh` to reset the cache on Dropbox or network drives.
 2. **`startup.js` invocation**
    ```js
    // src/startup.js

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "3dpmon multi-printer dashboard (v2 skeleton)",
   "type": "module",
   "scripts": {
+    "predev": "bash scripts/clear-vite.sh",
     "dev": "vite --force",
     "mock": "node src/core/mock-printer.ws.js",
     "build": "vite build",
@@ -11,7 +12,8 @@
     "test": "vitest run",
     "test:ui": "vitest --ui",
     "bench:head": "node bench/headpreview.bench.js",
-    "bench:temp": "node bench/tempgraph.bench.js"
+    "bench:temp": "node bench/tempgraph.bench.js",
+    "clean": "rimraf node_modules/.vite"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/clear-vite.sh
+++ b/scripts/clear-vite.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+rm -rf node_modules/.vite
+mkdir -p node_modules/.vite
+chmod -R u+rwX node_modules/.vite

--- a/styles/_tokens.scss
+++ b/styles/_tokens.scss
@@ -1,0 +1,7 @@
+:root {
+  --color-bg: #ffffff;
+  --color-text: #1b1b1b;
+  --card-bg: #f2f2f2;
+  --card-border: #c0c0c0;
+  --border-radius: 8px;
+}

--- a/styles/bar_title.scss
+++ b/styles/bar_title.scss
@@ -57,3 +57,7 @@
   width: 100%;
   text-align: left;
 }
+
+.theme-menu li:last-child button {
+  padding: 12px 8px;
+}

--- a/styles/conn_manager.scss
+++ b/styles/conn_manager.scss
@@ -1,4 +1,4 @@
-@use 'styles/root' as *;
+@use 'styles/_tokens' as *;
 
 dialog.conn-manager {
   width: 420px;

--- a/styles/root.scss
+++ b/styles/root.scss
@@ -1,18 +1,11 @@
 /* 基本トークンのみ (追加は後工程) */
+@use "_tokens" as *;
 @use "themes" as *;
 @use "bar_title";
 @use "card_camera";
 @use "card_headpreview";
 @use "splash";
 @use "conn_manager";
-
-:root {
-  --color-bg: #ffffff;
-  --color-text: #1b1b1b;
-  --card-bg: #f2f2f2;
-  --card-border: #c0c0c0;
-  --border-radius: 8px;
-}
 
 
 /* デフォルトで簡易リセット */

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,9 +9,9 @@
  * 【機能内容サマリ】
  * - Vite の基本ビルド設定を提供する
  *
- * @version 1.390.534 (PR #244)
- * @since   1.390.534 (PR #244)
- * @lastModified 2025-06-30 19:07:40
+ * @version 1.390.613 (PR #284)
+ * @since   1.390.613 (PR #284)
+ * @lastModified 2025-07-02 09:00:00
  */
 
 import { defineConfig } from 'vite';
@@ -31,15 +31,15 @@ export default defineConfig({
       scss: {
         /**
          * 自動で tokens を差し込む
-         * ただし styles/root.scss 自身には挿入しない (無限ループ回避)
+         * ただし styles/_tokens.scss 自身には挿入しない (無限ループ回避)
          */
         additionalData(source, filename) {
           // Windows パスは \ 区切りになるので path.normalize で統一
           const normalized = path.normalize(filename);
-          if (normalized.endsWith(path.normalize('styles/root.scss'))) {
+          if (normalized.endsWith(path.normalize('styles/_tokens.scss'))) {
             return source; // そのまま返す
           }
-          return `@use 'styles/root' as *;\n${source}`;
+          return `@use 'styles/_tokens' as *;\n${source}`;
         },
       },
     },
@@ -49,7 +49,8 @@ export default defineConfig({
       '@core': path.resolve(__dirname, 'src/core'),
       '@cards': path.resolve(__dirname, 'src/cards'),
       '@shared': path.resolve(__dirname, 'src/shared'),
-      '@dialogs': path.resolve(__dirname, 'src/dialogs')
+      '@dialogs': path.resolve(__dirname, 'src/dialogs'),
+      styles: path.resolve(__dirname, 'styles')
     }
   },
   server: {


### PR DESCRIPTION
## Summary
- add predev hook to clear Vite cache
- define `styles` alias in vite config
- switch SCSS imports to `_tokens`
- enlarge Connections menu tap target
- document Dropbox permission troubleshooting
- update debug guide with cache clearing note

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68637713eb8c832fb8bae052156c8eeb