### PR TITLE
Add log replay utility and test

### DIFF
--- a/tests/log_replay.test.js
+++ b/tests/log_replay.test.js
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+/**
+ * @fileoverview
+ * @description 3dpmon log replay test using WebSocket frames
+ * @file log_replay.test.js
+ * -----------------------------------------------------------
+ * @module tests/log_replay
+ *
+ * 【機能内容サマリ】
+ * - ログファイルを読み取り状態遷移を再現
+ *
+ * @version 1.390.669 (PR #310)
+ * @since   1.390.669 (PR #310)
+ * @lastModified 2025-07-09 00:00:00
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { parseLogToFrames } from './utils/log_replay.js';
+import { monitorData, setCurrentHostname, createEmptyMachineData } from '../3dp_lib/dashboard_data.js';
+import { processData } from '../3dp_lib/dashboard_msg_handler.js';
+import * as stagePreview from '../3dp_lib/dashboard_stage_preview.js';
+import path from 'path';
+
+const LOG_PATH = path.resolve('tests', 'data', 'printinglog_sample_test_001.log');
+
+describe('log replay', () => {
+  it('emulates print states from log', () => {
+    vi.spyOn(stagePreview, 'updateXYPreview').mockImplementation(() => {});
+    vi.spyOn(stagePreview, 'updateZPreview').mockImplementation(() => {});
+    setCurrentHostname('K1');
+    monitorData.machines['K1'] = createEmptyMachineData();
+    const frames = parseLogToFrames(LOG_PATH);
+    const states = [];
+    for (const f of frames) {
+      processData(f);
+      if ('state' in f) {
+        states.push(monitorData.machines['K1'].runtimeData.state);
+      }
+    }
+    expect(states).toEqual(['2', '0', '1', '2']);
+  });
+});

--- a/tests/utils/log_replay.js
+++ b/tests/utils/log_replay.js
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 ログ→WSフレーム変換ユーティリティ
+ * @file log_replay.js
+ * -----------------------------------------------------------
+ * @module tests/log_replay
+ *
+ * 【機能内容サマリ】
+ * - ログファイルから WebSocket 受信データを復元
+ *
+ * 【公開関数一覧】
+ * - {@link parseLogToFrames}：ログ行をJSONフレーム配列へ変換
+ *
+ * @version 1.390.669 (PR #310)
+ * @since   1.390.669 (PR #310)
+ * @lastModified 2025-07-09 00:00:00
+ * -----------------------------------------------------------
+ * @todo
+ * - 正規表現強化
+ */
+
+import fs from 'fs';
+
+/**
+ * ログファイルから WebSocket メッセージ配列を生成する。
+ * - "受信:" に続く JSON を解析
+ * - "heart beat:ok" は heart_beat フレームへ変換
+ *
+ * @function parseLogToFrames
+ * @param {string} path - ログファイルパス
+ * @returns {Object[]} 解析された WebSocket フレーム配列
+ */
+export function parseLogToFrames(path) {
+  const text = fs.readFileSync(path, 'utf8');
+  const frames = [];
+  for (const line of text.split(/\r?\n/)) {
+    const m = line.match(/受信:\s*(.+)$/);
+    if (!m) continue;
+    const payload = m[1].trim();
+    if (payload.startsWith('{')) {
+      try {
+        frames.push(JSON.parse(payload));
+      } catch {
+        /* JSON parse error ignored */
+      }
+    } else if (payload.startsWith('heart beat:ok')) {
+      frames.push({ ModeCode: 'heart_beat' });
+    }
+  }
+  return frames;
+}


### PR DESCRIPTION
## Summary
- add log_replay.js utility for converting log file lines back to WebSocket frames
- add log_replay.test.js to emulate printer state transitions using the sample log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e0b7be75c832fa1b0e708af8751ca