### PR TITLE
Expand print history retention to 1500 entries

### DIFF
--- a/3dp_lib/dashboard_filemanager.js
+++ b/3dp_lib/dashboard_filemanager.js
@@ -13,29 +13,19 @@
  * 【公開関数一覧】
  * - {@link FileManager}：履歴ロード・保存のユーティリティ
  *
- * @version 1.390.766 (PR #353)
+ * @version 1.390.767 (PR #353)
  * @since   1.390.193 (PR #86)
- * @lastModified 2025-08-07 22:07:09
+ * @lastModified 2025-08-07 22:24:00
  * -----------------------------------------------------------
  * @todo
  * - none
  */
 
 import { currentHostname } from "./dashboard_data.js";
+import { MAX_PRINT_HISTORY } from "./dashboard_storage.js";
 
 const containerId = 'filemanager-history';
 const STORAGE_KEY_PREFIX = '3dp-filemanager-history-';
-/**
- * 履歴保存の最大件数
- *
- * ファイルマネージャが localStorage に保持する履歴数の上限。
- * 従来は 150 件であったが、より長期間の履歴を確認できるよう
- * 1500 件まで保存できるようにする。
- *
- * @constant {number}
- */
-const MAX_HISTORY = 1500;
-
 /**
  * @typedef {Object} HistoryEntry
  * @property {number} id             ジョブID
@@ -142,7 +132,7 @@ export const FileManager = {
     });
     const mergedHistory = Array.from(histMap.values())
       .sort((a, b) => b.id - a.id)
-      .slice(0, MAX_HISTORY);
+      .slice(0, MAX_PRINT_HISTORY);
 
     const videoMap = new Map(stored.elapseVideoList.map(v => [v.id, v]));
     videos.forEach(v => {

--- a/3dp_lib/dashboard_filemanager.js
+++ b/3dp_lib/dashboard_filemanager.js
@@ -13,9 +13,9 @@
  * 【公開関数一覧】
  * - {@link FileManager}：履歴ロード・保存のユーティリティ
  *
- * @version 1.390.348 (PR #155)
+ * @version 1.390.766 (PR #353)
  * @since   1.390.193 (PR #86)
- * @lastModified 2025-06-20 14:50:39
+ * @lastModified 2025-08-07 22:07:09
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -25,7 +25,16 @@ import { currentHostname } from "./dashboard_data.js";
 
 const containerId = 'filemanager-history';
 const STORAGE_KEY_PREFIX = '3dp-filemanager-history-';
-const MAX_HISTORY = 150;
+/**
+ * 履歴保存の最大件数
+ *
+ * ファイルマネージャが localStorage に保持する履歴数の上限。
+ * 従来は 150 件であったが、より長期間の履歴を確認できるよう
+ * 1500 件まで保存できるようにする。
+ *
+ * @constant {number}
+ */
+const MAX_HISTORY = 1500;
 
 /**
  * @typedef {Object} HistoryEntry

--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -22,9 +22,9 @@
  * - {@link saveVideos}：動画一覧保存
  * - {@link jobsToRaw}：内部モデル→生データ変換
  *
- * @version 1.390.758 (PR #350)
+ * @version 1.390.766 (PR #353)
  * @since   1.390.197 (PR #88)
- * @lastModified 2025-07-05 15:00:00
+ * @lastModified 2025-08-07 22:07:09
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -56,8 +56,17 @@ import { showVideoOverlay } from "./dashboard_video_player.js";
 import { showSpoolDialog, showSpoolSelectDialog } from "./dashboard_spool_ui.js";
 import { PRINT_STATE_CODE } from "./dashboard_ui_mapping.js";
 
-/** 履歴の最大件数 */
-export const MAX_HISTORY = 150;
+/**
+ * 印刷履歴の最大保持件数
+ *
+ * 監視対象プリンタから取得した印刷履歴を保持する際の
+ * 上限件数を定義する。既定値の 150 件では過去の履歴が
+ * 早期に削除されるため、より多く参照できるよう 1500 件
+ * まで保持するよう拡張する。
+ *
+ * @constant {number}
+ */
+export const MAX_HISTORY = 1500;
 
 /**
  * 履歴マージ時にゼロ値を無視したいフィールド一覧

--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -22,9 +22,9 @@
  * - {@link saveVideos}：動画一覧保存
  * - {@link jobsToRaw}：内部モデル→生データ変換
  *
- * @version 1.390.766 (PR #353)
- * @since   1.390.197 (PR #88)
- * @lastModified 2025-08-07 22:07:09
+* @version 1.390.767 (PR #353)
+* @since   1.390.197 (PR #88)
+* @lastModified 2025-08-07 22:24:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -37,7 +37,8 @@ import {
   loadPrintHistory,
   savePrintHistory,
   loadPrintVideos,
-  savePrintVideos
+  savePrintVideos,
+  MAX_PRINT_HISTORY
 } from "./dashboard_storage.js";
 
 import { formatEpochToDateTime, formatDuration } from "./dashboard_utils.js";
@@ -55,18 +56,6 @@ import { sendCommand, fetchStoredData, getDeviceIp } from "./dashboard_connectio
 import { showVideoOverlay } from "./dashboard_video_player.js";
 import { showSpoolDialog, showSpoolSelectDialog } from "./dashboard_spool_ui.js";
 import { PRINT_STATE_CODE } from "./dashboard_ui_mapping.js";
-
-/**
- * 印刷履歴の最大保持件数
- *
- * 監視対象プリンタから取得した印刷履歴を保持する際の
- * 上限件数を定義する。既定値の 150 件では過去の履歴が
- * 早期に削除されるため、より多く参照できるよう 1500 件
- * まで保持するよう拡張する。
- *
- * @constant {number}
- */
-export const MAX_HISTORY = 1500;
 
 /**
  * 履歴マージ時にゼロ値を無視したいフィールド一覧
@@ -219,7 +208,7 @@ export function parseRawHistoryList(rawArray, baseUrl, host = currentHostname) {
     )
     .map(r => parseRawHistoryEntry(r, baseUrl, host))
     .sort((a, b) => b.id - a.id)
-    .slice(0, MAX_HISTORY);
+    .slice(0, MAX_PRINT_HISTORY);
 }
 
 // ---------------------- ストレージ操作 ----------------------
@@ -514,7 +503,7 @@ export async function refreshHistory(
   });
   const jobs = Array.from(mergedMap.values())
     .sort((a, b) => Number(b.id) - Number(a.id))
-    .slice(0, MAX_HISTORY);
+    .slice(0, MAX_PRINT_HISTORY);
 
 
   const state = Number(machine?.runtimeData?.state ?? 0);
@@ -573,7 +562,7 @@ export async function refreshHistory(
   });
   const mergedRaw = Array.from(rawMap.values())
     .sort((a, b) => b.id - a.id)
-    .slice(0, MAX_HISTORY);
+    .slice(0, MAX_PRINT_HISTORY);
   renderHistoryTable(mergedRaw, baseUrl);
 }
 
@@ -651,7 +640,7 @@ export function updateHistoryList(
   });
   const jobs = Array.from(mergedMap.values())
     .sort((a, b) => Number(b.id) - Number(a.id))
-    .slice(0, MAX_HISTORY);
+    .slice(0, MAX_PRINT_HISTORY);
 
   const videoMap = loadVideos();
   jobs.forEach(j => {

--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -27,9 +27,9 @@
  * - {@link finalizeFilamentUsage}：使用量確定
  * - {@link autoCorrectCurrentSpool}：履歴から残量補正
  *
-* @version 1.390.764 (PR #352)
-* @since   1.390.193 (PR #86)
-* @lastModified 2025-07-28 22:48:26
+ * @version 1.390.767 (PR #353)
+ * @since   1.390.193 (PR #86)
+ * @lastModified 2025-08-07 22:24:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -42,7 +42,7 @@ import {
   currentHostname,
   setStoredData
 } from "./dashboard_data.js";
-import { saveUnifiedStorage } from "./dashboard_storage.js";
+import { saveUnifiedStorage, trimUsageHistory } from "./dashboard_storage.js";
 import { consumeInventory } from "./dashboard_filament_inventory.js";
 import { updateStoredDataToDOM } from "./dashboard_ui.js";
 import { updateHistoryList } from "./dashboard_printmanager.js";
@@ -373,6 +373,7 @@ function logSpoolChange(spool, printId = "") {
     startLength: spool.startLength,
     startedAt: spool.startedAt
   });
+  trimUsageHistory();
   saveUnifiedStorage();
 }
 
@@ -395,6 +396,7 @@ function logUsage(spool, lengthMm, jobId) {
     usedLength: lengthMm,
     currentLength: spool.remainingLengthMm
   });
+  trimUsageHistory();
   saveUnifiedStorage();
 }
 
@@ -417,6 +419,7 @@ export function addUsageSnapshot(spool, jobId, remainMm) {
     currentLength: remainMm,
     isSnapshot: true
   });
+  trimUsageHistory();
   saveUnifiedStorage();
 }
 

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -26,13 +26,13 @@
  * - {@link loadPrintCurrent}：現ジョブ読込
  * - {@link savePrintCurrent}：現ジョブ保存
  *
-* @version 1.390.766 (PR #353)
+* @version 1.390.767 (PR #353)
 * @since   1.390.193 (PR #86)
-* @lastModified 2025-08-07 22:07:09
+* @lastModified 2025-08-07 22:24:00
  * -----------------------------------------------------------
  * @todo
  * - none
-*/
+ */
 
 "use strict";
 
@@ -114,7 +114,28 @@ const STORAGE_KEY = "3dp-monitor_1.400";
  *
  * @constant {number}
  */
-const MAX_HISTORY = 1500;
+export const MAX_PRINT_HISTORY = 1500;
+
+/**
+ * フィラメント使用履歴の最大保持件数
+ *
+ * 1 印刷で最大 2 リールまで使用する想定のため、
+ * 4500 件を上限として保持する。
+ *
+ * @constant {number}
+ */
+export const MAX_USAGE_HISTORY = 4500;
+
+/**
+ * フィラメント使用履歴配列が上限を超えた場合に古い記録を削除する。
+ *
+ * @returns {void}
+ */
+export function trimUsageHistory() {
+  if (monitorData.usageHistory.length > MAX_USAGE_HISTORY) {
+    monitorData.usageHistory = monitorData.usageHistory.slice(-MAX_USAGE_HISTORY);
+  }
+}
 
 /**
  * monitorData 全体を JSON にシリアライズし、localStorage に保存する。
@@ -186,6 +207,7 @@ export function restoreUnifiedStorage() {
         monitorData.filamentSpools = data.filamentSpools.map(sp => applySpoolDefaults(sp));
       if (Array.isArray(data.usageHistory))
         monitorData.usageHistory = data.usageHistory;
+      trimUsageHistory();
       if (Array.isArray(data.filamentInventory))
         monitorData.filamentInventory = data.filamentInventory;
       if (Array.isArray(data.filamentPresets))
@@ -406,7 +428,7 @@ export function savePrintHistory(history) {
   if (!host) return;
   ensureMachineData(host);
   monitorData.machines[host].printStore.history =
-    history.slice(0, MAX_HISTORY);
+    history.slice(0, MAX_PRINT_HISTORY);
   saveUnifiedStorage();
 }
 

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -26,9 +26,9 @@
  * - {@link loadPrintCurrent}：現ジョブ読込
  * - {@link savePrintCurrent}：現ジョブ保存
  *
-* @version 1.390.756 (PR #344)
+* @version 1.390.766 (PR #353)
 * @since   1.390.193 (PR #86)
-* @lastModified 2025-07-21 16:37:31
+* @lastModified 2025-08-07 22:07:09
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -105,8 +105,16 @@ function pushLog(msg, isErr = false) {
 
 /** localStorage へ保存するキー名 */
 const STORAGE_KEY = "3dp-monitor_1.400";
-/** 印刷履歴の最大保持件数 */
-const MAX_HISTORY = 250;
+/**
+ * 印刷履歴の最大保持件数
+ *
+ * localStorage に保存する印刷履歴配列の上限を定める。
+ * これまでは 250 件までの保持であったが、過去の履歴を
+ * より多く参照できるよう 1500 件まで保存できるようにする。
+ *
+ * @constant {number}
+ */
+const MAX_HISTORY = 1500;
 
 /**
  * monitorData 全体を JSON にシリアライズし、localStorage に保存する。


### PR DESCRIPTION
## Summary
- Extend print history retention in dashboard_printmanager to 1500 entries
- Persist up to 1500 file manager history records
- Allow local storage to keep 1500 print history entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894a3eb3628832fa757349d1c57f741