### PR TITLE
Fix lost history timers when printStartTime missing

### DIFF
--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -20,10 +20,11 @@
  * - {@link restartAggregatorTimer}：集約ループ再開
  * - {@link stopAggregatorTimer}：集約ループ停止
  * - {@link setHistoryPersistFunc}：履歴永続化関数の登録
+ * - {@link getCurrentPrintID}：現在の印刷IDを取得
  *
-* @version 1.390.697 (PR #322)
+* @version 1.390.702 (PR #324)
 * @since   1.390.193 (PR #86)
-* @lastModified 2025-07-10 21:30:00
+* @lastModified 2025-07-10 22:30:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -984,6 +985,17 @@ export function stopAggregatorTimer() {
 
     persistAggregatorState();
   }
+}
+
+/**
+ * getCurrentPrintID:
+ *   集約モジュールが保持する現在の印刷IDを返します。
+ *   初期化前や未検出時は `null` を返します。
+ *
+ * @returns {number|null} 現在の印刷ID
+ */
+export function getCurrentPrintID() {
+  return prevPrintID;
 }
 
 /**

--- a/3dp_lib/dashboard_msg_handler.js
+++ b/3dp_lib/dashboard_msg_handler.js
@@ -17,9 +17,9 @@
  * - {@link processData}：データ部処理
  * - {@link processError}：エラー処理
  *
-* @version 1.390.700 (PR #323)
+* @version 1.390.702 (PR #324)
 * @since   1.390.214 (PR #95)
-* @lastModified 2025-07-10 22:00:00
+* @lastModified 2025-07-10 22:30:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -64,6 +64,7 @@ import {
   persistAggregatorState,
   setHistoryPersistFunc,
   aggregatorUpdate,
+  getCurrentPrintID,
 } from "./dashboard_aggregator.js";
 import { restorePrintResume, persistPrintResume } from "./3dp_dashboard_init.js";
 import * as printManager from "./dashboard_printmanager.js";
@@ -315,7 +316,9 @@ export function processData(data) {
 
   // 数値化／前回値取得
   const st            = Number(data.state);
-  const currStartTime = Number(data.printStartTime   || 0);
+  const currStartTime = Number(
+    data.printStartTime ?? getCurrentPrintID() ?? 0
+  );
   const currJobTime   = Number(data.printJobTime     || 0);
   const currSelfPct   = Number(data.withSelfTest      || 0);
   const device        = Number(data.deviceState      || 0);


### PR DESCRIPTION
## Summary
- expose `getCurrentPrintID` from aggregator
- use last known print ID in message handler
- bump module versions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686fbb8c2a68832fb100c616d2700ea2