### PR TITLE
Ensure spool info merges with device history

### DIFF
--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -471,9 +471,9 @@ export async function refreshHistory(
   const buf = machine ? machine.historyData : [];
   const appliedIdx = new Set();
   if (buf && buf.length) {
-    const bufMap = new Map(buf.map((b, i) => [b.id, { data: b, idx: i }]));
+    const bufMap = new Map(buf.map((b, i) => [String(b.id), { data: b, idx: i }]));
     newJobs.forEach(job => {
-      const found = bufMap.get(job.id);
+      const found = bufMap.get(String(job.id));
       if (!found) return;
       Object.entries(found.data).forEach(([k, v]) => {
         if (k === "id") return;
@@ -490,12 +490,12 @@ export async function refreshHistory(
   }
   const oldJobs = loadHistory();
   const mergedMap = new Map();
-  newJobs.forEach(j => mergedMap.set(j.id, j));
+  newJobs.forEach(j => mergedMap.set(String(j.id), j));
   oldJobs.forEach(j => {
-    if (!mergedMap.has(j.id)) mergedMap.set(j.id, j);
+    if (!mergedMap.has(String(j.id))) mergedMap.set(String(j.id), j);
   });
   const jobs = Array.from(mergedMap.values())
-    .sort((a, b) => b.id - a.id)
+    .sort((a, b) => Number(b.id) - Number(a.id))
     .slice(0, MAX_HISTORY);
 
 
@@ -587,9 +587,9 @@ export function updateHistoryList(
   const buf = machine ? machine.historyData : [];
   const appliedIdx = new Set();
   if (buf && buf.length) {
-    const bufMap = new Map(buf.map((b, i) => [b.id, { data: b, idx: i }]));
+    const bufMap = new Map(buf.map((b, i) => [String(b.id), { data: b, idx: i }]));
     newJobs.forEach(job => {
-      const found = bufMap.get(job.id);
+      const found = bufMap.get(String(job.id));
       if (!found) return;
       Object.entries(found.data).forEach(([k, v]) => {
         if (k === "id") return;
@@ -606,9 +606,9 @@ export function updateHistoryList(
   let merged = false;
   const oldJobs = loadHistory();
   const mergedMap = new Map();
-  newJobs.forEach(j => mergedMap.set(j.id, j));
+  newJobs.forEach(j => mergedMap.set(String(j.id), j));
   oldJobs.forEach(j => {
-    const cur = mergedMap.get(j.id);
+    const cur = mergedMap.get(String(j.id));
     if (cur) {
       Object.entries(j).forEach(([k, v]) => {
         const isZeroInCur = MERGE_IGNORE_ZERO_FIELDS.has(k) && Number(cur[k]) === 0;
@@ -626,12 +626,12 @@ export function updateHistoryList(
         }
       });
     } else {
-      mergedMap.set(j.id, j);
+      mergedMap.set(String(j.id), j);
       merged = true;
     }
   });
   const jobs = Array.from(mergedMap.values())
-    .sort((a, b) => b.id - a.id)
+    .sort((a, b) => Number(b.id) - Number(a.id))
     .slice(0, MAX_HISTORY);
 
   const videoMap = loadVideos();

--- a/tests/history_spool_merge.test.js
+++ b/tests/history_spool_merge.test.js
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+/**
+ * @fileoverview
+ * @description verify reserveFilament history merges with device history
+ * @file history_spool_merge.test.js
+ * -----------------------------------------------------------
+ * @module tests/history_spool_merge
+ *
+ * 【機能内容サマリ】
+ * - reserveFilament entry merges into print history when device list arrives
+ *
+ * @version 1.390.724 (PR #333)
+ * @since   1.390.724 (PR #333)
+ * @lastModified 2025-07-11 15:20:00
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { monitorData, setCurrentHostname, createEmptyMachineData } from '../3dp_lib/dashboard_data.js';
+import { updateHistoryList } from '../3dp_lib/dashboard_printmanager.js';
+import { reserveFilament, addSpool, setCurrentSpoolId } from '../3dp_lib/dashboard_spool.js';
+import * as stagePreview from '../3dp_lib/dashboard_stage_preview.js';
+
+// ---------------------------------------------------------------------------
+// テスト本体
+// ---------------------------------------------------------------------------
+
+describe('history spool merge', () => {
+  it('merges spool info entry with device history', () => {
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(stagePreview, 'updateXYPreview').mockImplementation(() => {});
+    vi.spyOn(stagePreview, 'updateZPreview').mockImplementation(() => {});
+
+    setCurrentHostname('K1');
+    monitorData.machines['K1'] = createEmptyMachineData();
+    const spool = addSpool({ name: 'test', material: 'PLA', remainingLengthMm: 200000, totalLengthMm: 200000 });
+    setCurrentSpoolId(spool.id);
+
+    reserveFilament(100, '123');
+
+    const raw = [{ id: 123, filename: 'a.gcode', starttime: 1 }];
+    updateHistoryList(raw, '');
+
+    const entry = monitorData.machines['K1'].printStore.history.find(h => h.id === 123);
+    expect(entry).toBeDefined();
+    expect(Array.isArray(entry.filamentInfo)).toBe(true);
+    expect(entry.filamentInfo.some(info => info.spoolId === spool.id)).toBe(true);
+
+    const saved = JSON.parse(localStorage.getItem('3dp-monitor_1.400'));
+    const storedEntry = saved.machines.K1.printStore.history.find(h => h.id === 123);
+    expect(storedEntry).toBeDefined();
+    expect(storedEntry.filamentInfo.some(info => info.spoolId === spool.id)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- fix updateHistoryList id matching logic
- add regression test for spool info merge

## Testing
- `npx vitest run tests/history_spool_merge.test.js`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6870a67bfce0832faaf83259a1c9ebd7