### PR TITLE
Fix timer restart after print completion

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -17,9 +17,9 @@
  * - {@link persistPrintResume}：印刷再開用データを保存
  * - {@link initializeAutoSave}：自動保存タイマーを開始
  *
-* @version 1.390.524 (PR #240)
+* @version 1.390.651 (PR #302)
 * @since   1.390.193 (PR #86)
-* @lastModified 2025-06-28 16:40:44
+* @lastModified 2025-07-04 09:50:37
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -76,7 +76,11 @@ import {
   copyStoredDataToClipboard
 } from "./dashboard_utils.js";
 import { notificationManager } from "./dashboard_notification_manager.js";
-import { persistAggregatorState,stopAggregatorTimer } from "./dashboard_aggregator.js";
+import {
+  persistAggregatorState,
+  stopAggregatorTimer,
+  aggregatorUpdate
+} from "./dashboard_aggregator.js";
 import { showAlert } from "./dashboard_notification_manager.js";
 import {
   initSendRawJson,
@@ -455,10 +459,18 @@ const AUTO_SAVE_INTERVAL_MS = 3 * 60 * 1000; // 3分
  *   - 印刷再開用データを localStorage に保存
  *   - 統一ストレージ（dashboard_storage）を保存
  *   - aggregator の内部状態を localStorage に保存
+ *   - 保存前に {@link aggregatorUpdate} を実行しタイマー値を確定
  *
  * @returns {void}
  */
 function autoSaveAll() {
+  try {
+    // 現在のタイマー値を確定させてから保存処理を実行
+    aggregatorUpdate();
+  } catch (e) {
+    console.warn("autoSaveAll: aggregatorUpdate 実行中にエラーが発生しました", e);
+  }
+
   try {
     persistPrintResume();
     saveUnifiedStorage();

--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -20,9 +20,9 @@
  * - {@link restartAggregatorTimer}：集約ループ再開
  * - {@link stopAggregatorTimer}：集約ループ停止
  *
-* @version 1.390.620 (PR #287)
+* @version 1.390.651 (PR #302)
 * @since   1.390.193 (PR #86)
-* @lastModified 2025-07-02 15:14:20
+* @lastModified 2025-07-04 09:50:37
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -890,12 +890,21 @@ export function restartAggregatorTimer() {
 /**
  * stopAggregatorTimer:
  *   - 集約ループを停止
+ *   - 停止直前に {@link aggregatorUpdate} を実行し最終状態を保存
  */
 export function stopAggregatorTimer() {
   if (aggregatorTimer !== null) {
     clearInterval(aggregatorTimer);
     aggregatorTimer = null;
     console.debug("aggregatorUpdate タイマー停止");
+
+    try {
+      aggregatorUpdate();
+    } catch (e) {
+      console.error("aggregatorUpdate エラー:", e);
+    }
+
+    persistAggregatorState();
   }
 }
 

--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -25,9 +25,9 @@
  * - {@link updateConnectionUI}：UI 状態更新
  * - {@link simulateReceivedJson}：受信データシミュレート
  *
-* @version 1.390.516 (PR #236)
+* @version 1.390.651 (PR #302)
 * @since   1.390.451 (PR #205)
-* @lastModified 2025-06-28 14:54:54
+* @lastModified 2025-07-04 09:50:37
  * -----------------------------------------------------------
  * @todo
  * - none


### PR DESCRIPTION
## Summary
- ensure aggregator timers finalize on disconnection
- call `aggregatorUpdate` during autosave
- update headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686724985cc8832f8c01fe40b39a69b9