### PR TITLE
Fix expected end time display

### DIFF
--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -22,9 +22,9 @@
  * - {@link setHistoryPersistFunc}：履歴永続化関数の登録
  * - {@link getCurrentPrintID}：現在の印刷IDを取得
  *
- * @version 1.390.705 (PR #326)
+ * @version 1.390.711 (PR #328)
  * @since   1.390.193 (PR #86)
- * @lastModified 2025-07-10 23:48:59
+ * @lastModified 2025-07-11 07:28:24
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -667,7 +667,8 @@ export function aggregatorUpdate() {
   // --- ここでタイマー／予測用フィールド群が揃っているか確認 ---
   const needed = ["preparationTime","firstLayerCheckTime","pauseTime","completionElapsedTime",
                   "actualStartTime","initialLeftTime","initialLeftAt",
-                  "predictedFinishEpoch","estimatedRemainingTime","estimatedCompletionTime"];
+                  "predictedFinishEpoch","estimatedRemainingTime","estimatedCompletionTime",
+                  "expectedEndTime"];
   needed.forEach(key => {
     if (!(key in storedData)) { //キーが無い場合
       // rawValueを「未定義(null)」で作っておく
@@ -739,6 +740,25 @@ export function aggregatorUpdate() {
       setStoredData("printFinishTime", e, true);
       setStoredData("printFinishTime", {
         value: new Date(e*1000).toLocaleString(),
+        unit: ""
+      });
+    }
+  }, storedData);
+
+  // expectedEndTime 更新
+  checkUpdatedFields(["printFinishTime","estimatedCompletionTime"], () => {
+    const fin = parseInt(storedData.printFinishTime?.rawValue, 10);
+    let epoch = null;
+    if (!isNaN(fin) && fin > 0) {
+      epoch = fin;
+    } else {
+      const est = parseInt(storedData.estimatedCompletionTime?.rawValue, 10);
+      if (!isNaN(est) && est > 0) epoch = est;
+    }
+    setStoredData("expectedEndTime", epoch, true);
+    if (epoch !== null) {
+      setStoredData("expectedEndTime", {
+        value: new Date(epoch * 1000).toLocaleString(),
         unit: ""
       });
     }

--- a/tests/expected_end_time.test.js
+++ b/tests/expected_end_time.test.js
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+/**
+ * @fileoverview
+ * @description 3dpmon log playback test for expected end time
+ * @file expected_end_time.test.js
+ * -----------------------------------------------------------
+ * @module tests/expected_end_time
+ *
+ * 【機能内容サマリ】
+ * - Log device playback verifies expectedEndTime update
+ *
+ * 【公開関数一覧】
+ * - なし (Vitest suite)
+ *
+ * @version 1.390.711 (PR #328)
+ * @since   1.390.711 (PR #328)
+ * @lastModified 2025-07-11 07:28:24
+ * -----------------------------------------------------------
+ * @todo
+ * - none
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createLogDevice } from './utils/log_device.js';
+import { monitorData, setCurrentHostname, createEmptyMachineData } from '../3dp_lib/dashboard_data.js';
+import { processData } from '../3dp_lib/dashboard_msg_handler.js';
+import { aggregatorUpdate } from '../3dp_lib/dashboard_aggregator.js';
+import * as stagePreview from '../3dp_lib/dashboard_stage_preview.js';
+
+// ---------------------------------------------------------------------------
+// テスト本体
+// ---------------------------------------------------------------------------
+
+describe('expected end time update', () => {
+  it('updates expectedEndTime after finish', () => {
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(stagePreview, 'updateXYPreview').mockImplementation(() => {});
+    vi.spyOn(stagePreview, 'updateZPreview').mockImplementation(() => {});
+
+    setCurrentHostname('K1');
+    monitorData.machines['K1'] = createEmptyMachineData();
+
+    const device = createLogDevice('002', 0);
+    let now = 0;
+    let result;
+
+    do {
+      result = device.get(now);
+      for (const frame of result.json) {
+        processData(frame);
+        aggregatorUpdate();
+      }
+      now += 1;
+    } while (!result.is_finished);
+
+    aggregatorUpdate();
+    const sd = monitorData.machines['K1'].storedData;
+    expect(sd.expectedEndTime.rawValue).toBe(sd.printFinishTime.rawValue);
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure `expectedEndTime` field exists and updates from `printFinishTime`
- add regression test using log playback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68703cbbb23c832fb5d86c57c9e09e58