### PR TITLE
Update Node requirement to 20

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,7 +14,7 @@ jobs:
       - run: while sleep 300; do echo "keep-alive"; done &
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - run: npm ci
       - name: bench headpreview
         run: |
@@ -32,7 +32,7 @@ jobs:
       - run: while sleep 300; do echo "keep-alive"; done &
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - run: npm ci
       - name: bench tempgraph
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - run: while sleep 300; do echo "keep-alive"; done &
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - run: npm ci
       - name: run unit tests
         run: |
@@ -25,7 +25,7 @@ jobs:
       - run: while sleep 300; do echo "keep-alive"; done &
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - run: npm ci
       - name: run tempbuffer tests
         run: |
@@ -41,7 +41,7 @@ jobs:
       - run: while sleep 300; do echo "keep-alive"; done &
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - run: npm ci
       - name: run sidemenu tests
         run: |

--- a/docs/develop/future.md
+++ b/docs/develop/future.md
@@ -32,7 +32,7 @@
 | **/docs**       | 仕様書類          | README, future.md, ADR, Mermaid 図                                   |
 
 > **ビルドツール候補** : **Vite**（ESM, HMR, Code-Splitting, SCSS ネイティブ）
-> Node 18+、package.json に "type":"module" を宣言。
+> Node 20+、package.json に "type":"module" を宣言。
 
 ---
 

--- a/docs/develop/step1_vite_skeleton.md
+++ b/docs/develop/step1_vite_skeleton.md
@@ -11,7 +11,7 @@
 | Vite 開発サーバーが `/src/startup.js` をエントリに **空白画面**（`#app-root` のみ）を表示する | |
 | すべてのディレクトリ／基本ファイルが **Git 管理** 下に生成される | |
 | `npm run dev` / `npm run build` がエラーなく完走する | |
-| Node 18+ 環境でクロスプラットフォーム（Win/Mac/Linux）動作を確認 | |
+| Node 20+ 環境でクロスプラットフォーム（Win/Mac/Linux）動作を確認 | |
 
 ---
 

--- a/docs/develop/step2_connection_manager.md
+++ b/docs/develop/step2_connection_manager.md
@@ -106,8 +106,8 @@
        runs-on: ubuntu-latest
        steps:
          - uses: actions/checkout@v4
-         - uses: actions/setup-node@v4
-           with: { node-version: 18 }
+        - uses: actions/setup-node@v4
+           with: { node-version: 20 }
          - run: npm ci
          - run: npm test
    ```

--- a/docs/develop/step7_e2e_release_plan.md
+++ b/docs/develop/step7_e2e_release_plan.md
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: 18 }
+        with: { node-version: 20 }
       - run: npm ci
       - run: npx playwright install --with-deps
       - run: npm run build

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean": "rimraf node_modules/.vite"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "devDependencies": {
     "@vitest/ui": "^1.6.0",


### PR DESCRIPTION
## Summary
- set Node.js 20 in bench and CI workflows
- require Node 20+ in package.json
- update docs to reference Node 20

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864d3e3edcc832fbe2c4aa4354b1c17