### PR TITLE
Implement LayoutStore and unsubscribe fix

### DIFF
--- a/docs/develop/stepP0_card_refactor.md
+++ b/docs/develop/stepP0_card_refactor.md
@@ -29,3 +29,7 @@ rev 1.0 2025-07-xx 初版（ChatGPT 出力）
 - Vitest を用い、各カードの DOM 更新を検証。
 - Playwright によりダッシュボードを起動し、Bus へイベント送信して UI が更新されるか確認。
 
+### P0-R1 追加修正
+- `Card_TempGraph.destroy()` が `bus.off('printer:id:temps')` を呼ぶよう修正。
+- リスナー解除をテストで確認。
+

--- a/docs/develop/stepP1_layout_engine.md
+++ b/docs/develop/stepP1_layout_engine.md
@@ -1,0 +1,31 @@
+# P-1 — LayoutStore + CardContainer 実装
+
+rev 1.0 2025-07-03 初版（ChatGPT 出力）
+
+## ゴール
+- カード配置とプリンタIDを含むレイアウトを JSON 保存 / 復元する
+- SideBar から新規作成・保存・切替が可能
+- CSS Grid + Sortable.js を用いたドラッグ/リサイズ対応
+
+## 追加ファイル
+- `src/core/LayoutStore.js`
+- `src/core/CardContainer.js`
+- `src/dialogs/LayoutModal.js`
+- `styles/card_container.scss`
+- `tests/unit/layout_store.test.js`
+- `tests/unit/card_container.test.js`
+- `tests/e2e/layout_switch.spec.ts`
+
+## データスキーマ
+- `CardInst`：カードID、種別、deviceId、位置サイズ等
+- `Layout`：レイアウトID、名前、更新時刻、カード配列
+- 保存先は `localStorage.layouts`
+
+## LayoutStore API
+- `getAll()` / `get(id)` / `save(layout)` / `delete(id)`
+- `generateId()` は nanoid を使用
+
+## テスト設計
+- unit: 保存で件数増、削除で減
+- card_container: 読み込みで子数一致、ドラッグ終了で layout:update 発火
+- e2e: レイアウト切り替えでカード表示が変化

--- a/src/core/EventBus.js
+++ b/src/core/EventBus.js
@@ -12,9 +12,9 @@
  * 【公開定数一覧】
  * - {@link bus}：シングルトンのイベントバス
  *
-* @version 1.390.536 (PR #245)
-* @since   1.390.536 (PR #245)
-* @lastModified 2025-06-28 19:30:39
+ * @version 1.390.635 (PR #295)
+ * @since   1.390.536 (PR #245)
+ * @lastModified 2025-07-03 00:00:00
  * -----------------------------------------------------------
  * @todo
  * - なし
@@ -62,6 +62,15 @@ export const bus = (() => {
      */
     emit(evt, data) {
       (map.get(evt) ?? []).forEach(f => f(data));
+    },
+    /**
+     * 登録されているリスナー数を取得する。
+     *
+     * @param {string} evt - イベント名
+     * @returns {number} - 登録数
+     */
+    count(evt) {
+      return (map.get(evt) ?? []).length;
     }
   };
 })();

--- a/src/core/LayoutStore.js
+++ b/src/core/LayoutStore.js
@@ -1,0 +1,88 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 レイアウト保存管理モジュール
+ * @file LayoutStore.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * -----------------------------------------------------------
+ * @module core/LayoutStore
+ *
+ * 【機能内容サマリ】
+ * - ユーザが作成したレイアウト情報を localStorage へ保存・取得する
+ *
+ * 【公開クラス一覧】
+ * - {@link LayoutStore}：レイアウト永続化クラス
+ *
+ * @version 1.390.635 (PR #295)
+ * @since   1.390.635 (PR #295)
+ * @lastModified 2025-07-03 00:00:00
+ * -----------------------------------------------------------
+ * @todo
+ * - なし
+ */
+
+import { nanoid } from 'nanoid';
+
+/**
+ * レイアウト永続化を担当するストアクラス。
+ * @class
+ */
+export class LayoutStore {
+  /** @private */
+  #key = 'layouts';
+
+  /**
+   * すべてのレイアウトを取得する。
+   * @returns {import('../types').Layout[]} Layout 配列
+   */
+  getAll() {
+    const raw = localStorage.getItem(this.#key);
+    if (!raw) return [];
+    try {
+      return JSON.parse(raw) || [];
+    } catch (e) {
+      console.error('LayoutStore#getAll parse error', e);
+      return [];
+    }
+  }
+
+  /**
+   * 指定 ID のレイアウトを取得する。
+   * @param {string} id - レイアウト ID
+   * @returns {import('../types').Layout|undefined} レイアウトオブジェクト
+   */
+  get(id) {
+    return this.getAll().find(l => l.id === id);
+  }
+
+  /**
+   * レイアウトを保存（存在すれば更新）。
+   * @param {import('../types').Layout} layout - 保存対象レイアウト
+   * @returns {void}
+   */
+  save(layout) {
+    const list = this.getAll();
+    const idx = list.findIndex(l => l.id === layout.id);
+    if (idx >= 0) list[idx] = layout; else list.push(layout);
+    localStorage.setItem(this.#key, JSON.stringify(list));
+  }
+
+  /**
+   * 指定 ID のレイアウトを削除する。
+   * @param {string} id - レイアウト ID
+   * @returns {void}
+   */
+  delete(id) {
+    const list = this.getAll().filter(l => l.id !== id);
+    localStorage.setItem(this.#key, JSON.stringify(list));
+  }
+
+  /**
+   * 一意な ID を生成する。
+   * @returns {string} 新しい ID
+   */
+  generateId() {
+    return nanoid();
+  }
+}
+
+export default LayoutStore;

--- a/tests/tempgraph.test.js
+++ b/tests/tempgraph.test.js
@@ -23,4 +23,12 @@ describe('Card_TempGraph', () => {
     card.destroy();
     spy.mockRestore();
   });
+
+  it('unsubscribes on destroy', () => {
+    const card = new Card_TempGraph({ deviceId: 'p1', bus });
+    card.connected();
+    const before = bus.count('printer:p1:temps');
+    card.destroy();
+    expect(bus.count('printer:p1:temps')).toBe(before - 1);
+  });
 });

--- a/tests/unit/layout_store.test.js
+++ b/tests/unit/layout_store.test.js
@@ -1,0 +1,35 @@
+// @vitest-environment happy-dom
+/**
+ * @fileoverview
+ * @description LayoutStore unit tests
+ * @file layout_store.test.js
+ * -----------------------------------------------------------
+ * @module tests/layout_store
+ *
+ * 【機能内容サマリ】
+ * - LayoutStore の保存・削除処理を検証
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import LayoutStore from '@core/LayoutStore.js';
+
+const store = new LayoutStore();
+
+describe('LayoutStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('save adds new layout', () => {
+    const layout = { id: '1', name: 'a', updated: 0, grid: [] };
+    store.save(layout);
+    expect(store.getAll().length).toBe(1);
+  });
+
+  it('delete removes layout', () => {
+    const layout = { id: '1', name: 'a', updated: 0, grid: [] };
+    store.save(layout);
+    store.delete('1');
+    expect(store.getAll().length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- document unsubscribe fix for Card_TempGraph
- add listener count helper to EventBus
- verify unsubscribe via new unit test
- implement LayoutStore for layout persistence
- add unit tests and docs for layout engine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686518286b5c832fac4493c1c605327f