### PR TITLE
Implement WS heartbeat and camera fixes

### DIFF
--- a/docs/develop/stepP7_camera_stream.md
+++ b/docs/develop/stepP7_camera_stream.md
@@ -1,0 +1,45 @@
+# Step P7 Camera Stream Integration
+
+カメラプレビューを MJPEG/スナップショット方式へ拡張する。
+
+## 対応ストリームと判定順
+
+| 優先 | 種別 | URL 例 | 判定方法 |
+| --- | --- | --- | --- |
+| ① | HTTP MJPEG | `http://<ip>:<port>/?action=stream` | `fetch(HEAD)` 2 s 以内に 200 OK |
+| ② | Snapshot Poll | `http://<ip>:<port>/?action=snapshot` | ① が 404 か 406 の場合 |
+| ✕ | フォールバック停止 | – | サービス拒否時は警告表示 |
+
+## StreamSelector.pick
+
+```ts
+const port = connection.camPort ?? 8080;
+const base = `http://${connection.ip}:${port}`;
+try {
+  const r = await fetch(`${base}/?action=stream`, { method:'HEAD', signal, cache:'no-store', mode:'no-cors' });
+  if (r.ok) return { mode:'mjpeg', url:`${base}/?action=stream` };
+} catch (err) {
+  if (err.message.includes('ERR_CONNECTION_REFUSED')) {
+    bus.emit('log:add', `[CAM] Service down on ${connection.ip}:${port}`);
+    return { mode:'down' };
+  }
+}
+try {
+  const r = await fetch(`${base}/?action=snapshot`, { method:'HEAD', signal, cache:'no-store', mode:'no-cors' });
+  if (r.ok) return { mode:'snapshot', url:`${base}/?action=snapshot` };
+} catch {}
+return { mode:'unsupported' };
+```
+
+## CameraCard 表示
+
+| 状態 | 表示 |
+| --- | --- |
+| mode:'down' | バナー「Camera service offline」 |
+| mode:'unsupported' | アイコン＋“No stream” |
+
+## 失敗時ロジック
+
+- サービス停止は再試行しない。バナーは5秒表示後にカードを最小化。
+- 404/406 はスナップショットへフォールバック。ネットワークエラーは10秒後に再試行。
+

--- a/src/cards/Card_Camera.js
+++ b/src/cards/Card_Camera.js
@@ -11,7 +11,7 @@
  * 【公開クラス一覧】
  * - {@link CameraCard}：カメラプレビューカード
  *
-* @version 1.390.649 (PR #301)
+* @version 1.390.657 (PR #304)
 * @since   1.390.557 (PR #255)
 * @lastModified 2025-07-03 15:00:00
  * -----------------------------------------------------------
@@ -164,7 +164,8 @@ export default class CameraCard extends BaseCard {
   update({ streamUrl }) {
     if (streamUrl && this.video) {
       this.streamUrl = streamUrl;
-      this.video.src = streamUrl;
+      const url = streamUrl + (streamUrl.includes('?') ? '&t=' : '?t=') + Date.now();
+      this.video.src = url;
       this._retryCount = 0;
     }
   }

--- a/src/core/WSClient.js
+++ b/src/core/WSClient.js
@@ -1,0 +1,205 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 WebSocket クライアントモジュール
+ * @file WSClient.js
+ * -----------------------------------------------------------
+ * @module core/WSClient
+ *
+ * 【機能内容サマリ】
+ * - WebSocket 接続とハートビート管理を担当
+ * - 接続ロスト検知および再接続をサポート
+ *
+ * 【公開クラス一覧】
+ * - {@link WSClient}：WebSocket クライアント
+ *
+* @version 1.390.657 (PR #304)
+* @since   1.390.657 (PR #304)
+ * @lastModified 2025-07-04 12:00:00
+ * -----------------------------------------------------------
+ * @todo
+ * - なし
+ */
+
+import { bus } from './EventBus.js';
+
+/**
+ * WebSocket クライアント。接続管理とハートビート送受信を行う。
+ */
+export default class WSClient extends EventTarget {
+  /**
+   * @param {string} url - 接続先 URL
+   * @param {string} id  - 識別子
+   */
+  constructor(url, id) {
+    super();
+    /** @type {string} */
+    this.url = url;
+    /** @type {string} */
+    this.id = id;
+    /** @type {WebSocket|null} */
+    this.socket = null;
+    /** @type {number} */
+    this.retry = 0;
+    /** @type {number|null} */
+    this._hbTimer = null;
+    /** @type {number|null} */
+    this._monTimer = null;
+    /** @type {number} */
+    this.lastHb = Date.now();
+    this._onOpen = this.#handleOpen.bind(this);
+    this._onMsg = this.#handleMessage.bind(this);
+    this._onErr = this.#handleError.bind(this);
+    this._onClose = this.#handleClose.bind(this);
+  }
+
+  /**
+   * WebSocket 接続を開始する。
+   *
+   * @returns {void}
+   */
+  connect() {
+    this.socket = new WebSocket(this.url);
+    this.socket.addEventListener('open', this._onOpen);
+    this.socket.addEventListener('message', this._onMsg);
+    this.socket.addEventListener('error', this._onErr);
+    this.socket.addEventListener('close', this._onClose);
+  }
+
+  /**
+   * JSON データを送信する。
+   *
+   * @param {Object} obj - 送信オブジェクト
+   * @returns {void}
+   */
+  send(obj) {
+    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+      this.socket.send(typeof obj === 'string' ? obj : JSON.stringify(obj));
+    }
+  }
+
+  /**
+   * ハートビート送信を開始する。
+   *
+   * @function
+   * @returns {void}
+   */
+  startHeartbeat() {
+    this.stopHeartbeat();
+    this.lastHb = Date.now();
+    this._hbTimer = setInterval(() => {
+      this.send({ ModeCode: 'heart_beat', msg: new Date().toISOString() });
+    }, 30000);
+    this._monTimer = setInterval(() => {
+      const diff = Date.now() - this.lastHb;
+      if (diff > 45000) {
+        bus.emit('printer:timeout', this.id);
+        bus.emit('log:add', `[HB] lost ${this.id}`);
+      }
+      if (diff > 60000) {
+        this.socket?.close();
+      }
+    }, 5000);
+  }
+
+  /**
+   * ハートビート関連タイマーを停止する。
+   *
+   * @function
+   * @returns {void}
+   */
+  stopHeartbeat() {
+    if (this._hbTimer) {
+      clearInterval(this._hbTimer);
+      this._hbTimer = null;
+    }
+    if (this._monTimer) {
+      clearInterval(this._monTimer);
+      this._monTimer = null;
+    }
+  }
+
+  /**
+   * リソースを破棄する。
+   *
+   * @returns {void}
+   */
+  destroy() {
+    this.stopHeartbeat();
+    if (this.socket) {
+      if (this.socket.removeEventListener) {
+        this.socket.removeEventListener('open', this._onOpen);
+        this.socket.removeEventListener('message', this._onMsg);
+        this.socket.removeEventListener('error', this._onErr);
+        this.socket.removeEventListener('close', this._onClose);
+      } else {
+        this.socket.onopen = null;
+        this.socket.onmessage = null;
+        this.socket.onerror = null;
+        this.socket.onclose = null;
+      }
+      this.socket.close();
+      this.socket = null;
+    }
+  }
+
+  /**
+   * open イベントハンドラ。
+   *
+   * @private
+   * @returns {void}
+   */
+  #handleOpen() {
+    this.dispatchEvent(new Event('open'));
+    this.startHeartbeat();
+  }
+
+  /**
+   * message イベントハンドラ。
+   *
+   * @private
+   * @param {MessageEvent} evt - メッセージ
+   * @returns {void}
+   */
+  #handleMessage(evt) {
+    const txt = evt.data;
+    if (txt === 'ok') {
+      this.lastHb = Date.now();
+      return;
+    }
+    let obj = null;
+    try {
+      obj = JSON.parse(txt);
+      if (obj && obj.ModeCode === 'heart_beat') {
+        this.lastHb = Date.now();
+        return;
+      }
+    } catch {
+      /* ignore parse error */
+    }
+    this.dispatchEvent(new CustomEvent('message', { detail: obj ?? txt }));
+  }
+
+  /**
+   * error イベントハンドラ。
+   *
+   * @private
+   * @param {Event} e - エラーイベント
+   * @returns {void}
+   */
+  #handleError(e) {
+    bus.emit('log:add', `[ERR] ${this.id} socket error`);
+    this.dispatchEvent(new CustomEvent('error', { detail: e }));
+  }
+
+  /**
+   * close イベントハンドラ。
+   *
+   * @private
+   * @returns {void}
+   */
+  #handleClose() {
+    this.stopHeartbeat();
+    this.dispatchEvent(new Event('close'));
+  }
+}
+

--- a/tests/unit/hb_timeout.test.js
+++ b/tests/unit/hb_timeout.test.js
@@ -1,0 +1,48 @@
+// @vitest-environment happy-dom
+/**
+ * @fileoverview
+ * @description WSClient heartbeat timeout tests
+ * @file hb_timeout.test.js
+ * -----------------------------------------------------------
+ * @module tests/hb_timeout
+ *
+ * 【機能内容サマリ】
+ * - ハートビート監視が一定時間でタイムアウトするか検証
+ *
+ * @version 1.390.657 (PR #304)
+ * @since   1.390.657 (PR #304)
+ * @lastModified 2025-07-04 12:00:00
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import WSClient from '@core/WSClient.js';
+import { bus } from '@core/EventBus.js';
+import WebSocketMock from '../__mocks__/ws.js';
+
+globalThis.WebSocket = WebSocketMock;
+
+vi.useFakeTimers();
+
+describe('WSClient heartbeat', () => {
+  it('emits timeout when no heartbeat', () => {
+    const spy = vi.fn();
+    bus.on('printer:timeout', spy);
+    const client = new WSClient('ws://localhost', 'p1');
+    client.connect();
+    vi.advanceTimersByTime(10); // open
+    client.lastHb = Date.now() - 46000;
+    vi.advanceTimersByTime(5000);
+    expect(spy).toHaveBeenCalled();
+    client.destroy();
+  });
+
+  it('updates lastHb on ok', () => {
+    const client = new WSClient('ws://localhost', 'p1');
+    client.connect();
+    vi.advanceTimersByTime(10);
+    const prev = client.lastHb;
+    client.socket.onmessage({ data: 'ok' });
+    expect(client.lastHb).toBeGreaterThanOrEqual(prev);
+    client.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- add WSClient class with heartbeat monitoring
- update ConnectionManager to use WSClient and handle removals
- cache-bust camera frame URLs
- add heartbeat timeout unit test
- document camera stream integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867ca98d7fc832fbc89065595423913