### PR TITLE
Fix start time persistence and spool tracking

### DIFF
--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -22,9 +22,9 @@
  * - {@link setHistoryPersistFunc}：履歴永続化関数の登録
  * - {@link getCurrentPrintID}：現在の印刷IDを取得
  *
- * @version 1.390.704 (PR #325)
-* @since   1.390.193 (PR #86)
- * @lastModified 2025-07-10 23:11:44
+ * @version 1.390.705 (PR #326)
+ * @since   1.390.193 (PR #86)
+ * @lastModified 2025-07-10 23:48:59
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -743,9 +743,18 @@ export function aggregatorUpdate() {
   // --- フィラメント残量の動的計算 ---
   const spool = getCurrentSpool();
   if (spool) autoCorrectCurrentSpool();
-  // usedMaterialLength 受信時だけ残量計算を更新
-  if (spool && storedData.usedMaterialLength?.isNew) {
-    const st   = Number(storedData.state?.rawValue || 0);
+  const st   = Number(storedData.state?.rawValue || 0);
+  // usedMaterialLength 受信時、または復元直後に currentJobStartLength が未設定の
+  // 状態で印刷が進行中の場合に残量計算を開始
+  if (
+    spool &&
+    (storedData.usedMaterialLength?.isNew ||
+      (spool.currentJobStartLength == null &&
+        (st === PRINT_STATE_CODE.printStarted || st === PRINT_STATE_CODE.printPaused)))
+  ) {
+    if (spool.currentJobStartLength == null) {
+      spool.currentJobStartLength = spool.remainingLengthMm;
+    }
     const prog = parseInt(storedData.printProgress?.rawValue || 0, 10);
     const used = Number(storedData.usedMaterialLength.rawValue);
     let est  = Number(storedData.materialLength?.rawValue ?? NaN);
@@ -922,6 +931,16 @@ export function restoreAggregatorState() {
     if (k === "prevPrintID")      field = "prevPrintID";
     setStoredData(field, v, true);
   });
+
+  // 復元後に actualStartTime が存在し印刷ID も分かっている場合は
+  // 履歴に反映して UI を即時更新する
+  if (historyPersistFunc && prevPrintID && actualStartEpoch != null) {
+    try {
+      historyPersistFunc(prevPrintID);
+    } catch (e) {
+      console.error("historyPersistFunc error", e);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure filament remaining calculation initializes after reload
- update history with actual start time upon restore

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fd113a0d0832f9fac3d3fc12b23a8