### PR TITLE
Add spool assign feature for history

### DIFF
--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -22,9 +22,9 @@
  * - {@link saveVideos}：動画一覧保存
  * - {@link jobsToRaw}：内部モデル→生データ変換
  *
-* @version 1.390.756 (PR #344)
-* @since   1.390.197 (PR #88)
-* @lastModified 2025-07-21 16:37:31
+ * @version 1.390.758 (PR #350)
+ * @since   1.390.197 (PR #88)
+ * @lastModified 2025-07-05 15:00:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -53,7 +53,7 @@ import {
 } from "./dashboard_spool.js";
 import { sendCommand, fetchStoredData, getDeviceIp } from "./dashboard_connection.js";
 import { showVideoOverlay } from "./dashboard_video_player.js";
-import { showSpoolDialog } from "./dashboard_spool_ui.js";
+import { showSpoolDialog, showSpoolSelectDialog } from "./dashboard_spool_ui.js";
 import { PRINT_STATE_CODE } from "./dashboard_ui_mapping.js";
 
 /** 履歴の最大件数 */
@@ -794,6 +794,11 @@ export function renderHistoryTable(rawArray, baseUrl) {
     const countTexts = [];
     const remainTexts = [];
     const changeTexts = [];
+    if (spoolInfos.length === 0) {
+      spoolTexts.push(
+        `<button class="spool-assign" data-id="${raw.id}">スプール指定</button>`
+      );
+    }
     spoolInfos.forEach((info, idx) => {
       const sp = getSpoolById(info.spoolId) || null;
       const mat = info.material || sp?.material || '';
@@ -881,6 +886,23 @@ export function renderHistoryTable(rawArray, baseUrl) {
       if (res) {
         updateSpool(sp.id, res);
       }
+    });
+    tr.querySelector(".spool-assign")?.addEventListener("click", async () => {
+      const sp = await showSpoolSelectDialog({ title: "スプール指定" });
+      if (!sp) return;
+      raw.filamentInfo = [
+        {
+          spoolId: sp.id,
+          serialNo: sp.serialNo,
+          spoolName: sp.name,
+          colorName: sp.colorName,
+          filamentColor: sp.filamentColor,
+          material: sp.material,
+          spoolCount: sp.printCount,
+          expectedRemain: sp.remainingLengthMm
+        }
+      ];
+      updateHistoryList([raw], baseUrl);
     });
   });
 

--- a/3dp_lib/dashboard_spool_ui.js
+++ b/3dp_lib/dashboard_spool_ui.js
@@ -12,11 +12,12 @@
  * - 材料入力の計算補助
  *
  * 【公開関数一覧】
- * - なし（DOMContentLoaded で自動初期化）
+ * - {@link showSpoolDialog}：スプール編集ダイアログ
+ * - {@link showSpoolSelectDialog}：スプール選択ダイアログ
  *
- * @version 1.390.317 (PR #143)
+ * @version 1.390.758 (PR #350)
  * @since   1.390.193 (PR #86)
- * @lastModified 2025-06-19 22:38:18
+ * @lastModified 2025-07-05 15:00:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -150,6 +151,61 @@ function showSpoolDialog({ title = "", spool = {} }) {
     });
 
     function cleanup() { overlay.remove(); }
+  });
+}
+
+/**
+ * スプール選択ダイアログを表示する。
+ *
+ * @function showSpoolSelectDialog
+ * @param {Object} [opts]
+ * @param {string} [opts.title=""] - ダイアログタイトル
+ * @param {Array<Object>} [opts.spools=getSpools()] - 選択候補のスプール一覧
+ * @returns {Promise<Object|null>} 選択されたスプール、キャンセル時は null
+ */
+function showSpoolSelectDialog({ title = "", spools = getSpools() } = {}) {
+  injectStyles();
+  return new Promise(resolve => {
+    const overlay = document.createElement("div");
+    overlay.className = "spool-dialog-overlay";
+    const dlg = document.createElement("div");
+    dlg.className = "spool-dialog";
+    overlay.appendChild(dlg);
+
+    const h3 = document.createElement("h3");
+    h3.textContent = title;
+    dlg.appendChild(h3);
+
+    const select = document.createElement("select");
+    spools.forEach(sp => {
+      const opt = document.createElement("option");
+      opt.value = sp.id;
+      opt.textContent = `${sp.name} (${sp.remainingLengthMm}/${sp.totalLengthMm} mm)`;
+      select.appendChild(opt);
+    });
+    dlg.appendChild(select);
+
+    const btns = document.createElement("div");
+    btns.className = "spool-dialog-buttons";
+    const btnOk = document.createElement("button");
+    btnOk.textContent = "OK";
+    const btnCancel = document.createElement("button");
+    btnCancel.textContent = "キャンセル";
+    btns.append(btnOk, btnCancel);
+    dlg.appendChild(btns);
+
+    document.body.appendChild(overlay);
+
+    btnOk.addEventListener("click", () => {
+      const id = select.value;
+      const sp = spools.find(s => String(s.id) === String(id)) || null;
+      overlay.remove();
+      resolve(sp);
+    });
+    btnCancel.addEventListener("click", () => {
+      overlay.remove();
+      resolve(null);
+    });
   });
 }
 
@@ -351,4 +407,4 @@ function initSpoolUI() {
   render();
 }
 
-export { showSpoolDialog };
+export { showSpoolDialog, showSpoolSelectDialog };


### PR DESCRIPTION
## Summary
- extend spool UI with selectable spool list dialog
- enable fixing missing spool info from print history

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ded96b4d8832fa61fc07af2acc2cd