### PR TITLE
Use local timezone for log timestamps

### DIFF
--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -25,9 +25,9 @@
  * - {@link updateConnectionUI}：UI 状態更新
  * - {@link simulateReceivedJson}：受信データシミュレート
  *
-* @version 1.390.651 (PR #302)
+* @version 1.390.681 (PR #312)
 * @since   1.390.451 (PR #205)
-* @lastModified 2025-07-04 09:50:37
+* @lastModified 2025-07-10 07:33:39
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -406,7 +406,7 @@ function handleSocketMessage(event, host) {
   }
 
 // --- 2) タイムスタンプ更新 (lastLogTimestamp に現在時刻を反映) ---
-  const now = new Date().toISOString();
+  const now = getCurrentTimestamp();
   const tsField = document.querySelector('[data-field="lastLogTimestamp"] .value');
   if (tsField) tsField.textContent = now;
 
@@ -645,7 +645,7 @@ export function startHeartbeat(socket, intervalMs = 30_000, host = currentHostna
     if (st.ws && st.ws.readyState === WebSocket.OPEN) {
       const payload = {
         ModeCode: "heart_beat",
-        msg: new Date().toISOString()
+        msg: getCurrentTimestamp()
       };
       st.ws.send(JSON.stringify(payload));
     }
@@ -753,7 +753,7 @@ export function sendCommand(method, params = {}, host = currentHostname) {
     const now = Date.now();
     if (now - lastWsAlertTime > 1000) {
       lastWsAlertTime = now;
-      const ts = new Date(now).toISOString();
+      const ts = getCurrentTimestamp();
       const hostName = host === PLACEHOLDER_HOSTNAME ? "(placeholder)" : host;
       const detail = st.ws ? `readyState=${st.ws.readyState}` : "ws=null";
       const msg = `[${hostName}] WebSocket が接続されていません @ ${ts} (${detail})`;
@@ -804,7 +804,7 @@ export function sendGcodeCommand(gcode, host = currentHostname) {
     const now = Date.now();
     if (now - lastWsAlertTime > 1000) {
       lastWsAlertTime = now;
-      const ts = new Date(now).toISOString();
+      const ts = getCurrentTimestamp();
       const hostName = host === PLACEHOLDER_HOSTNAME ? "(placeholder)" : host;
       const detail = st.ws ? `readyState=${st.ws.readyState}` : "ws=null";
       const msg = `[${hostName}] WebSocket が接続されていません @ ${ts} (${detail})`;

--- a/3dp_lib/dashboard_msg_handler.js
+++ b/3dp_lib/dashboard_msg_handler.js
@@ -17,9 +17,9 @@
  * - {@link processData}：データ部処理
  * - {@link processError}：エラー処理
  *
-* @version 1.390.661 (PR #307)
+* @version 1.390.681 (PR #312)
 * @since   1.390.214 (PR #95)
-* @lastModified 2025-07-08 21:51:49
+* @lastModified 2025-07-10 07:33:39
  * -----------------------------------------------------------
 * @todo
 * - none
@@ -49,7 +49,7 @@ import {
 import { pushLog } from "./dashboard_log_util.js";
 import { notificationManager } from "./dashboard_notification_manager.js";
 import { handlePrintStateTransition } from "./dashboard_printstatus.js";
-import { parseCurPosition } from "./dashboard_utils.js";
+import { parseCurPosition, getCurrentTimestamp } from "./dashboard_utils.js";
 import {
   updateXYPreview,
   updateZPreview,
@@ -270,7 +270,7 @@ export function processData(data) {
 
   // (2.1) heartbeat のみ処理
   if (data.ModeCode === "heart_beat") {
-    machine.runtimeData.lastHeartbeat = new Date().toISOString();
+    machine.runtimeData.lastHeartbeat = getCurrentTimestamp();
     return;
   }
 

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -26,9 +26,9 @@
  * - {@link loadPrintCurrent}：現ジョブ読込
  * - {@link savePrintCurrent}：現ジョブ保存
  *
- * @version 1.390.341 (PR #154)
- * @since   1.390.193 (PR #86)
- * @lastModified 2025-06-21 00:00:00
+* @version 1.390.681 (PR #312)
+* @since   1.390.193 (PR #86)
+* @lastModified 2025-07-10 07:33:39
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -38,6 +38,7 @@
 
 import { monitorData, currentHostname, ensureMachineData } from "./dashboard_data.js";
 import { logManager } from "./dashboard_log_util.js";
+import { getCurrentTimestamp } from "./dashboard_utils.js";
 
 let _enableStorageLog = false;
 let _lastSavedJson    = null;
@@ -79,7 +80,7 @@ export function setStorageLogEnabled(flag) {
  */
 function pushLog(msg, isErr = false) {
   logManager.add({
-    timestamp: new Date().toISOString(),
+    timestamp: getCurrentTimestamp(),
     level:     isErr ? "error" : "info",
     msg
   });
@@ -105,11 +106,11 @@ export function saveUnifiedStorage() {
     _lastSavedJson = json;
     if (_enableStorageLog) {
       console.debug("[saveUnifiedStorage] monitorData を保存しました");
-      logManager.add({ timestamp:new Date().toISOString(), level:"info", msg:"[saveUnifiedStorage] 設定と履歴を保存しました" });
+      logManager.add({ timestamp:getCurrentTimestamp(), level:"info", msg:"[saveUnifiedStorage] 設定と履歴を保存しました" });
     }
   } catch (e) {
     console.warn("[saveUnifiedStorage] 保存に失敗しました:", e);
-    logManager.add({ timestamp:new Date().toISOString(), level:"error", msg:`[saveUnifiedStorage] エラー: ${e.message}` });
+    logManager.add({ timestamp:getCurrentTimestamp(), level:"error", msg:`[saveUnifiedStorage] エラー: ${e.message}` });
   }
 }
 

--- a/3dp_lib/dashboard_utils.js
+++ b/3dp_lib/dashboard_utils.js
@@ -15,9 +15,9 @@
  * 【公開関数一覧】
  * - {@link formatDuration} ほか複数をエクスポート
  *
- * @version 1.390.341 (PR #144)
+* @version 1.390.681 (PR #312)
  * @since   1.390.193 (PR #86)
- * @lastModified 2025-06-20 22:42:15
+ * @lastModified 2025-07-10 07:33:39
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -99,12 +99,19 @@ function formatBinary(value) {
 }
 
 /**
- * 現在のISO8601形式タイムスタンプを返します。
- * @returns {string}
+ * 現在のローカルタイムゾーン付き ISO8601 形式タイムスタンプを返します。
+ * 例: `2025-07-20T12:34:56.789+0900`
+ *
+ * @returns {string} ローカルタイムゾーン表記の ISO8601 文字列
  */
 function getCurrentTimestamp() {
   const d = new Date();
   const pad = (num, size) => ("000000" + num).slice(-size);
+  const offsetMin = d.getTimezoneOffset();
+  const sign = offsetMin <= 0 ? "+" : "-";
+  const abs = Math.abs(offsetMin);
+  const offHour = pad(Math.floor(abs / 60), 2);
+  const offMin = pad(abs % 60, 2);
   return (
     d.getFullYear() + "-" +
     pad(d.getMonth() + 1, 2) + "-" +
@@ -113,7 +120,7 @@ function getCurrentTimestamp() {
     pad(d.getMinutes(), 2) + ":" +
     pad(d.getSeconds(), 2) + "." +
     pad(d.getMilliseconds(), 3) +
-    "Z"
+    sign + offHour + offMin
   );
 }
 


### PR DESCRIPTION
## Summary
- display timestamps with local timezone
- record heartbeat and log entries using local time
- update stored data log timestamps
- bump version docs

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null)*

------
https://chatgpt.com/codex/tasks/task_e_686eed4f4bec832f8d224d2a11352440