### PR TITLE
Fix spool print ID sync on new jobs

### DIFF
--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -21,9 +21,9 @@
  * - {@link stopAggregatorTimer}：集約ループ停止
  * - {@link setHistoryPersistFunc}：履歴永続化関数の登録
  *
-* @version 1.390.696 (PR #321)
+* @version 1.390.697 (PR #322)
 * @since   1.390.193 (PR #86)
-* @lastModified 2025-07-10 21:05:00
+* @lastModified 2025-07-10 21:30:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -195,6 +195,16 @@ export function ingestData(data) {
       setStoredData(f, null, true);
       setStoredData(f, null, false);
     });
+    // 新しいジョブIDを検出した際、現在スプールにもIDを反映する
+    const spool = getCurrentSpool();
+    if (spool && spool.currentPrintID !== String(id)) {
+      if (spool.currentJobExpectedLength == null) {
+        // 予定使用量が未登録の場合は 0 で仮登録してIDのみ確定
+        reserveFilament(0, String(id));
+      } else {
+        spool.currentPrintID = String(id);
+      }
+    }
     prevPrintID = id;
   }
 

--- a/tests/log_device_usage.test.js
+++ b/tests/log_device_usage.test.js
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+/**
+ * @fileoverview
+ * @description 3dpmon log replay test for filament usage with log 002
+ * @file log_device_usage.test.js
+ * -----------------------------------------------------------
+ * @module tests/log_device_usage
+ *
+ * 【機能内容サマリ】
+ * - ログ002を再生しフィラメント履歴を確認
+ *
+ * @version 1.390.697 (PR #322)
+ * @since   1.390.697 (PR #322)
+ * @lastModified 2025-07-10 21:30:00
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { parseLogToFrames } from './utils/log_replay.js';
+import { monitorData, setCurrentHostname, createEmptyMachineData } from '../3dp_lib/dashboard_data.js';
+import { processData } from '../3dp_lib/dashboard_msg_handler.js';
+import * as stagePreview from '../3dp_lib/dashboard_stage_preview.js';
+import { addSpool, setCurrentSpoolId } from '../3dp_lib/dashboard_spool.js';
+import { aggregatorUpdate } from '../3dp_lib/dashboard_aggregator.js';
+import path from 'path';
+
+const LOG_PATH = path.resolve('tests', 'data', 'printinglog_sample_test_002.log');
+
+describe('filament usage from log 002', () => {
+  it('records spool information into history', () => {
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(stagePreview, 'updateXYPreview').mockImplementation(() => {});
+    vi.spyOn(stagePreview, 'updateZPreview').mockImplementation(() => {});
+    setCurrentHostname('K1');
+    monitorData.machines['K1'] = createEmptyMachineData();
+    const spool = addSpool({ name: 'test', material: 'PLA', remainingLengthMm: 200000, totalLengthMm: 200000 });
+    setCurrentSpoolId(spool.id);
+
+    const frames = parseLogToFrames(LOG_PATH);
+    for (const f of frames) {
+      processData(f);
+      aggregatorUpdate();
+    }
+
+    aggregatorUpdate();
+    const entry = monitorData.machines['K1'].historyData.find(h => h.id === 1752145064);
+    expect(entry).toBeDefined();
+    expect(spool.currentPrintID).toBe('1752145064');
+  });
+});


### PR DESCRIPTION
## Summary
- sync spool.currentPrintID on new printStartTime
- add regression test using sample log 002 to confirm spool ID update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fadef9e98832fa7bcdd8a0a601a37