### PR TITLE
Fix spool length corruption on restore

### DIFF
--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -27,9 +27,9 @@
  * - {@link finalizeFilamentUsage}：使用量確定
  * - {@link autoCorrectCurrentSpool}：履歴から残量補正
  *
-* @version 1.390.687 (PR #313)
+* @version 1.390.731 (PR #337)
 * @since   1.390.193 (PR #86)
-* @lastModified 2025-07-10 17:35:30
+* @lastModified 2025-07-11 23:50:08
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -569,6 +569,10 @@ export function autoCorrectCurrentSpool() {
   }
   if (!change) return;
 
+  // 履歴から取得した開始残量が数値でなければ補正不能と判断
+  const startLen = Number(change.startLength);
+  if (!Number.isFinite(startLen)) return;
+
   let total = 0;
   let count = 0;
   for (let i = startIdx + 1; i < logs.length; i++) {
@@ -582,9 +586,11 @@ export function autoCorrectCurrentSpool() {
     }
   }
 
-  const expected = Math.max(0, Number(change.startLength) - total);
+  // 計算された残量が有限値でなければ補正しない
+  const expected = Math.max(0, startLen - total);
+  if (!Number.isFinite(expected)) return;
   const diff = Math.abs(expected - spool.remainingLengthMm);
-  if (diff > 0.1 || spool.printCount !== count) {
+  if (Number.isFinite(diff) && (diff > 0.1 || spool.printCount !== count)) {
     spool.remainingLengthMm = expected;
     spool.printCount = count;
     saveUnifiedStorage();

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -26,9 +26,9 @@
  * - {@link loadPrintCurrent}：現ジョブ読込
  * - {@link savePrintCurrent}：現ジョブ保存
  *
-* @version 1.390.681 (PR #312)
+* @version 1.390.731 (PR #337)
 * @since   1.390.193 (PR #86)
-* @lastModified 2025-07-10 07:33:39
+* @lastModified 2025-07-11 23:50:08
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -60,6 +60,14 @@ function applySpoolDefaults(sp) {
   sp.density ??= 0;
   sp.reelSubName ??= "";
   sp.isPending ??= false;
+  // 数値項目の正規化: NaN または null の場合は 0 をセット
+  if (sp.remainingLengthMm != null) {
+    const rem = Number(sp.remainingLengthMm);
+    sp.remainingLengthMm = Number.isFinite(rem) ? rem : 0;
+  }
+  if (sp.startLength == null || !Number.isFinite(Number(sp.startLength))) {
+    sp.startLength = sp.remainingLengthMm ?? 0;
+  }
   return sp;
 }
 


### PR DESCRIPTION
## Summary
- sanitize numeric fields when loading spool data
- guard against invalid history values in `autoCorrectCurrentSpool`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68719baa2794832f9e46916e4b6959e7