### PR TITLE
Fix persist of actual start time

### DIFF
--- a/3dp_lib/dashboard_msg_handler.js
+++ b/3dp_lib/dashboard_msg_handler.js
@@ -17,9 +17,9 @@
  * - {@link processData}：データ部処理
  * - {@link processError}：エラー処理
  *
-* @version 1.390.661 (PR #307)
+* @version 1.390.678 (PR #313)
 * @since   1.390.214 (PR #95)
-* @lastModified 2025-07-08 21:51:49
+* @lastModified 2025-07-10 07:45:00
  * -----------------------------------------------------------
 * @todo
 * - none
@@ -60,7 +60,8 @@ import {
   ingestData,
   restoreAggregatorState,
   restartAggregatorTimer,
-  persistAggregatorState
+  persistAggregatorState,
+  setHistoryPersistFunc,
 } from "./dashboard_aggregator.js";
 import { restorePrintResume, persistPrintResume } from "./3dp_dashboard_init.js";
 import * as printManager from "./dashboard_printmanager.js";
@@ -103,7 +104,12 @@ function persistHistoryTimers(printId) {
     entry = { id: printId };
     machine.historyData.push(entry);
   }
-  ["preparationTime", "firstLayerCheckTime", "pauseTime"].forEach(key => {
+  [
+    "preparationTime",
+    "firstLayerCheckTime",
+    "pauseTime",
+    "actualStartTime",
+  ].forEach(key => {
     const v = machine.storedData[key]?.rawValue;
     if (v != null) entry[key] = v;
   });
@@ -112,6 +118,9 @@ function persistHistoryTimers(printId) {
   persistPrintResume();
   persistAggregatorState();
 }
+
+// aggregator へ履歴永続化フックを登録
+setHistoryPersistFunc(persistHistoryTimers);
 
 /**
  * handleMessage:

--- a/3dp_lib/dashboard_stage_preview.js
+++ b/3dp_lib/dashboard_stage_preview.js
@@ -14,9 +14,9 @@
  * 【公開関数一覧】
  * - {@link restoreXYPreviewState} など複数を一括エクスポート
  *
- * @version 1.390.317 (PR #143)
- * @since   1.390.214 (PR #95)
- * @lastModified 2025-06-19 22:38:18
+* @version 1.390.678 (PR #313)
+* @since   1.390.214 (PR #95)
+* @lastModified 2025-07-10 07:45:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -67,14 +67,13 @@ function setPrinterModel(model) {
     return; // 未対応モデルは変更なし
   }
   const stageElem = document.getElementById("xy-stage");
-  if (stageElem) {
-    const px = stageSizeMm * STAGE_SCALE;
-    stageElem.style.width = `${px}px`;
-    stageElem.style.height = `${px}px`;
-    stageElem.innerHTML = "";
-    xyDots.length = 0;
-    xyInitialized = false;
-  }
+  if (!stageElem) return; // テスト環境などでDOMが無い場合
+  const px = stageSizeMm * STAGE_SCALE;
+  stageElem.style.width = `${px}px`;
+  stageElem.style.height = `${px}px`;
+  stageElem.innerHTML = "";
+  xyDots.length = 0;
+  xyInitialized = false;
   const labelBottom = document.querySelector("#z-preview-container .z-label-bottom");
   if (labelBottom) labelBottom.textContent = String(stageZMaxMm);
   updateXYPreview(lastXYPosition.x, lastXYPosition.y);
@@ -150,6 +149,7 @@ function restoreXYHistoryDots() {
  */
 function initXYPreview() {
   const container = document.getElementById("xy-stage");
+  if (!container) return; // DOM が存在しなければ何もしない
   container.style.userSelect = "none";
   const gridCount = 7;
   const width = container.clientWidth;


### PR DESCRIPTION
## Summary
- save `actualStartTime` during ongoing print
- allow aggregator to persist history immediately when the start time is detected
- avoid DOM errors when stage preview elements are missing in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ee8659528832fb5f3a2509560cfb3