### PR TITLE
Add log device storedData test and spool persistence

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -384,6 +384,15 @@ const persistKeys = [
   "prevPrintID"
 ];
 
+// 印刷再開用に保存したいスプール関連キー
+const spoolKeys = [
+  "currentSpoolId",
+  "currentPrintID",
+  "currentJobStartLength",
+  "currentJobExpectedLength",
+  "remainingLengthMm"
+];
+
 /**
  * @function restorePrintResume
  * @description
@@ -425,6 +434,34 @@ export function restorePrintResume(currentPrintId = null) {
       console.warn(`restorePrintResume: '${key}' の JSON パースに失敗しました`, e);
     }
   });
+
+  const spool = getCurrentSpool();
+  if (spool) {
+    spoolKeys.forEach(k => {
+      const raw = localStorage.getItem(`pd_${host}_${k}`);
+      if (raw == null) return;
+      try {
+        const val = JSON.parse(raw);
+        switch (k) {
+          case 'currentSpoolId':
+            setCurrentSpoolId(val);
+            break;
+          case 'currentPrintID':
+            spool.currentPrintID = val;
+            break;
+          case 'currentJobStartLength':
+            spool.currentJobStartLength = val;
+            break;
+          case 'currentJobExpectedLength':
+            spool.currentJobExpectedLength = val;
+            break;
+          case 'remainingLengthMm':
+            spool.remainingLengthMm = val;
+            break;
+        }
+      } catch {}
+    });
+  }
 }
 
 /**
@@ -448,6 +485,34 @@ export function persistPrintResume() {
       localStorage.removeItem(`pd_${host}_${key}`);
     }
   });
+
+  const spool = getCurrentSpool();
+  if (spool) {
+    spoolKeys.forEach(k => {
+      const val = (() => {
+        switch (k) {
+          case 'currentSpoolId':
+            return monitorData.currentSpoolId;
+          case 'currentPrintID':
+            return spool.currentPrintID;
+          case 'currentJobStartLength':
+            return spool.currentJobStartLength;
+          case 'currentJobExpectedLength':
+            return spool.currentJobExpectedLength;
+          case 'remainingLengthMm':
+            return spool.remainingLengthMm;
+          default:
+            return null;
+        }
+      })();
+      const key = `pd_${host}_${k}`;
+      if (val != null) {
+        localStorage.setItem(key, JSON.stringify(val));
+      } else {
+        localStorage.removeItem(key);
+      }
+    });
+  }
 }
 
  

--- a/tests/log_device_storeddata.test.js
+++ b/tests/log_device_storeddata.test.js
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+/**
+ * @fileoverview
+ * @description 3dpmon log device test using storedData before/after snapshots
+ * @file log_device_storeddata.test.js
+ * -----------------------------------------------------------
+ * @module tests/log_device_storeddata
+ *
+ * 【機能内容サマリ】
+ * - ログ002をモックデバイスで再生しstoredData更新を検証
+ *
+ * @version 1.390.705 (PR #328)
+ * @since   1.390.705 (PR #328)
+ * @lastModified 2025-07-11 07:50:00
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { createLogDevice } from './utils/log_device.js';
+import { monitorData, setCurrentHostname, createEmptyMachineData } from '../3dp_lib/dashboard_data.js';
+import { processData } from '../3dp_lib/dashboard_msg_handler.js';
+import { aggregatorUpdate } from '../3dp_lib/dashboard_aggregator.js';
+import { addSpool, setCurrentSpoolId } from '../3dp_lib/dashboard_spool.js';
+import * as stagePreview from '../3dp_lib/dashboard_stage_preview.js';
+
+const BEFORE_PATH = path.resolve('tests', 'data', 'printinglog_sample_test_002_storedData_before.log');
+const AFTER_PATH  = path.resolve('tests', 'data', 'printinglog_sample_test_002_storedData_after.log');
+
+/**
+ * storedDataロガーファイルを読み込みJSONとして返す
+ * @param {string} p - ファイルパス
+ * @returns {Object} パースされたオブジェクト
+ */
+function loadStoredData(p) {
+  const txt = fs.readFileSync(p, 'utf8');
+  return JSON.parse(txt);
+}
+
+describe('log device storedData update', () => {
+  it('replays log and updates storedData', () => {
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(stagePreview, 'updateXYPreview').mockImplementation(() => {});
+    vi.spyOn(stagePreview, 'updateZPreview').mockImplementation(() => {});
+    setCurrentHostname('K1');
+    monitorData.machines['K1'] = createEmptyMachineData();
+    monitorData.machines['K1'].storedData = loadStoredData(BEFORE_PATH);
+    const spool = addSpool({ name: 'test', material: 'PLA', remainingLengthMm: 200000, totalLengthMm: 200000 });
+    setCurrentSpoolId(spool.id);
+
+    const dev = createLogDevice('002', 0, 0, true);
+    let now = 0;
+    while (true) {
+      const { json, is_finished } = dev.get(now);
+      for (const frame of json) {
+        processData(frame);
+        aggregatorUpdate();
+      }
+      if (is_finished) break;
+      now += 1;
+    }
+    aggregatorUpdate();
+
+    const after = loadStoredData(AFTER_PATH);
+    const sd = monitorData.machines['K1'].storedData;
+    expect(sd.printStartTime.rawValue).toBe(after.printStartTime.rawValue);
+    expect(Object.keys(sd).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add spool resume persistence
- create a log device test for storedData snapshots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68703cdd7f9c832f821bebf4ecbecb06