### PR TITLE
Add spool serial tracking

### DIFF
--- a/3dp_lib/dashboard_data.js
+++ b/3dp_lib/dashboard_data.js
@@ -20,9 +20,9 @@
  * - {@link setStoredData}：storedData に値格納
  * - {@link getDisplayValue}：表示用値取得
  *
-* @version 1.390.496 (PR #225)
+* @version 1.390.756 (PR #344)
 * @since   1.390.193 (PR #86)
-* @lastModified 2025-06-28 12:00:48
+* @lastModified 2025-07-21 16:37:31
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -189,7 +189,8 @@ export function setCurrentHostname(host) {
  *   filamentPresets: Array<Object>,
  *   usageHistory: Array<Object>,
  *   filamentInventory: Array<Object>,
- *   currentSpoolId: string|null
+ *   currentSpoolId: string|null,
+ *   spoolSerialCounter: number
  * }}
  */
 export const monitorData = {
@@ -219,6 +220,11 @@ export const monitorData = {
   usageHistory: [],
   filamentInventory: [],
   currentSpoolId: null,
+  /**
+   * スプール通し番号の採番用カウンタ
+   * @type {number}
+   */
+  spoolSerialCounter: 0,
   temporaryBuffer: []
 };
 

--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -22,9 +22,9 @@
  * - {@link saveVideos}：動画一覧保存
  * - {@link jobsToRaw}：内部モデル→生データ変換
  *
-* @version 1.390.751 (PR #347)
+* @version 1.390.756 (PR #344)
 * @since   1.390.197 (PR #88)
-* @lastModified 2025-07-19 11:01:37
+* @lastModified 2025-07-21 16:37:31
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -526,6 +526,7 @@ export async function refreshHistory(
       if (!jobs[0].filamentInfo.some(info => info.spoolId === sp.id)) {
         jobs[0].filamentInfo.push({
           spoolId: sp.id,
+          serialNo: sp.serialNo,
           spoolName: sp.name,
           colorName: sp.colorName,
           filamentColor: sp.filamentColor,
@@ -792,6 +793,7 @@ export function renderHistoryTable(rawArray, baseUrl) {
     const spoolTexts = [];
     const countTexts = [];
     const remainTexts = [];
+    const changeTexts = [];
     spoolInfos.forEach((info, idx) => {
       const sp = getSpoolById(info.spoolId) || null;
       const mat = info.material || sp?.material || '';
@@ -809,10 +811,13 @@ export function renderHistoryTable(rawArray, baseUrl) {
       spoolTexts.push(text);
       countTexts.push(info.spoolCount ?? sp?.printCount ?? 0);
       remainTexts.push(info.expectedRemain ?? sp?.remainingLengthMm ?? 0);
+      const serial = info.serialNo ?? sp?.serialNo ?? '';
+      changeTexts.push(`🔄️ ${serial}`);
     });
     const spoolText = spoolTexts.join('<br>');
     const printCnt  = countTexts.join('<br>');
     const remainLen = remainTexts.join('<br>');
+    const changeText = changeTexts.join('<br>');
     const tr = document.createElement("tr");
     tr.innerHTML = `
       <td>
@@ -846,6 +851,7 @@ export function renderHistoryTable(rawArray, baseUrl) {
       <td>${md5}</td>
       <td>${videoLink}</td>
       <td>${spoolText}</td>
+      <td data-key="spoolchange">${changeText}</td>
       <td data-key="spoolcount">${printCnt}</td>
       <td data-key="remain">${remainLen}</td>
     `;

--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -27,9 +27,9 @@
  * - {@link finalizeFilamentUsage}：使用量確定
  * - {@link autoCorrectCurrentSpool}：履歴から残量補正
  *
-* @version 1.390.746 (PR #343)
+* @version 1.390.756 (PR #344)
 * @since   1.390.193 (PR #86)
-* @lastModified 2025-07-16 11:28:50
+* @lastModified 2025-07-21 16:37:31
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -213,9 +213,11 @@ export function setCurrentSpoolId(id) {
 export function addSpool(data) {
   // UI から渡されるデータを元に初期値を設定したスプールオブジェクトを生成する
   const id = genId();
+  const serialNo = ++monitorData.spoolSerialCounter;
   const spool = {
     id,
     spoolId: id,
+    serialNo,
     presetId: data.presetId || null,
     modelId: data.modelId || data.presetId || null,
     name: data.name || "",
@@ -347,6 +349,7 @@ function logSpoolChange(spool, printId = "") {
   monitorData.usageHistory.push({
     usageId: Date.now(),
     spoolId: spool.id,
+    spoolSerial: spool.serialNo,
     startPrintID: printId,
     startLength: spool.startLength,
     startedAt: spool.startedAt
@@ -367,6 +370,7 @@ function logUsage(spool, lengthMm, jobId) {
   monitorData.usageHistory.push({
     usageId: Date.now(),
     spoolId: spool.id,
+    spoolSerial: spool.serialNo,
     jobId,
     startedAt: Date.now(),
     usedLength: lengthMm,
@@ -434,6 +438,7 @@ export function reserveFilament(lengthMm, jobId = "") {
     if (!entry.filamentInfo.some(info => info.spoolId === s.id)) {
       entry.filamentInfo.push({
         spoolId: s.id,
+        serialNo: s.serialNo,
         spoolName: s.name,
         colorName: s.colorName,
         filamentColor: s.filamentColor,
@@ -489,6 +494,7 @@ export function finalizeFilamentUsage(lengthMm, jobId = "") {
     entry.filamentInfo ??= [];
     entry.filamentInfo.push({
       spoolId: s.id,
+      serialNo: s.serialNo,
       spoolName: s.name,
       colorName: s.colorName,
       filamentColor: s.filamentColor,

--- a/3dp_monitor.css
+++ b/3dp_monitor.css
@@ -1002,6 +1002,7 @@ input:checked + .slider:before {
 #print-history-table td[data-key="pausetime"],
 #print-history-table td[data-key="usagetime"],
 #print-history-table td[data-key="usagematerial"],
+#print-history-table td[data-key="spoolchange"],
 #print-history-table td[data-key="spoolcount"],
 #print-history-table td[data-key="remain"],
 #file-list-table td[data-key="number"],

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -781,12 +781,13 @@
                 <th data-key="filemd5">ファイルMD5</th>
                 <th data-key="video">動画</th>
                 <th data-key="spool">フィラメント情報</th>
+                <th data-key="spoolchange">交換</th>
                 <th data-key="spoolcount">同一リール印刷数</th>
                 <th data-key="remain">想定残量</th>
             </tr>
           </thead>
           <tbody>
-          <tr><td colspan='21'>データ読み込み待ち</td></tr>
+          <tr><td colspan='22'>データ読み込み待ち</td></tr>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
## Summary
- assign unique serial numbers to spools
- persist serial numbers in storage and usage logs
- display spool exchange info in print history
- update print history table with exchange column

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ded227198832fbbf962aac6db4218