### PR TITLE
Fix expected end time display

### DIFF
--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -22,9 +22,9 @@
  * - {@link setHistoryPersistFunc}：履歴永続化関数の登録
  * - {@link getCurrentPrintID}：現在の印刷IDを取得
  *
- * @version 1.390.705 (PR #326)
+ * @version 1.390.711 (PR #328)
  * @since   1.390.193 (PR #86)
- * @lastModified 2025-07-10 23:48:59
+ * @lastModified 2025-07-11 09:25:51
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -742,6 +742,21 @@ export function aggregatorUpdate() {
         unit: ""
       });
     }
+  }, storedData);
+
+  // expectedEndTime update
+  checkUpdatedFields([
+    "printFinishTime",
+    "predictedFinishEpoch"
+  ], () => {
+    const fin = parseInt(storedData.printFinishTime?.rawValue, 10);
+    const pred = parseInt(storedData.predictedFinishEpoch?.rawValue, 10);
+    const val = (!isNaN(fin) && fin > 0)
+      ? fin
+      : (!isNaN(pred) && pred > 0)
+        ? pred
+        : null;
+    setStoredData("expectedEndTime", val, true);
   }, storedData);
 
   // --- フィラメント残量の動的計算 ---

--- a/tests/expected_end_time.test.js
+++ b/tests/expected_end_time.test.js
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+/**
+ * @fileoverview
+ * @description ensure expectedEndTime field reflects final print finish time
+ * @file expected_end_time.test.js
+ * -----------------------------------------------------------
+ * @module tests/expected_end_time
+ *
+ * 【機能内容サマリ】
+ * - log 002 replay via log_device verifies expectedEndTime
+ *
+ * @version 1.390.711 (PR #328)
+ * @since   1.390.711 (PR #328)
+ * @lastModified 2025-07-11 09:25:51
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createLogDevice } from './utils/log_device.js';
+import { monitorData, setCurrentHostname, createEmptyMachineData } from '../3dp_lib/dashboard_data.js';
+import { processData } from '../3dp_lib/dashboard_msg_handler.js';
+import * as stagePreview from '../3dp_lib/dashboard_stage_preview.js';
+import { aggregatorUpdate } from '../3dp_lib/dashboard_aggregator.js';
+
+describe('expectedEndTime calculation', () => {
+  it('updates expectedEndTime using log device for log 002', () => {
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(stagePreview, 'updateXYPreview').mockImplementation(() => {});
+    vi.spyOn(stagePreview, 'updateZPreview').mockImplementation(() => {});
+
+    setCurrentHostname('K1');
+    monitorData.machines['K1'] = createEmptyMachineData();
+
+    const dev = createLogDevice('002', 0, 0, true);
+    const result = dev.get(999999);
+    for (const frame of result.json) {
+      processData(frame);
+      aggregatorUpdate();
+    }
+    aggregatorUpdate();
+
+    const stored = monitorData.machines['K1'].storedData;
+    expect(parseInt(stored.expectedEndTime.rawValue, 10))
+      .toBe(parseInt(stored.printFinishTime.rawValue, 10));
+  });
+});


### PR DESCRIPTION
## Summary
- update aggregator to fill `expectedEndTime`
- test expected end time using log device

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687058b219b8832fa3f0038d081f9806