### PR TITLE
Fix font inspector script iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ Unit tests are executed with [Vitest](https://vitest.dev/).
 
 See [docs/develop/tests.md](docs/develop/tests.md) for coverage goals and additional details.
 
+## Font Inspector
+`scripts/font_inspector.js` can enumerate glyphs in any TrueType or OpenType font.
+
+Run the following to list all designed characters:
+
+```bash
+node scripts/font_inspector.js --target_font <font-file> --dump_exist_designed_all_char
+```
+
+Use `--dump_registed_all_char` to output every registered Unicode code point.
+
 ### Troubleshooting
 If `npm run dev` fails with `EACCES: permission denied, rename` on Dropbox or
 other network drives, run `scripts/clear-vite.sh` to reset Vite's cache.

--- a/scripts/font_inspector.js
+++ b/scripts/font_inspector.js
@@ -15,9 +15,9 @@
  * - {@link dumpRegisteredAllChar}: 登録済みの全 Unicode 文字を出力
  * - {@link dumpExistDesignedAllChar}: デザインが存在する文字だけを出力
  *
- * @version 1.390.744 (PR #342)
+ * @version 1.390.746 (PR #343)
  * @since   1.390.744 (PR #342)
- * @lastModified  2025-07-14 11:20:18
+ * @lastModified  2025-07-14 12:00:00
  * -----------------------------------------------------------
  * @todo
  * - なし
@@ -35,7 +35,7 @@ import opentype from 'opentype.js';
 export function dumpRegisteredAllChar(fontPath) {
   const font = opentype.loadSync(fontPath);
   const chars = [];
-  for (const glyph of font.glyphs.glyphs) {
+  for (const glyph of Object.values(font.glyphs.glyphs)) {
     if (glyph.unicode !== undefined) {
       chars.push(String.fromCodePoint(glyph.unicode));
     }
@@ -56,7 +56,7 @@ export function dumpRegisteredAllChar(fontPath) {
 export function dumpExistDesignedAllChar(fontPath) {
   const font = opentype.loadSync(fontPath);
   const chars = [];
-  for (const glyph of font.glyphs.glyphs) {
+  for (const glyph of Object.values(font.glyphs.glyphs)) {
     if (glyph.unicode === undefined) {
       continue;
     }


### PR DESCRIPTION
## Summary
- fix iteration logic in `font_inspector.js`
- document usage of `font_inspector.js` in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68746c17eebc832fb1442737a047875a