### PR TITLE
Fix LayoutStore unique ID generation

### DIFF
--- a/docs/develop/stepP1_layout_engine.md
+++ b/docs/develop/stepP1_layout_engine.md
@@ -23,7 +23,7 @@ rev 1.0 2025-07-03 初版（ChatGPT 出力）
 
 ## LayoutStore API
 - `getAll()` / `get(id)` / `save(layout)` / `delete(id)`
-- `generateId()` は nanoid を使用
+- `generateId()` は nanoid/non-secure を使用
 
 ## テスト設計
 - unit: 保存で件数増、削除で減

--- a/src/core/LayoutStore.js
+++ b/src/core/LayoutStore.js
@@ -12,15 +12,15 @@
  * 【公開クラス一覧】
  * - {@link LayoutStore}：レイアウト永続化クラス
  *
- * @version 1.390.635 (PR #295)
+ * @version 1.390.637 (PR #296)
  * @since   1.390.635 (PR #295)
- * @lastModified 2025-07-03 00:00:00
+ * @lastModified 2025-07-02 21:44:27
  * -----------------------------------------------------------
  * @todo
  * - なし
  */
 
-import { nanoid } from 'nanoid';
+import { nanoid } from 'nanoid/non-secure';
 
 /**
  * レイアウト永続化を担当するストアクラス。

--- a/tests/unit/layout_store.test.js
+++ b/tests/unit/layout_store.test.js
@@ -32,4 +32,12 @@ describe('LayoutStore', () => {
     store.delete('1');
     expect(store.getAll().length).toBe(0);
   });
+
+  it('generateId returns unique ids', () => {
+    const ids = new Set();
+    for (let i = 0; i < 5; i++) {
+      ids.add(store.generateId());
+    }
+    expect(ids.size).toBe(5);
+  });
 });


### PR DESCRIPTION
## Summary
- update LayoutStore to use `nanoid/non-secure`
- bump version headers
- test that generated IDs are unique
- document updated nanoid usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68652856c2cc832fb532df27e735f141