### PR TITLE
Fix current print card update

### DIFF
--- a/3dp_lib/dashboard_msg_handler.js
+++ b/3dp_lib/dashboard_msg_handler.js
@@ -17,9 +17,9 @@
  * - {@link processData}：データ部処理
  * - {@link processError}：エラー処理
  *
-* @version 1.390.736 (PR #339)
+* @version 1.390.737 (PR #340)
 * @since   1.390.214 (PR #95)
-* @lastModified 2025-07-13 10:38:58
+* @lastModified 2025-07-13 11:05:00
  * -----------------------------------------------------------
  * @todo
  * - none

--- a/3dp_lib/dashboard_msg_handler.js
+++ b/3dp_lib/dashboard_msg_handler.js
@@ -17,9 +17,9 @@
  * - {@link processData}：データ部処理
  * - {@link processError}：エラー処理
  *
-* @version 1.390.728 (PR #335)
+* @version 1.390.736 (PR #339)
 * @since   1.390.214 (PR #95)
-* @lastModified 2025-07-11 20:49:00
+* @lastModified 2025-07-13 10:38:58
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -555,6 +555,35 @@ export function processData(data) {
   // (2.7.3) その他フィールド一括反映
   // 重要：ここで得られた値のみ、setstoredDataの第4フラグ(機器から得られる情報)をフラグONとする
   Object.entries(data).forEach(([k, v]) => setStoredData(k, v, true, true));
+
+  // --- 新しい印刷情報が後から届いた場合の現在ジョブ更新処理 ----------------
+  // fileName または printStartTime が受信された際、printManager が保持する
+  // 現在印刷中ジョブ情報を更新して UI へ即反映させる。印刷開始直後に情報が
+  // 遅延して届くケースで、ファイル名や開始時刻が不明のまま表示され続ける
+  // 問題を解消する目的で追加。
+  if (data.fileName || data.printStartTime) {
+    const curJob = printManager.loadCurrent() || {};
+    let changed = false;
+    if (data.fileName) {
+      curJob.filename = String(data.fileName).split("/").pop();
+      curJob.rawFilename = String(data.fileName);
+      changed = true;
+    }
+    if (data.printStartTime) {
+      const start = Number(data.printStartTime);
+      if (!isNaN(start) && start > 0) {
+        curJob.id = start;
+        curJob.startTime = new Date(start * 1000).toISOString();
+        changed = true;
+      }
+    }
+    if (changed) {
+      printManager.saveCurrent(curJob);
+      printManager.renderPrintCurrent(
+        document.getElementById("print-current-container")
+      );
+    }
+  }
 
   // (2.7.4) 進捗100%以上で履歴登録
   if (Number(data.printProgress ?? 0) >= 100) {

--- a/tests/currentprint_update.test.js
+++ b/tests/currentprint_update.test.js
@@ -1,0 +1,46 @@
+// @vitest-environment happy-dom
+/**
+ * @fileoverview
+ * @description ensure current job updates when file name or start time arrive late
+ * @file currentprint_update.test.js
+ * -----------------------------------------------------------
+ * @module tests/currentprint_update
+ *
+ * 【機能内容サマリ】
+ * - 遅延したファイル名/開始時刻による現在ジョブ更新を検証
+ *
+ * @version 1.390.737 (PR #340)
+ * @since   1.390.737 (PR #340)
+ * @lastModified 2025-07-13 11:05:00
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { setCurrentHostname, monitorData, createEmptyMachineData } from '../3dp_lib/dashboard_data.js';
+import { processData } from '../3dp_lib/dashboard_msg_handler.js';
+import { loadCurrent } from '../3dp_lib/dashboard_printmanager.js';
+import * as stagePreview from '../3dp_lib/dashboard_stage_preview.js';
+
+// -------------------------------------------------------------------------
+// テスト本体
+// -------------------------------------------------------------------------
+
+describe('current job update on late info', () => {
+  it('updates stored current job when info arrives after start', () => {
+    vi.spyOn(stagePreview, 'updateXYPreview').mockImplementation(() => {});
+    vi.spyOn(stagePreview, 'updateZPreview').mockImplementation(() => {});
+
+    setCurrentHostname('K1');
+    monitorData.machines['K1'] = createEmptyMachineData();
+
+    // Start without filename or start time
+    processData({ state: 1, printProgress: 0 });
+    expect(loadCurrent()).toBeNull();
+
+    // Later receive filename and start time
+    processData({ fileName: '/path/to/test.gcode', printStartTime: 1000 });
+    const job = loadCurrent();
+    expect(job).not.toBeNull();
+    expect(job.filename).toBe('test.gcode');
+    expect(job.id).toBe(1000);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure current print job info updates when filename or start time arrives late
- document version bump

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68730c672ef4832fa45daf30f9374056