### PR TITLE
Add multi-printer dual-pane dashboard support

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -16,10 +16,11 @@
  * - {@link restorePrintResume}：印刷再開用データを復元
  * - {@link persistPrintResume}：印刷再開用データを保存
  * - {@link initializeAutoSave}：自動保存タイマーを開始
+ * - {@link getPaneEl}：ペインスコープ付き要素取得ヘルパー
  *
-* @version 1.390.651 (PR #302)
+* @version 1.400.652 (PR #303)
 * @since   1.390.193 (PR #86)
-* @lastModified 2025-07-04 09:50:37
+* @lastModified 2025-07-04 10:30:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -91,8 +92,23 @@ import {
 } from "./dashboard_send_command.js";
 
 let filamentPreview = null;
+
+// ---------------------------------------------------------------------------
+// getPaneEl: ペインスコープ付き要素取得ヘルパー
+// ---------------------------------------------------------------------------
 /**
- * @fileoverview
+ * ペインインデックスに応じた要素を取得します。
+ * ID を `p${paneIndex}-${id}` に変換して getElementById を呼びます。
+ *
+ * @param {string} id            - 接頭辞なしの元 ID
+ * @param {number} [paneIndex=1] - ペイン番号 (1 または 2)
+ * @returns {HTMLElement|null}
+ */
+export function getPaneEl(id, paneIndex = 1) {
+  return document.getElementById(`p${paneIndex}-${id}`);
+}
+
+/**
  * ダッシュボードを初期化します。
  *
  * @param {object} hooks
@@ -103,6 +119,7 @@ let filamentPreview = null;
  *                                                        接続状態変化時に呼び出す
  * @param {(data: any) => void} hooks.onMessage            メッセージ受信時に呼び出す
  * @param {object} hooks.notificationManager               通知マネージャ
+ * @param {number} [hooks.paneIndex=1]                     ペイン番号 (1 or 2)
  */
 export function initializeDashboard({
   onConnect,
@@ -110,34 +127,37 @@ export function initializeDashboard({
   onCameraError,
   onConnectionStateChange,
   onMessage,
-  notificationManager
+  notificationManager,
+  paneIndex = 1
 }) {
-  // (1) ストレージ復元／マイグレーション
-  restoreLegacyStoredData();
-  cleanupLegacy();
-  restoreUnifiedStorage();
-  // 読み込んだストレージ内容を通知マネージャへ反映
-  notificationManager.loadSettings();
-  if (!monitorData.filamentSpools.length) {
-    const preset = FILAMENT_PRESETS.find(
-      p => p.presetId === "preset-unknown-somename-somecolor"
-    );
-    if (preset) {
-      const sp = addSpoolFromPreset(preset);
-      setCurrentSpoolId(sp.id);
-      saveUnifiedStorage();
+  // (1) ストレージ復元／マイグレーション（ペイン1のみ実行）
+  if (paneIndex === 1) {
+    restoreLegacyStoredData();
+    cleanupLegacy();
+    restoreUnifiedStorage();
+    // 読み込んだストレージ内容を通知マネージャへ反映
+    notificationManager.loadSettings();
+    if (!monitorData.filamentSpools.length) {
+      const preset = FILAMENT_PRESETS.find(
+        p => p.presetId === "preset-unknown-somename-somecolor"
+      );
+      if (preset) {
+        const sp = addSpoolFromPreset(preset);
+        setCurrentSpoolId(sp.id);
+        saveUnifiedStorage();
+      }
     }
-  }
 
-  // (2) ホスト未定義ならプレースホルダ設定
-  if (!currentHostname) {
-    setCurrentHostname(PLACEHOLDER_HOSTNAME);
+    // (2) ホスト未定義ならプレースホルダ設定
+    if (!currentHostname) {
+      setCurrentHostname(PLACEHOLDER_HOSTNAME);
+    }
   }
 
   // (3) プレビュー復元＆初期化
   restoreXYPreviewState();
-  initXYPreview();
-  const fpMount = document.getElementById("filament-preview");
+  initXYPreview(paneIndex);
+  const fpMount = getPaneEl("filament-preview", paneIndex);
   if (fpMount) {
     const machine = monitorData.machines[currentHostname] || {};
     const spool   = getCurrentSpool();
@@ -191,33 +211,31 @@ export function initializeDashboard({
   }
 
   // ステージ回転ボタン
-  document.getElementById("btn-stage-flat")?.addEventListener("click", setFlatView);
-  document.getElementById("btn-stage-45")?.addEventListener("click", setTilt45View);
-  document.getElementById("btn-stage-65-72")?.addEventListener("click", setObliqueView);
-  document.getElementById("btn-stage-spin")?.addEventListener("click", toggleZSpin);
+  getPaneEl("btn-stage-flat",  paneIndex)?.addEventListener("click", setFlatView);
+  getPaneEl("btn-stage-45",    paneIndex)?.addEventListener("click", setTilt45View);
+  getPaneEl("btn-stage-65-72", paneIndex)?.addEventListener("click", setObliqueView);
+  getPaneEl("btn-stage-spin",  paneIndex)?.addEventListener("click", toggleZSpin);
 
   // (4) ログ描画・自動スクロール設定
-  const logBox = document.getElementById("log");
+  const logBox = getPaneEl("log", paneIndex);
   initLogAutoScroll(logBox);
   initLogRenderer(logBox);
 
   // (5) 接続／切断ボタンバインド
-  const ipInput    = document.getElementById("destination-input");
-  const acb        = document.getElementById("auto-connect-toggle");
-  const camToggle  = document.getElementById("camera-toggle-title");
-  const btnConnect = document.getElementById("connect-button");
-  const btnDisc    = document.getElementById("disconnect-button");
-
+  const ipInput    = getPaneEl("destination-input",   paneIndex);
+  const acb        = getPaneEl("auto-connect-toggle", paneIndex);
+  const camToggle  = getPaneEl("camera-toggle-title", paneIndex);
+  const btnConnect = getPaneEl("connect-button",      paneIndex);
+  const btnDisc    = getPaneEl("disconnect-button",   paneIndex);
 
   // ここで monitorData.appSettings から UI に反映
-  ipInput.value     = monitorData.appSettings.wsDest        || "";
-  acb.checked       = monitorData.appSettings.autoConnect;
-  camToggle.checked = monitorData.appSettings.cameraToggle;
-
+  if (ipInput)   ipInput.value     = monitorData.appSettings.wsDest     || "";
+  if (acb)       acb.checked       = monitorData.appSettings.autoConnect;
+  if (camToggle) camToggle.checked = monitorData.appSettings.cameraToggle;
 
   // 接続ボタンクリック → IPチェック→保存→接続
   btnConnect?.addEventListener("click", () => {
-    const ip = ipInput.value.trim();
+    const ip = ipInput?.value.trim();
     if (!ip) {
       showAlert("接続先のIPアドレスを設定し、接続を押してください", "warn");
       return;
@@ -233,139 +251,150 @@ export function initializeDashboard({
   btnDisc?.addEventListener("click", onDisconnect);
 
   // (6) ログコピー・クリア操作
-  document.getElementById("copy-all-notification-button")
+  getPaneEl("copy-all-notification-button",  paneIndex)
     ?.addEventListener("click", e => copyLogsToClipboard(logManager.getNotifications(), null, e.currentTarget));
-  document.getElementById("copy-last-50-notification-button")
+  getPaneEl("copy-last-50-notification-button", paneIndex)
     ?.addEventListener("click", e => copyLogsToClipboard(logManager.getNotifications(), 50, e.currentTarget));
-  document.getElementById("clear-notification-logs-button")
+  getPaneEl("clear-notification-logs-button", paneIndex)
     ?.addEventListener("click", () => {
       logManager.clear();
       flushNotificationLogsToDom();
     });
-  document.getElementById("copy-all-button")
+  getPaneEl("copy-all-button",  paneIndex)
     ?.addEventListener("click", e => copyLogsToClipboard(logManager.getAll(), null, e.currentTarget));
-  document.getElementById("copy-last-50-button")
+  getPaneEl("copy-last-50-button", paneIndex)
     ?.addEventListener("click", e => copyLogsToClipboard(logManager.getAll(), 50, e.currentTarget));
-  document.getElementById("copy-storeddata-button")
+  getPaneEl("copy-storeddata-button", paneIndex)
     ?.addEventListener("click", copyStoredDataToClipboard);
 
   // (7) カメラトグル制御
-  camToggle.addEventListener("change", () => {
-    monitorData.appSettings.cameraToggle = camToggle.checked;
-    saveUnifiedStorage();
-    if (camToggle.checked) startCameraStream();
-    else                    stopCameraStream();
-  });
+  if (camToggle) {
+    camToggle.addEventListener("change", () => {
+      monitorData.appSettings.cameraToggle = camToggle.checked;
+      saveUnifiedStorage();
+      if (camToggle.checked) startCameraStream(undefined, paneIndex);
+      else                    stopCameraStream(undefined, paneIndex);
+    });
+  }
 
   // (8) 自動接続トグル
-  acb.addEventListener("change", () => {
-    monitorData.appSettings.autoConnect = acb.checked;
-    saveUnifiedStorage();
-    pushLog(`自動接続を ${acb.checked ? "ON" : "OFF"} にしました`, "info");
-    showAlert (`自動接続を ${acb.checked ? "ON" : "OFF"} にしました`, "info");
-  });
-
+  if (acb) {
+    acb.addEventListener("change", () => {
+      monitorData.appSettings.autoConnect = acb.checked;
+      saveUnifiedStorage();
+      pushLog(`自動接続を ${acb.checked ? "ON" : "OFF"} にしました`, "info");
+      showAlert(`自動接続を ${acb.checked ? "ON" : "OFF"} にしました`, "info");
+    });
+  }
 
   // (9) 通知設定パネル初期化
-  const notifBody = document.getElementById("notification-panel-body");
+  const notifBody = getPaneEl("notification-panel-body", paneIndex);
   if (notifBody && notificationManager && typeof notificationManager.initSettingsUI === "function") {
     notificationManager.initSettingsUI(notifBody);
   }
 
   // (10) 温度グラフ初期化＆過去データ読み込み
-  initTemperatureGraph();
+  const canvasEl = getPaneEl("temp-graph-canvas", paneIndex);
+  initTemperatureGraph({}, canvasEl);
   updateTemperatureGraphFromStoredData(
-    monitorData.machines[currentHostname].storedData
+    monitorData.machines[currentHostname].storedData,
+    canvasEl
   );
 
   // (10.5) 温度グラフのズームリセットボタン
-  document.getElementById("temp-graph-reset-button")
-    ?.addEventListener("click", resetTemperatureGraphView);
+  getPaneEl("temp-graph-reset-button", paneIndex)
+    ?.addEventListener("click", () => resetTemperatureGraphView(canvasEl));
 
-  // (11) ページロード時の自動接続
-  // 起動時は接続先が設定されているときだけ AutoConnect
-  if (monitorData.appSettings.autoConnect && monitorData.appSettings.wsDest) {
-    setTimeout(onConnect, 1500);
-  } else {
-    showAlert("接続先欄に機器アドレスを入力して、接続を押すと監視がはじまります","warn");
+  // (11) ページロード時の自動接続（ペイン1のみ）
+  if (paneIndex === 1) {
+    if (monitorData.appSettings.autoConnect && monitorData.appSettings.wsDest) {
+      setTimeout(onConnect, 1500);
+    } else {
+      showAlert("接続先欄に機器アドレスを入力して、接続を押すと監視がはじまります", "warn");
+    }
   }
-  
+
   // (12) ページロード時のカメラ起動は廃止
   // WebSocket 接続確立時に自動開始されるためここでは実行しない
 
   // (12.5) 保存済みの履歴と現在印刷を表示
-  const savedJobs = printManager.loadHistory();
-  if (savedJobs.length) {
-    const baseUrl = monitorData.appSettings.wsDest
-      ? `http://${monitorData.appSettings.wsDest}:80`
-      : "";
-    const raw = printManager.jobsToRaw(savedJobs);
-    printManager.renderHistoryTable(raw, baseUrl);
+  if (paneIndex === 1) {
+    const savedJobs = printManager.loadHistory();
+    if (savedJobs.length) {
+      const baseUrl = monitorData.appSettings.wsDest
+        ? `http://${monitorData.appSettings.wsDest}:80`
+        : "";
+      const raw = printManager.jobsToRaw(savedJobs);
+      printManager.renderHistoryTable(raw, baseUrl);
+    }
   }
   printManager.renderPrintCurrent(
-    document.getElementById("print-current-container")
+    getPaneEl("print-current-container", paneIndex)
   );
 
-  // (13) ファイルマネージャ初期化
-  FileManager.init();
+  // (13) ファイルマネージャ初期化（ペイン1のみ）
+  if (paneIndex === 1) {
+    FileManager.init();
+  }
 
   // (14) 印刷履歴手動リフレッシュ
-  const historyBtn = document.getElementById("history-refresh-btn");
+  const historyBtn = getPaneEl("history-refresh-btn", paneIndex);
   if (historyBtn) {
     historyBtn.addEventListener("click", () => {
-      document.getElementById("btn-history-list")?.click();
+      getPaneEl("btn-history-list", paneIndex)?.click();
     });
   }
 
   // (14.5) コマンドパレット側ボタン → 上部クイックボタンの代理クリック
   const aliasClick = (src, dest) => {
-    const s = document.getElementById(src);
-    const d = document.getElementById(dest);
+    const s = getPaneEl(src,  paneIndex);
+    const d = getPaneEl(dest, paneIndex);
     if (s && d) s.addEventListener("click", () => d.click());
   };
-  aliasClick("btn-stop-print-cmd",   "btn-stop-print");
-  aliasClick("btn-pause-print-cmd",  "btn-pause-print");
-  aliasClick("btn-resume-print-cmd", "btn-resume-print");
-  aliasClick("btn-history-list-cmd","btn-history-list");
-  aliasClick("btn-file-list-cmd",  "btn-file-list");
+  aliasClick("btn-stop-print-cmd",    "btn-stop-print");
+  aliasClick("btn-pause-print-cmd",   "btn-pause-print");
+  aliasClick("btn-resume-print-cmd",  "btn-resume-print");
+  aliasClick("btn-history-list-cmd",  "btn-history-list");
+  aliasClick("btn-file-list-cmd",     "btn-file-list");
 
   printManager.initHistoryTabs();
 
   // (15) ファイルアップロード初期化
   printManager.setupUploadUI();
 
-  // (16) 通知コンテナ初期化（notificationManager 用）
-  if (!document.querySelector(".notification-container")) {
+  // (16) 通知コンテナ確認
+  if (!getPaneEl("notification-container", paneIndex)) {
     const container = document.createElement("div");
     container.className = "notification-container";
+    container.id = `p${paneIndex}-notification-container`;
     document.body.appendChild(container);
   }
 
   // (17) 初期状態（切断）の UI 表示を整える
-  const cancelBtn = document.getElementById("camera-cancel-button");
+  const cancelBtn = getPaneEl("camera-cancel-button", paneIndex);
   cancelBtn?.addEventListener("click", () => {
-    stopCameraStream();
+    stopCameraStream(undefined, paneIndex);
   });
-  updateConnectionUI("disconnected");
-  setupPrinterUI();
+  updateConnectionUI("disconnected", {}, undefined, paneIndex);
+  setupPrinterUI(paneIndex);
 
-  // (18) 時間計算用変数自動保存
-  initializeAutoSave();
+  // (18) 時間計算用変数自動保存（ペイン1のみ）
+  if (paneIndex === 1) {
+    initializeAutoSave();
+  }
 
   // (19) JSONコマンド送信機能
-  initSendRawJson();
-  initSendGcode();
-  initTestRawJson();
-  initPauseHome();
-  initXYUnlock();
+  initSendRawJson(paneIndex);
+  initSendGcode(paneIndex);
+  initTestRawJson(paneIndex);
+  initPauseHome(paneIndex);
+  initXYUnlock(paneIndex);
 }
 
 // ────────────── 印刷再開データの復元／永続化 ──────────────
 
 /**
  * @constant {string[]}
- * @description
- * restorePrintResume / persistPrintResume の両関数で使うキー一覧
  */
 
 // 印刷再開用に保存したいキー
@@ -421,15 +450,11 @@ export function restorePrintResume(currentPrintId = null) {
 
   persistKeys.forEach(key => {
     const raw = localStorage.getItem(`pd_${host}_${key}`);
-    if (raw == null) return;  // データなし
+    if (raw == null) return;
 
     try {
-      // JSON パースして storedData にセット（rawValue／computedValue 両方に流し込む）
       const value = JSON.parse(raw);
-
-      // 第3引数 true を渡すことで rawValue にもセットします
       setStoredData(key, value, true);
-
     } catch (e) {
       console.warn(`restorePrintResume: '${key}' の JSON パースに失敗しました`, e);
     }
@@ -481,7 +506,6 @@ export function persistPrintResume() {
     if (entry?.rawValue != null) {
       localStorage.setItem(storageKey, JSON.stringify(entry.rawValue));
     } else {
-      // 該当データがない場合はキーを消しておく
       localStorage.removeItem(`pd_${host}_${key}`);
     }
   });
@@ -515,22 +539,15 @@ export function persistPrintResume() {
   }
 }
 
- 
+
 /** 自動保存間隔（ミリ秒） */
 const AUTO_SAVE_INTERVAL_MS = 3 * 60 * 1000; // 3分
 
 /**
- * autoSaveAll:
- *   - 印刷再開用データを localStorage に保存
- *   - 統一ストレージ（dashboard_storage）を保存
- *   - aggregator の内部状態を localStorage に保存
- *   - 保存前に {@link aggregatorUpdate} を実行しタイマー値を確定
- *
- * @returns {void}
+ * autoSaveAll
  */
 function autoSaveAll() {
   try {
-    // 現在のタイマー値を確定させてから保存処理を実行
     aggregatorUpdate();
   } catch (e) {
     console.warn("autoSaveAll: aggregatorUpdate 実行中にエラーが発生しました", e);
@@ -546,19 +563,10 @@ function autoSaveAll() {
 }
 
 /**
- * initializeAutoSave:
- *   - DOMContentLoaded 後に一度だけ beforeunload イベントへ autoSaveAll を登録
- *   - 定期的な autoSaveAll をセット
- *
- * @returns {void}
+ * initializeAutoSave
  */
 export function initializeAutoSave() {
-  // ページを離脱するときにも保存
   window.addEventListener("beforeunload", autoSaveAll);
-
-  //aggrigatorを停止
   stopAggregatorTimer();
-
-  // 一定間隔で定期保存
   setInterval(autoSaveAll, AUTO_SAVE_INTERVAL_MS);
 }

--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -222,33 +222,9 @@ export function initializeDashboard({
   initLogRenderer(logBox);
 
   // (5) 接続／切断ボタンバインド
-  const ipInput    = getPaneEl("destination-input",   paneIndex);
-  const acb        = getPaneEl("auto-connect-toggle", paneIndex);
-  const camToggle  = getPaneEl("camera-toggle-title", paneIndex);
-  const btnConnect = getPaneEl("connect-button",      paneIndex);
-  const btnDisc    = getPaneEl("disconnect-button",   paneIndex);
-
-  // ここで monitorData.appSettings から UI に反映
-  if (ipInput)   ipInput.value     = monitorData.appSettings.wsDest     || "";
-  if (acb)       acb.checked       = monitorData.appSettings.autoConnect;
-  if (camToggle) camToggle.checked = monitorData.appSettings.cameraToggle;
-
-  // 接続ボタンクリック → IPチェック→保存→接続
-  btnConnect?.addEventListener("click", () => {
-    const ip = ipInput?.value.trim();
-    if (!ip) {
-      showAlert("接続先のIPアドレスを設定し、接続を押してください", "warn");
-      return;
-    }
-    // 設定に反映して永続化
-    monitorData.appSettings.wsDest = ip;
-    saveUnifiedStorage();
-
-    onConnect();  // connectWs() を呼び出す
-  });
-
-  // 切断
-  btnDisc?.addEventListener("click", onDisconnect);
+  // destination-input / auto-connect-toggle / camera-toggle は接続設定モーダルに移行済み
+  // connect-button / disconnect-button は updateConnectionUI() が表示制御するため残存するが
+  // クリックイベントは setupConnectButton() 経由で dashboard_connection.js が登録する
 
   // (6) ログコピー・クリア操作
   getPaneEl("copy-all-notification-button",  paneIndex)
@@ -266,26 +242,6 @@ export function initializeDashboard({
     ?.addEventListener("click", e => copyLogsToClipboard(logManager.getAll(), 50, e.currentTarget));
   getPaneEl("copy-storeddata-button", paneIndex)
     ?.addEventListener("click", copyStoredDataToClipboard);
-
-  // (7) カメラトグル制御
-  if (camToggle) {
-    camToggle.addEventListener("change", () => {
-      monitorData.appSettings.cameraToggle = camToggle.checked;
-      saveUnifiedStorage();
-      if (camToggle.checked) startCameraStream(undefined, paneIndex);
-      else                    stopCameraStream(undefined, paneIndex);
-    });
-  }
-
-  // (8) 自動接続トグル
-  if (acb) {
-    acb.addEventListener("change", () => {
-      monitorData.appSettings.autoConnect = acb.checked;
-      saveUnifiedStorage();
-      pushLog(`自動接続を ${acb.checked ? "ON" : "OFF"} にしました`, "info");
-      showAlert(`自動接続を ${acb.checked ? "ON" : "OFF"} にしました`, "info");
-    });
-  }
 
   // (9) 通知設定パネル初期化
   const notifBody = getPaneEl("notification-panel-body", paneIndex);
@@ -305,14 +261,8 @@ export function initializeDashboard({
   getPaneEl("temp-graph-reset-button", paneIndex)
     ?.addEventListener("click", () => resetTemperatureGraphView(canvasEl));
 
-  // (11) ページロード時の自動接続（ペイン1のみ）
-  if (paneIndex === 1) {
-    if (monitorData.appSettings.autoConnect && monitorData.appSettings.wsDest) {
-      setTimeout(onConnect, 1500);
-    } else {
-      showAlert("接続先欄に機器アドレスを入力して、接続を押すと監視がはじまります", "warn");
-    }
-  }
+  // (11) ページロード時の自動接続は 3dp_dashboard_main.js の _autoConnectAll() が担当
+  // connections[] の autoConnect フラグを見て接続する（wsDest ベースの旧ロジックは廃止）
 
   // (12) ページロード時のカメラ起動は廃止
   // WebSocket 接続確立時に自動開始されるためここでは実行しない

--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -357,7 +357,7 @@ export function initializeDashboard({
   aliasClick("btn-history-list-cmd",  "btn-history-list");
   aliasClick("btn-file-list-cmd",     "btn-file-list");
 
-  printManager.initHistoryTabs();
+  printManager.initHistoryTabs(paneIndex);
 
   // (15) ファイルアップロード初期化
   printManager.setupUploadUI();

--- a/3dp_lib/3dp_dashboard_main.js
+++ b/3dp_lib/3dp_dashboard_main.js
@@ -89,10 +89,11 @@ function _initGlobalMenuBar() {
     dropdown?.classList.toggle("hidden");
   });
 
-  // ドロップダウン外クリックで閉じる
+  // ドロップダウン外クリックで閉じる（menuBtn自身のクリックはtoggleで処理するため除外）
   document.addEventListener("click", (e) => {
     if (dropdown && !dropdown.classList.contains("hidden")) {
-      if (!dropdown.contains(/** @type {Node} */(e.target)) && e.target !== menuBtn) {
+      const target = /** @type {Node} */(e.target);
+      if (!dropdown.contains(target) && !menuBtn?.contains(target)) {
         dropdown.classList.add("hidden");
       }
     }

--- a/3dp_lib/3dp_dashboard_main.js
+++ b/3dp_lib/3dp_dashboard_main.js
@@ -11,13 +11,17 @@
  * - 各モジュールの読み込みと初期化
  * - 例外ハンドリングやデバッグオブジェクト設定
  * - DOMContentLoaded で初期化処理を実行
+ * - グローバルメニューバーのイベント登録
+ * - connections[] からの自動接続復元
+ * - レイアウト設定の復元（1ペイン / 2ペイン）
+ * - ペイン2の initializeDashboard 呼び出し
  *
  * 【公開関数一覧】
  * - なし（エントリポイントとして即時実行）
  *
- * @version 1.390.435 (PR #196)
+ * @version 1.400.435 (PR #303)
  * @since   1.390.193 (PR #86)
- * @lastModified 2025-06-22 18:30:00
+ * @lastModified 2025-07-04 12:00:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -33,13 +37,13 @@ import {
 } from "./dashboard_connection.js";
 import { handleMessage } from "./dashboard_msg_handler.js";
 import {
-  startCameraStream,
   stopCameraStream,
   handleCameraError
 } from "./dashboard_camera_ctrl.js";
 import { initializeDashboard } from "./3dp_dashboard_init.js";
 import { audioManager } from "./dashboard_audio_manager.js";
 import { notificationManager } from "./dashboard_notification_manager.js";
+import { monitorData } from "./dashboard_data.js";
 
 import { initUIEventHandlers } from "./dashboard_ui.js";
 import { initStorageUI } from "./dashboard_storage_ui.js";
@@ -49,6 +53,14 @@ import "./dashboard_spool_ui.js";
 import "./dashboard_filament_manager.js";
 import "./dashboard_filament_change.js";
 
+// ——— レイアウト / 接続設定モジュール ———
+import {
+  restoreLayout,
+  showLayoutSelectDialog,
+  updatePaneSelectors
+} from "./dashboard_layout_manager.js";
+import { ConnSettingsModal } from "./dashboard_conn_settings.js";
+
 // ——— グローバル例外ハンドリング ———
 window.addEventListener("unhandledrejection", evt => {
   console.error("unhandledrejection:", evt.reason);
@@ -57,6 +69,114 @@ window.addEventListener("unhandledrejection", evt => {
 // ——— デバッグ用グローバル参照 ———
 window.audioManager = audioManager;
 window.notificationManager = notificationManager;
+
+// ─── グローバルメニューバー ────────────────────────────────────────
+
+/**
+ * グローバルメニューバーのイベントを登録する。
+ * @private
+ * @returns {void}
+ */
+function _initGlobalMenuBar() {
+  const menuBtn     = document.getElementById("gmb-menu-btn");
+  const dropdown    = document.getElementById("gmb-dropdown");
+  const connBtn     = document.getElementById("gmb-conn-settings");
+  const layoutBtn   = document.getElementById("gmb-layout-select");
+
+  // ≡ Menu ▾ の開閉
+  menuBtn?.addEventListener("click", (e) => {
+    e.stopPropagation();
+    dropdown?.classList.toggle("hidden");
+  });
+
+  // ドロップダウン外クリックで閉じる
+  document.addEventListener("click", (e) => {
+    if (dropdown && !dropdown.classList.contains("hidden")) {
+      if (!dropdown.contains(/** @type {Node} */(e.target)) && e.target !== menuBtn) {
+        dropdown.classList.add("hidden");
+      }
+    }
+  });
+
+  // 接続設定...
+  connBtn?.addEventListener("click", () => {
+    dropdown?.classList.add("hidden");
+    new ConnSettingsModal().open();
+  });
+
+  // ダッシュボード選択...
+  layoutBtn?.addEventListener("click", () => {
+    dropdown?.classList.add("hidden");
+    showLayoutSelectDialog();
+  });
+}
+
+// ─── 自動接続復元 ────────────────────────────────────────────────
+
+/**
+ * connections[] の autoConnect フラグが立っているプリンタへ自動接続する。
+ * 各接続は 200ms ずつずらして呼び出し、WebSocket の競合を防ぐ。
+ *
+ * @private
+ * @returns {void}
+ */
+function _autoConnectAll() {
+  const connections = monitorData.appSettings.connections ?? [];
+  let delay = 0;
+  for (const conn of connections) {
+    if (!conn.autoConnect || !conn.ip) continue;
+    const dest = `${conn.ip}:${conn.wsPort ?? 9999}`;
+    setTimeout(() => {
+      connectWs(dest);
+    }, delay);
+    delay += 200;
+  }
+}
+
+// ─── ペイン2の初期化 ──────────────────────────────────────────────
+
+/**
+ * ペイン2の initializeDashboard を呼び出す。
+ * layout-preset2 クラスが付いているときだけ実質的に意味を持つが、
+ * DOM要素が存在すれば初期化しておく。
+ *
+ * @private
+ * @returns {void}
+ */
+function _initPane2() {
+  if (!document.getElementById("pane-2")) return;
+
+  initializeDashboard({
+    /** 接続ボタン押下時（ペイン2） */
+    onConnect: () => {
+      disconnectWs();
+      connectWs();
+    },
+    /** 切断ボタン押下時（ペイン2） */
+    onDisconnect: () => {
+      disconnectWs();
+      stopCameraStream(undefined, 2);
+    },
+    /** カメラエラー時（ペイン2） */
+    onCameraError: () => {
+      handleCameraError(2);
+    },
+    /** WebSocket 接続状態変化時（ペイン2） */
+    onConnectionStateChange: _connected => {
+      updateConnectionUI("connected", {}, undefined, 2);
+    },
+    /** 受信メッセージ処理（ペイン2） */
+    onMessage: data => {
+      handleMessage(data);
+    },
+    /** オーディオ管理 */
+    audioManager,
+    /** 通知管理 */
+    notificationManager,
+    /** ペイン番号 */
+    paneIndex: 2
+  });
+}
 
 /**
  * ページ読み込み完了後のエントリポイント。
@@ -68,6 +188,8 @@ window.notificationManager = notificationManager;
  * - notificationManager・audioManager のテスト・設定バインド
  */
 document.addEventListener("DOMContentLoaded", () => {
+
+  // ── ペイン1 初期化 ──────────────────────────────────────────────
   initializeDashboard({
     /** 接続ボタン押下時 */
     onConnect: () => {
@@ -78,15 +200,15 @@ document.addEventListener("DOMContentLoaded", () => {
     onDisconnect: () => {
       disconnectWs();
       // IPアドレス再入力後に旧カメラストリームが残らないよう停止
-      stopCameraStream();
+      stopCameraStream(undefined, 1);
     },
     /** カメラエラー時 */
     onCameraError: () => {
-      handleCameraError();
+      handleCameraError(1);
     },
     /** WebSocket 接続状態が変化したとき */
-    onConnectionStateChange: connected => {
-      updateConnectionUI("connected");
+    onConnectionStateChange: _connected => {
+      updateConnectionUI("connected", {}, undefined, 1);
     },
     /** 受信メッセージを処理するとき */
     onMessage: data => {
@@ -95,10 +217,30 @@ document.addEventListener("DOMContentLoaded", () => {
     /** オーディオ管理 */
     audioManager,
     /** 通知管理 */
-    notificationManager
+    notificationManager,
+    /** ペイン番号 */
+    paneIndex: 1
   });
 
+  // ── ペイン2 初期化 ──────────────────────────────────────────────
+  _initPane2();
+
+  // ── UI イベント ─────────────────────────────────────────────────
   initUIEventHandlers();
   initStorageUI();
 
+  // ── グローバルメニューバー ───────────────────────────────────────
+  _initGlobalMenuBar();
+
+  // ── レイアウト復元 ──────────────────────────────────────────────
+  // connections[] の順序でペインセレクタを再構築し、
+  // 保存済みレイアウト（preset1/preset2）と paneAssignment を復元する
+  updatePaneSelectors();
+  restoreLayout();
+
+  // ── 自動接続 ────────────────────────────────────────────────────
+  // connections[] の autoConnect フラグが立っているプリンタに接続する
+  // （initializeDashboard 内の旧 wsDest ベース自動接続とは排他になるよう
+  //   dashboard_data.js のマイグレーション後はここのみで動作する）
+  _autoConnectAll();
 });

--- a/3dp_lib/dashboard_camera_ctrl.js
+++ b/3dp_lib/dashboard_camera_ctrl.js
@@ -12,16 +12,17 @@
  * - 接続状態に応じた UI 更新
  * - Exponential Backoff による再接続
  * - 配信サービス停止時は一度だけエラー通知
+ * - マルチペイン対応: ホストごとに独立した状態を管理
  *
  * 【公開関数一覧】
  * - {@link startCameraStream}：カメラストリーム開始
  * - {@link stopCameraStream}：カメラストリーム停止
  * - {@link handleCameraError}：接続エラー処理
  *
- * @version 1.390.508 (PR #232)
-* @since   1.390.193 (PR #86)
-* @lastModified 2025-06-28 13:25:09
-* -----------------------------------------------------------
+ * @version 1.400.509 (PR #303)
+ * @since   1.390.193 (PR #86)
+ * @lastModified 2025-07-04 10:30:00
+ * -----------------------------------------------------------
  * @todo
  * - none
  */
@@ -37,33 +38,77 @@ const CAMERA_MAX_RETRY      = 5;     // 最大再接続試行回数
 const DEFAULT_RETRY_DELAY   = 2000;  // 基本リトライ間隔 (ms)
 const STREAM_PORT           = 8080;  // ストリーム提供ポート
 
-// ─── 内部状態 ────────────────────────────────────────────────
-let cameraImg               = null;  // <img id="camera-feed">
-let cameraAttempts          = 0;     // 現在のリトライ試行回数
-let cameraRetryTimeout      = null;  // setTimeout ID
-let cameraCountdownTimer    = null;  // setInterval ID
-let firstConnected          = false; // 初回接続完了フラグ
-let userRequestedDisconnect = false; // ユーザによる停止フラグ
-let serviceStoppedNotified  = false; // サービス停止通知済みフラグ
+// ─── マルチインスタンス状態管理 ────────────────────────────────
+
+/**
+ * ホストごとのカメラ接続状態
+ * @type {Record<string, CameraState>}
+ */
+const cameraStateMap = {};
+
+/**
+ * @typedef {Object} CameraState
+ * @property {HTMLImageElement|null} img
+ * @property {number}    attempts
+ * @property {number|null} retryTimeout
+ * @property {number|null} countdownTimer
+ * @property {boolean}   firstConnected
+ * @property {boolean}   userRequestedDisconnect
+ * @property {boolean}   serviceStoppedNotified
+ * @property {number}    paneIndex
+ */
+
+/**
+ * ホストに対応するカメラ状態を取得（なければ生成）
+ * @param {string} hostKey
+ * @returns {CameraState}
+ */
+function getCameraState(hostKey) {
+  if (!cameraStateMap[hostKey]) {
+    cameraStateMap[hostKey] = {
+      img: null,
+      attempts: 0,
+      retryTimeout: null,
+      countdownTimer: null,
+      firstConnected: false,
+      userRequestedDisconnect: false,
+      serviceStoppedNotified: false,
+      paneIndex: 1
+    };
+  }
+  return cameraStateMap[hostKey];
+}
+
+/**
+ * paneIndex に対応した要素を取得するヘルパー
+ * @param {string} id
+ * @param {number} paneIndex
+ * @returns {HTMLElement|null}
+ */
+function getPaneEl(id, paneIndex) {
+  return document.getElementById(`p${paneIndex}-${id}`) ||
+         document.getElementById(id);
+}
 
 /**
  * _cancelCameraTimers
- * -------------------
  * カメラ接続に関連するタイマーとハンドラをすべて解除します。
- * リトライ上限到達時や手動停止時に利用されます。
  *
  * @private
+ * @param {string} hostKey
  * @returns {void}
  */
-function _cancelCameraTimers() {
-  if (cameraImg) {
-    cameraImg.onload = null;
-    cameraImg.onerror = null;
+function _cancelCameraTimers(hostKey) {
+  const s = cameraStateMap[hostKey];
+  if (!s) return;
+  if (s.img) {
+    s.img.onload = null;
+    s.img.onerror = null;
   }
-  clearTimeout(cameraRetryTimeout);
-  cameraRetryTimeout = null;
-  clearInterval(cameraCountdownTimer);
-  cameraCountdownTimer = null;
+  clearTimeout(s.retryTimeout);
+  s.retryTimeout = null;
+  clearInterval(s.countdownTimer);
+  s.countdownTimer = null;
 }
 
 /**
@@ -72,14 +117,17 @@ function _cancelCameraTimers() {
  *
  * @param {"disconnected"|"connecting"|"retrying"|"connected"} state
  * @param {{attempt?:number, max?:number, wait?:number}} [opt={}]
+ * @param {number} [paneIndex=1]
  */
-function updateCameraConnectionUI(state, opt = {}) {
-  const labelEl   = document.getElementById("camera-status-label");
-  const subEl     = document.getElementById("camera-status-sub");
-  const spinner   = document.getElementById("camera-spinner");
-  const noSignal  = document.querySelector(".no-signal");
-  const statusBox = document.querySelector(".camera-status");
-  const cancelBtn = document.getElementById("camera-cancel-button");
+function updateCameraConnectionUI(state, opt = {}, paneIndex = 1) {
+  const labelEl   = getPaneEl("camera-status-label", paneIndex);
+  const subEl     = getPaneEl("camera-status-sub",   paneIndex);
+  const spinner   = getPaneEl("camera-spinner",      paneIndex);
+  const paneEl    = document.getElementById(`pane-${paneIndex}`) || document.body;
+  const noSignal  = paneEl.querySelector(".no-signal");
+  const statusBox = paneEl.querySelector(".camera-status");
+  const cancelBtn = getPaneEl("camera-cancel-button", paneIndex);
+  const cameraImg = getPaneEl("camera-feed", paneIndex);
   const show = el => el?.classList.remove("hidden");
   const hide = el => el?.classList.add("hidden");
 
@@ -87,8 +135,8 @@ function updateCameraConnectionUI(state, opt = {}) {
     case "disconnected":
       // 「- NO SIGNAL -」
       if (noSignal) noSignal.textContent = "- NO SIGNAL -";
-      labelEl.textContent = "";
-      subEl.textContent   = "";
+      if (labelEl) labelEl.textContent = "";
+      if (subEl)   subEl.textContent   = "";
 
       // 表示制御
       cameraImg?.classList.add("off");
@@ -100,10 +148,9 @@ function updateCameraConnectionUI(state, opt = {}) {
 
     case "connecting":
       if (noSignal) noSignal.textContent = "... CONNECTING ...";
-      labelEl.textContent = "接続中...";
-      subEl.textContent   = `(${opt.attempt||0}/${opt.max||CAMERA_MAX_RETRY})`;
+      if (labelEl) labelEl.textContent = "接続中...";
+      if (subEl)   subEl.textContent   = `(${opt.attempt||0}/${opt.max||CAMERA_MAX_RETRY})`;
 
-      // 表示制御
       cameraImg?.classList.add("off");
       statusBox?.classList.remove("hidden");
       show(noSignal);
@@ -113,10 +160,9 @@ function updateCameraConnectionUI(state, opt = {}) {
 
     case "retrying":
       if (noSignal) noSignal.textContent = "- SIGNAL LOST -";
-      labelEl.textContent = "再接続待機";
-      subEl.textContent   = `再試行まで ${opt.wait||0} 秒`;
+      if (labelEl) labelEl.textContent = "再接続待機";
+      if (subEl)   subEl.textContent   = `再試行まで ${opt.wait||0} 秒`;
 
-      // 表示制御
       cameraImg?.classList.add("off");
       statusBox?.classList.remove("hidden");
       show(noSignal);
@@ -126,10 +172,9 @@ function updateCameraConnectionUI(state, opt = {}) {
 
     case "connected":
       if (noSignal) noSignal.textContent = "- NO SIGNAL -";
-      labelEl.textContent = "";
-      subEl.textContent   = "";
+      if (labelEl) labelEl.textContent = "";
+      if (subEl)   subEl.textContent   = "";
 
-      // 表示制御
       cameraImg?.classList.remove("off");
       statusBox?.classList.add("hidden");
       hide(noSignal);
@@ -141,7 +186,6 @@ function updateCameraConnectionUI(state, opt = {}) {
 
 /**
  * isStreamServiceDown
- * -------------------
  * ポート 8080/ への GET で ERR_CONNECTION_REFUSED が返るか試し、
  * サービス停止と判断します。
  *
@@ -150,90 +194,94 @@ function updateCameraConnectionUI(state, opt = {}) {
  */
 async function isStreamServiceDown(host) {
   try {
-    // no-cors モードでシンプル GET
     await fetch(`http://${host}:${STREAM_PORT}/`, { method: "GET", mode: "no-cors" });
     return false;
   } catch (err) {
-    // 接続拒否などはここに到達
     return true;
   }
 }
 
 /**
  * startCameraStream
- * -----------------
  * カメラ映像ストリームを開始／再接続します。
- * カメラトグル設定をチェックし、要素取得後に内部接続を開始します。
  *
  * @export
+ * @param {string} [hostOverride] - 接続先ホスト（省略時は appSettings.wsDest を使用）
+ * @param {number} [paneIndex=1]  - ペイン番号
  * @returns {void}
  */
-export function startCameraStream() {
-  const host = monitorData.appSettings.wsDest?.split(":")[0];
-  userRequestedDisconnect = false;
-  serviceStoppedNotified  = false; // 毎起動時に通知フラグクリア
-  firstConnected          = false;
+export function startCameraStream(hostOverride, paneIndex = 1) {
+  const rawHost = hostOverride || monitorData.appSettings.wsDest?.split(":")[0];
+  const host = rawHost || "";
+  const hostKey = host || "_default";
+
+  const s = getCameraState(hostKey);
+  s.paneIndex = paneIndex;
+  s.userRequestedDisconnect = false;
+  s.serviceStoppedNotified  = false;
+  s.firstConnected          = false;
 
   // OFF or ホスト未設定 なら即停止
   if (!host || !monitorData.appSettings.cameraToggle) {
-    updateCameraConnectionUI("disconnected");
+    updateCameraConnectionUI("disconnected", {}, paneIndex);
     return;
   }
 
-  cameraImg = document.getElementById("camera-feed");
-  if (!cameraImg) {
-    console.error("[camera] #camera-feed 要素が見つかりません");
-    updateCameraConnectionUI("disconnected");
+  s.img = getPaneEl("camera-feed", paneIndex);
+  if (!s.img) {
+    console.error(`[camera] #p${paneIndex}-camera-feed 要素が見つかりません`);
+    updateCameraConnectionUI("disconnected", {}, paneIndex);
     return;
   }
 
   // カウンタ＆タイマー初期化
-  cameraAttempts = 0;
-  clearTimeout(cameraRetryTimeout);
-  clearInterval(cameraCountdownTimer);
+  s.attempts = 0;
+  clearTimeout(s.retryTimeout);
+  clearInterval(s.countdownTimer);
 
-  // 実作業は内部関数へ
-  _connectImgStream(host);
+  _connectImgStream(hostKey, paneIndex);
 }
 
 /**
  * stopCameraStream
  * カメラ映像ストリームを停止します。
- * 映像停止＆タイマークリア後、UIを「切断」に更新します。
  *
  * @export
+ * @param {string} [hostOverride]
+ * @param {number} [paneIndex=1]
  * @returns {void}
  */
-export function stopCameraStream() {
-  // ユーザ操作によるOFF
-  if (cameraImg) {
-    cameraImg.src = "";
-    cameraImg.classList.add("off");
+export function stopCameraStream(hostOverride, paneIndex = 1) {
+  const rawHost = hostOverride || monitorData.appSettings.wsDest?.split(":")[0];
+  const hostKey = rawHost || "_default";
+  const s = cameraStateMap[hostKey];
+
+  if (s?.img) {
+    s.img.src = "";
+    s.img.classList.add("off");
   }
-  userRequestedDisconnect = true;
+  if (s) {
+    s.userRequestedDisconnect = true;
+    s.attempts = 0;
+  }
 
-  // リトライカウンタ＆タイマー初期化
-  cameraAttempts = 0;
-  _cancelCameraTimers();
-
-  // すぐに NO SIGNAL
-  updateCameraConnectionUI("disconnected");
+  _cancelCameraTimers(hostKey);
+  updateCameraConnectionUI("disconnected", {}, paneIndex);
   pushLog("カメラストリーム停止", "info");
   notificationManager.notify("cameraConnectionStopped");
 }
 
-
 /**
  * handleCameraError
- * -----------------
  * 旧API互換エントリポイント。
  * 画像読み込みエラー発生時に呼び出します。
  *
  * @export
+ * @param {number} [paneIndex=1]
  * @returns {void}
  */
-export function handleCameraError() {
-  updateCameraConnectionUI("disconnected");
+export function handleCameraError(paneIndex = 1) {
+  updateCameraConnectionUI("disconnected", {}, paneIndex);
   pushLog("カメラ映像の読み込みエラー", "error");
 }
 
@@ -241,112 +289,114 @@ export function handleCameraError() {
  * _connectImgStream
  * 実際に <img> の src を切り替えてストリームを開始／再接続します。
  *
- * @param {string} host
+ * @param {string} hostKey
+ * @param {number} paneIndex
  */
-function _connectImgStream(host) {
-  if (userRequestedDisconnect) return;
+function _connectImgStream(hostKey, paneIndex) {
+  const s = getCameraState(hostKey);
+  if (s.userRequestedDisconnect) return;
+
+  // ホストキーが "_default" の場合は実際のIPを取得
+  const host = hostKey === "_default"
+    ? (monitorData.appSettings.wsDest?.split(":")[0] || "")
+    : hostKey;
 
   // リトライ上限チェック
-  if (cameraAttempts >= CAMERA_MAX_RETRY) {
-    userRequestedDisconnect = true;
-    _cancelCameraTimers();
-    updateCameraConnectionUI("disconnected");
+  if (s.attempts >= CAMERA_MAX_RETRY) {
+    s.userRequestedDisconnect = true;
+    _cancelCameraTimers(hostKey);
+    updateCameraConnectionUI("disconnected", {}, paneIndex);
     pushLog(`カメラ自動リトライ上限(${CAMERA_MAX_RETRY})に達しました`, "error");
     notificationManager.notify("cameraConnectionFailed");
     return;
   }
 
-  cameraAttempts++;
+  s.attempts++;
   updateCameraConnectionUI("connecting", {
-    attempt: cameraAttempts,
+    attempt: s.attempts,
     max:     CAMERA_MAX_RETRY
-  });
-  pushLog(`カメラストリーム接続試行 (${cameraAttempts}/${CAMERA_MAX_RETRY})`, "info");
+  }, paneIndex);
+  pushLog(`カメラストリーム接続試行 (${s.attempts}/${CAMERA_MAX_RETRY})`, "info");
 
-  const delayMs = DEFAULT_RETRY_DELAY * Math.pow(2, cameraAttempts - 1);
+  const delayMs = DEFAULT_RETRY_DELAY * Math.pow(2, s.attempts - 1);
   const waitSec = Math.ceil(delayMs / 1000);
   const url     = `http://${host}:${STREAM_PORT}/?action=stream`;
 
   // 既存タイマークリア
-  clearTimeout(cameraRetryTimeout);
-  clearInterval(cameraCountdownTimer);
+  clearTimeout(s.retryTimeout);
+  clearInterval(s.countdownTimer);
 
   // 読み込み成功 (フレーム受信)
-  cameraImg.onload = () => {
-    if (userRequestedDisconnect) return;
+  s.img.onload = () => {
+    if (s.userRequestedDisconnect) return;
 
-    // 待機中のリトライタイマーがあればキャンセルする
-    if (cameraRetryTimeout) {
-      clearTimeout(cameraRetryTimeout);
-      cameraRetryTimeout = null;
+    if (s.retryTimeout) {
+      clearTimeout(s.retryTimeout);
+      s.retryTimeout = null;
     }
-    if (cameraCountdownTimer) {
-      clearInterval(cameraCountdownTimer);
-      cameraCountdownTimer = null;
+    if (s.countdownTimer) {
+      clearInterval(s.countdownTimer);
+      s.countdownTimer = null;
     }
 
-    // 接続成立時の共通処理
-    if (!firstConnected) {
-      cameraAttempts = 0;
-      firstConnected = true;
-      updateCameraConnectionUI("connected");
+    if (!s.firstConnected) {
+      s.attempts = 0;
+      s.firstConnected = true;
+      updateCameraConnectionUI("connected", {}, paneIndex);
       pushLog("カメラ接続成功", "success");
       notificationManager.notify("cameraConnected");
-    } else if (cameraAttempts > 0) {
-      // 再接続が成功した場合は UI を更新してリトライ回数をリセット
-      cameraAttempts = 0;
-      updateCameraConnectionUI("connected");
+    } else if (s.attempts > 0) {
+      s.attempts = 0;
+      updateCameraConnectionUI("connected", {}, paneIndex);
       pushLog("カメラ再接続成功", "info");
     }
   };
 
   // 読み込みエラー
-  cameraImg.onerror = async () => {
-    if (userRequestedDisconnect) return;
+  s.img.onerror = async () => {
+    if (s.userRequestedDisconnect) return;
 
     // サービス停止チェック
-    if (!serviceStoppedNotified && await isStreamServiceDown(host)) {
-      serviceStoppedNotified = true;
-      updateCameraConnectionUI("disconnected");
+    if (!s.serviceStoppedNotified && await isStreamServiceDown(host)) {
+      s.serviceStoppedNotified = true;
+      updateCameraConnectionUI("disconnected", {}, paneIndex);
       pushLog("機器側の動画配信サービスが異常停止しています", "error");
       notificationManager.notify("cameraServiceStopped");
-      return; // リトライ打ち切り
+      return;
     }
 
     // 通常の再試行ロジック
     updateCameraConnectionUI("retrying", {
-      attempt: cameraAttempts + 1,
+      attempt: s.attempts + 1,
       max:     CAMERA_MAX_RETRY,
       wait:    waitSec
-    });
-    pushLog(`カメラ切断検知 (${cameraAttempts}/${CAMERA_MAX_RETRY})`, "warn");
+    }, paneIndex);
+    pushLog(`カメラ切断検知 (${s.attempts}/${CAMERA_MAX_RETRY})`, "warn");
 
     // カウントダウン表示
     let remaining = waitSec;
-    cameraCountdownTimer = setInterval(() => {
+    s.countdownTimer = setInterval(() => {
       remaining--;
       if (remaining > 0) {
         updateCameraConnectionUI("retrying", {
-          attempt: cameraAttempts + 1,
+          attempt: s.attempts + 1,
           max:     CAMERA_MAX_RETRY,
           wait:    remaining
-        });
+        }, paneIndex);
       } else {
-        clearInterval(cameraCountdownTimer);
+        clearInterval(s.countdownTimer);
       }
     }, 1000);
 
     // リトライスケジュール
-    cameraRetryTimeout = setTimeout(() => {
-      if (userRequestedDisconnect) return;
-      cameraImg.src = "";          // 強制リセット
-      _connectImgStream(host);     // 再帰的に再接続
+    s.retryTimeout = setTimeout(() => {
+      if (s.userRequestedDisconnect) return;
+      s.img.src = "";
+      _connectImgStream(hostKey, paneIndex);
     }, delayMs);
   };
 
   // ストリーム開始
-  cameraImg.src = url;
-  cameraImg.classList.remove("off");
-
-  // フレーム監視タイマーは廃止
+  s.img.src = url;
+  s.img.classList.remove("off");
 }

--- a/3dp_lib/dashboard_chart.js
+++ b/3dp_lib/dashboard_chart.js
@@ -11,6 +11,7 @@
  * - Chart.js を用いた温度グラフ描画
  * - データ点の間引きやスロットリング更新に対応
  * - Zoom プラグインによる拡大・パン操作
+ * - マルチペイン対応: キャンバス要素ごとに独立した状態を管理
  *
  * 【公開関数一覧】
  * - {@link initTemperatureGraph}：グラフ初期化
@@ -18,9 +19,9 @@
  * - {@link resetTemperatureGraphView}：表示範囲リセット
  * - {@link updateTemperatureGraphFromStoredData}：データ更新
  *
- * @version 1.390.317 (PR #143)
+ * @version 1.400.318 (PR #303)
  * @since   1.390.193 (PR #86)
- * @lastModified 2025-06-19 22:38:18
+ * @lastModified 2025-07-04 10:30:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -36,9 +37,6 @@
 
 /**
  * デフォルト構成パラメータ
- * - timeWindowMs: 表示範囲の時間幅（ms）
- * - decimationSamples: LTTBアルゴリズムで間引く最大点数
- * - throttleIntervalMs: Chart更新の最小間隔（ms）
  */
 const DEFAULT_CONFIG = {
   timeWindowMs:       15 * 60 * 1000,
@@ -46,28 +44,69 @@ const DEFAULT_CONFIG = {
   throttleIntervalMs: 500,
 };
 
-// ==============================
-// 内部状態管理
-// ==============================
-
-let tempChart = null;
-let config = { ...DEFAULT_CONFIG };
-let lastUpdate = 0;
-let updateQueued = false;
-let isFirstRender = true;
-
-/** 取得対象キー群（サーバーから渡される storedData のキーに合わせる） */
+/** 取得対象キー群 */
 const DATASET_KEYS = ["nozzleCurrent", "nozzleTarget", "bedCurrent", "bedTarget", "boxCurrent"];
 const FIELD_KEYS   = ["nozzleTemp", "targetNozzleTemp", "bedTemp0", "targetBedTemp0", "boxTemp"];
 
-/** 一時キューと本体格納用データ */
-const pointQueue = {};
-const tempData   = {};
-// DATASET_KEYS の数だけ初期化
-DATASET_KEYS.forEach(key => {
-  pointQueue[key] = [];
-  tempData[key]   = [];
-});
+// ==============================
+// マルチインスタンス状態管理
+// ==============================
+
+/**
+ * キャンバス要素ごとのグラフ状態を保持するマップ
+ * @type {Map<HTMLCanvasElement, ChartState>}
+ */
+const chartStateMap = new Map();
+
+/**
+ * @typedef {Object} ChartState
+ * @property {Chart|null}  chart
+ * @property {Object}      data        - DATASET_KEYS ごとのデータ配列
+ * @property {Object}      pointQueue  - DATASET_KEYS ごとのキュー配列
+ * @property {Object}      config      - 設定オブジェクト
+ * @property {number}      lastUpdate  - 最終更新時刻 (ms)
+ * @property {boolean}     updateQueued
+ * @property {boolean}     isFirstRender
+ */
+
+/**
+ * キャンバス要素に対応する状態を取得（なければ生成）します。
+ * @param {HTMLCanvasElement} canvasEl
+ * @returns {ChartState}
+ */
+function getChartState(canvasEl) {
+  if (!chartStateMap.has(canvasEl)) {
+    const data = {};
+    const pointQueue = {};
+    DATASET_KEYS.forEach(key => {
+      data[key] = [];
+      pointQueue[key] = [];
+    });
+    chartStateMap.set(canvasEl, {
+      chart: null,
+      data,
+      pointQueue,
+      config: { ...DEFAULT_CONFIG },
+      lastUpdate: 0,
+      updateQueued: false,
+      isFirstRender: true
+    });
+  }
+  return chartStateMap.get(canvasEl);
+}
+
+/**
+ * canvasEl が指定されていない場合のフォールバック。
+ * 後方互換性のため p1-temp-graph-canvas を探します。
+ * @returns {HTMLCanvasElement|null}
+ */
+function resolveCanvas(canvasEl) {
+  if (canvasEl instanceof HTMLCanvasElement) return canvasEl;
+  return /** @type {HTMLCanvasElement|null} */ (
+    document.getElementById("p1-temp-graph-canvas") ||
+    document.getElementById("temp-graph-canvas")
+  );
+}
 
 // ==============================
 // 初期化・リセット
@@ -75,18 +114,19 @@ DATASET_KEYS.forEach(key => {
 
 /**
  * グラフの初期化処理
- * Chart.js による描画設定を行い、Canvasが存在しない場合は処理しない。
  *
- * @param {object} userConfig - オプション指定 { timeWindowMs, decimationSamples, throttleIntervalMs }
+ * @param {object}             [userConfig={}] - オプション指定
+ * @param {HTMLCanvasElement}  [canvasEl]      - 対象キャンバス（省略時は後方互換フォールバック）
  */
-export function initTemperatureGraph(userConfig = {}) {
-  config = { ...DEFAULT_CONFIG, ...userConfig };
-
-  const canvas = document.getElementById("temp-graph-canvas");
+export function initTemperatureGraph(userConfig = {}, canvasEl) {
+  const canvas = resolveCanvas(canvasEl);
   if (!canvas) {
     console.warn("initTemperatureGraph: canvas 要素が見つかりません");
     return;
   }
+
+  const state = getChartState(canvas);
+  state.config = { ...DEFAULT_CONFIG, ...userConfig };
 
   const ctx = canvas.getContext("2d");
   if (!ctx) {
@@ -94,15 +134,21 @@ export function initTemperatureGraph(userConfig = {}) {
     return;
   }
 
-  tempChart = new Chart(ctx, {
+  // 既存インスタンスがあれば破棄
+  if (state.chart) {
+    state.chart.destroy();
+    state.chart = null;
+  }
+
+  state.chart = new Chart(ctx, {
     type: "line",
     data: {
       datasets: [
-        { label: "ノズル温度 (現在)", data: tempData.nozzleCurrent, fill: false, borderWidth: 2 },
-        { label: "ノズル温度 (目標)", data: tempData.nozzleTarget,  fill: false, borderWidth: 2 },
-        { label: "ベッド温度 (現在)", data: tempData.bedCurrent,    fill: false, borderWidth: 2 },
-        { label: "ベッド温度 (目標)", data: tempData.bedTarget,     fill: false, borderWidth: 2 },
-        { label: "箱内温度 (現在)",   data: tempData.boxCurrent,     fill: false, borderWidth: 2 }
+        { label: "ノズル温度 (現在)", data: state.data.nozzleCurrent, fill: false, borderWidth: 2 },
+        { label: "ノズル温度 (目標)", data: state.data.nozzleTarget,  fill: false, borderWidth: 2 },
+        { label: "ベッド温度 (現在)", data: state.data.bedCurrent,    fill: false, borderWidth: 2 },
+        { label: "ベッド温度 (目標)", data: state.data.bedTarget,     fill: false, borderWidth: 2 },
+        { label: "算内温度 (現在)",   data: state.data.boxCurrent,     fill: false, borderWidth: 2 }
       ]
     },
     options: {
@@ -123,7 +169,7 @@ export function initTemperatureGraph(userConfig = {}) {
       decimation: {
         enabled: true,
         algorithm: "lttb",
-        samples: config.decimationSamples
+        samples: state.config.decimationSamples
       },
       scales: {
         x: {
@@ -148,34 +194,40 @@ export function initTemperatureGraph(userConfig = {}) {
 
 /**
  * グラフをクリアし、全データと状態をリセットします。
- * Chart.js Zoom プラグインが使用されている場合はズーム範囲もリセットします。
+ *
+ * @param {HTMLCanvasElement} [canvasEl]
  */
-export function resetTemperatureGraph() {
+export function resetTemperatureGraph(canvasEl) {
+  const canvas = resolveCanvas(canvasEl);
+  if (!canvas) return;
+  const state = getChartState(canvas);
+
   DATASET_KEYS.forEach(key => {
-    tempData[key].length = 0;
-    pointQueue[key].length = 0;
+    state.data[key].length = 0;
+    state.pointQueue[key].length = 0;
   });
 
-  if (tempChart) {
-    tempChart.data.datasets.forEach(ds => (ds.data = []));
-    tempChart.resetZoom?.();  // Zoom プラグインを使っている場合はズームをリセット
-    tempChart.update();
+  if (state.chart) {
+    state.chart.data.datasets.forEach(ds => (ds.data = []));
+    state.chart.resetZoom?.();
+    state.chart.update();
   }
 
-  isFirstRender = true;
+  state.isFirstRender = true;
 }
 
 /**
- * 温度グラフのズームおよびパン表示のみを初期状態へ戻します。
- * データ内容は保持したまま、Chart.js Zoom プラグインが有効であれば
- * resetZoom() を実行してスケールをリセットします。
+ * 温度グラフのズームおよびパン表示のみを初期状態へ戺します。
  *
+ * @param {HTMLCanvasElement} [canvasEl]
  * @returns {void}
  */
-export function resetTemperatureGraphView() {
-  if (tempChart) {
-    // resetZoom が存在する場合のみ呼び出し
-    tempChart.resetZoom?.();
+export function resetTemperatureGraphView(canvasEl) {
+  const canvas = resolveCanvas(canvasEl);
+  if (!canvas) return;
+  const state = getChartState(canvas);
+  if (state.chart) {
+    state.chart.resetZoom?.();
   }
 }
 
@@ -184,65 +236,66 @@ export function resetTemperatureGraphView() {
 // ==============================
 
 /**
- * 古いデータ点を削除して表示対象時間枠を制限する
- * @param {Array<{t:number,y:number}>} arr
- * @param {number} now - 現在時刻(ms)
- * @returns {Array} - フィルタ済み配列
+ * 古いデータ点を削除して表示対象時間枚を制限する
  */
-function filterOldData(arr, now) {
-  return arr.filter(pt => pt.t >= now - config.timeWindowMs);
+function filterOldData(arr, now, timeWindowMs) {
+  return arr.filter(pt => pt.t >= now - timeWindowMs);
 }
 
 /**
  * Chart.jsの更新を間引き制御（スロットリング）して呼び出す
  */
-function scheduleChartUpdate() {
+function scheduleChartUpdate(state) {
   const now = Date.now();
 
-  if (now - lastUpdate >= config.throttleIntervalMs) {
-    tempChart.update(isFirstRender ? undefined : "none");
-    lastUpdate = now;
-    isFirstRender = false;
-  } else if (!updateQueued) {
-    updateQueued = true;
+  if (now - state.lastUpdate >= state.config.throttleIntervalMs) {
+    state.chart.update(state.isFirstRender ? undefined : "none");
+    state.lastUpdate = now;
+    state.isFirstRender = false;
+  } else if (!state.updateQueued) {
+    state.updateQueued = true;
     setTimeout(() => {
-      tempChart.update("none");
-      lastUpdate = Date.now();
-      updateQueued = false;
-    }, config.throttleIntervalMs - (now - lastUpdate));
+      state.chart.update("none");
+      state.lastUpdate = Date.now();
+      state.updateQueued = false;
+    }, state.config.throttleIntervalMs - (now - state.lastUpdate));
   }
 }
 
 /**
  * storedData オブジェクトから最新温度データを抽出し、
- * 時系列グラフに反映する（キュー → 本体転送 → Chart.js 更新）。
+ * 時系列グラフに反映する。
  *
  * @param {Record<string, {rawValue: number|string, computedValue?: any, isNew?: boolean}>} dataStore
- *   温度データを含む storedData（各フィールドに rawValue を持つオブジェクト）のマップ
+ * @param {HTMLCanvasElement} [canvasEl] - 対象キャンバス（省略時は後方互換フォールバック）
  * @returns {void}
  */
-export function updateTemperatureGraphFromStoredData(dataStore) {
-  if (!tempChart) return;
+export function updateTemperatureGraphFromStoredData(dataStore, canvasEl) {
+  const canvas = resolveCanvas(canvasEl);
+  if (!canvas) return;
+  const state = getChartState(canvas);
+  if (!state.chart) return;
+
   const now = Date.now();
 
-  // データ取得関数：NaN や null を 0 扱いにする
+  // データ取得関数
   const getVal = key => parseFloat(dataStore[key]?.rawValue ?? 0) || 0;
 
   // 1) 現在時刻付きのデータ点をキューに追加
-  pointQueue.nozzleCurrent.push({ t: now, y: getVal("nozzleTemp") });
-  pointQueue.nozzleTarget.push({ t: now, y: getVal("targetNozzleTemp") });
-  pointQueue.bedCurrent.push({ t: now, y: getVal("bedTemp0") });
-  pointQueue.bedTarget.push({ t: now, y: getVal("targetBedTemp0") });
-  pointQueue.boxCurrent.push({ t: now, y: getVal("boxTemp") });
+  state.pointQueue.nozzleCurrent.push({ t: now, y: getVal("nozzleTemp") });
+  state.pointQueue.nozzleTarget.push({ t: now, y: getVal("targetNozzleTemp") });
+  state.pointQueue.bedCurrent.push({ t: now, y: getVal("bedTemp0") });
+  state.pointQueue.bedTarget.push({ t: now, y: getVal("targetBedTemp0") });
+  state.pointQueue.boxCurrent.push({ t: now, y: getVal("boxTemp") });
 
   // 2) キューから本体に移し、過去の点を除去
   DATASET_KEYS.forEach((key, idx) => {
-    tempData[key].push(...pointQueue[key]);
-    tempData[key] = filterOldData(tempData[key], now);
-    tempChart.data.datasets[idx].data = tempData[key];
-    pointQueue[key].length = 0;
+    state.data[key].push(...state.pointQueue[key]);
+    state.data[key] = filterOldData(state.data[key], now, state.config.timeWindowMs);
+    state.chart.data.datasets[idx].data = state.data[key];
+    state.pointQueue[key].length = 0;
   });
 
   // 3) Chartの再描画（スロットル付き）
-  scheduleChartUpdate();
+  scheduleChartUpdate(state);
 }

--- a/3dp_lib/dashboard_conn_settings.js
+++ b/3dp_lib/dashboard_conn_settings.js
@@ -1,0 +1,276 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 接続設定モーダルモジュール
+ * @file dashboard_conn_settings.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * @author pumpCurry
+ * -----------------------------------------------------------
+ * @module dashboard_conn_settings
+ *
+ * 【機能内容サマリ】
+ * - 接続設定モーダル（プリンタ名・色・IP・WS・CAM・自動接続）
+ * - connections[] の CRUD と色設定
+ *
+ * 【公開クラス一覧】
+ * - {@link ConnSettingsModal}：接続設定モーダルクラス
+ *
+ * @version 1.400.001 (PR #303)
+ * @since   1.400.001 (PR #303)
+ * @lastModified 2025-07-04 10:30:00
+ * -----------------------------------------------------------
+ * @todo
+ * - none
+ */
+
+"use strict";
+
+import { monitorData } from "./dashboard_data.js";
+import { saveUnifiedStorage } from "./dashboard_storage.js";
+import { connectWs, disconnectWs } from "./dashboard_connection.js";
+
+/** IP アドレス検証 */
+const IP_RE = /^(25[0-5]|2[0-4]\d|1?\d{1,2})(\.(25[0-5]|2[0-4]\d|1?\d{1,2})){3}$/;
+/** ポート番号検証 */
+const PORT_RE = /^(6553[0-5]|655[0-2]\d|65[0-4]\d{2}|6[0-4]\d{3}|[1-5]?\d{0,4})$/;
+
+/**
+ * 一意な接続 ID を生成します。
+ * @returns {string}
+ */
+function genId() {
+  return `conn_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+}
+
+/**
+ * 接続設定モーダルクラス。
+ * プリンタごとの名前・色・IP・ポート・自動接続を管理します。
+ */
+export class ConnSettingsModal {
+  constructor() {
+    /** @type {HTMLDialogElement|null} */
+    this.dialog = null;
+  }
+
+  /**
+   * モーダルを開く。
+   * @returns {void}
+   */
+  open() {
+    if (this.dialog) return;
+    this.dialog = document.createElement("dialog");
+    this.dialog.className = "conn-settings-dialog";
+    this.dialog.setAttribute("role", "dialog");
+    this.dialog.setAttribute("aria-modal", "true");
+    this.dialog.setAttribute("aria-label", "接続設定");
+
+    this.dialog.innerHTML = `
+      <div class="conn-settings-header">
+        <h2>接続設定</h2>
+        <button class="conn-settings-close" aria-label="閉じる">×</button>
+      </div>
+      <div class="conn-settings-body"></div>
+      <div class="conn-settings-footer">
+        <button class="conn-add-btn">＋ プリンタを追加</button>
+      </div>
+    `;
+
+    this.dialog.querySelector(".conn-settings-close")
+      ?.addEventListener("click", () => this.close());
+    this.dialog.querySelector(".conn-add-btn")
+      ?.addEventListener("click", () => this.#addConnection());
+    this.dialog.addEventListener("click", e => {
+      if (e.target === this.dialog) this.close();
+    });
+
+    document.body.appendChild(this.dialog);
+    this.#render();
+    this.dialog.showModal();
+  }
+
+  /**
+   * モーダルを閉じる。
+   * @returns {void}
+   */
+  close() {
+    if (!this.dialog) return;
+    this.dialog.close();
+    this.dialog.remove();
+    this.dialog = null;
+  }
+
+  /**
+   * 接続一覧を再描画する。
+   * @private
+   */
+  #render() {
+    if (!this.dialog) return;
+    const body = this.dialog.querySelector(".conn-settings-body");
+    if (!body) return;
+    body.innerHTML = "";
+
+    const connections = monitorData.appSettings.connections || [];
+    if (connections.length === 0) {
+      body.innerHTML = '<p class="conn-empty">接続が登録されていません。</p>';
+      return;
+    }
+
+    connections.forEach(conn => {
+      const entry = this.#buildEntry(conn);
+      body.appendChild(entry);
+    });
+  }
+
+  /**
+   * 接続エントリ要素を生成する。
+   * @private
+   * @param {{id:string,name:string,color:string,ip:string,wsPort:number,camPort?:number,autoConnect:boolean}} conn
+   * @returns {HTMLElement}
+   */
+  #buildEntry(conn) {
+    const div = document.createElement("div");
+    div.className = "conn-entry";
+    div.dataset.id = conn.id;
+
+    const indicator = this.#getIndicator(conn);
+
+    div.innerHTML = `
+      <div class="conn-indicator">${indicator}</div>
+      <div class="conn-fields">
+        <div class="conn-top-row">
+          <input type="text"  class="conn-name"  value="${this.#esc(conn.name)}"  placeholder="プリンタ名" aria-label="プリンタ名">
+          <input type="color" class="conn-color" value="${conn.color || '#4a9eff'}" aria-label="プリンタカラー">
+          <label class="conn-auto-label">
+            <input type="checkbox" class="conn-auto" ${conn.autoConnect ? "checked" : ""}> 自動接続
+          </label>
+        </div>
+        <div class="conn-addr-row">
+          <label>IP <input type="text"   class="conn-ip"  value="${this.#esc(conn.ip)}"     placeholder="192.168.1.x" aria-label="IPアドレス"></label>
+          <label>WS <input type="number" class="conn-ws"  value="${conn.wsPort || ''}"      placeholder="9999" min="1" max="65535" aria-label="WSポート"></label>
+          <label>CAM<input type="number" class="conn-cam" value="${conn.camPort || ''}"     placeholder="8080" min="1" max="65535" aria-label="CAMポート"></label>
+        </div>
+        <div class="conn-action-row">
+          <button class="conn-save-btn">保存</button>
+          <button class="conn-delete-btn">削除</button>
+        </div>
+      </div>
+    `;
+
+    div.querySelector(".conn-save-btn")
+      ?.addEventListener("click", () => this.#saveEntry(div, conn.id));
+    div.querySelector(".conn-delete-btn")
+      ?.addEventListener("click", () => this.#deleteEntry(conn.id));
+
+    return div;
+  }
+
+  /**
+   * 接続インジケーター文字列を返す。
+   * @private
+   */
+  #getIndicator(conn) {
+    // 将来的には connectionMap から接続状態を読むが、現時点では IP の有無で判定
+    if (!conn.ip) return "⚫";
+    return "🔴";
+  }
+
+  /**
+   * エントリを保存する。
+   * @private
+   */
+  #saveEntry(div, id) {
+    const name     = div.querySelector(".conn-name")?.value.trim() || "";
+    const color    = div.querySelector(".conn-color")?.value || "#4a9eff";
+    const ip       = div.querySelector(".conn-ip")?.value.trim() || "";
+    const wsPort   = parseInt(div.querySelector(".conn-ws")?.value || "9999", 10);
+    const camPort  = parseInt(div.querySelector(".conn-cam")?.value || "0", 10) || undefined;
+    const auto     = div.querySelector(".conn-auto")?.checked ?? false;
+
+    // 入力検証
+    if (ip && !IP_RE.test(ip)) {
+      alert("IP アドレスの形式が正しくありません");
+      return;
+    }
+    if (isNaN(wsPort) || !PORT_RE.test(String(wsPort))) {
+      alert("WS ポート番号が正しくありません");
+      return;
+    }
+
+    const connections = monitorData.appSettings.connections;
+    const idx = connections.findIndex(c => c.id === id);
+    if (idx !== -1) {
+      connections[idx] = { ...connections[idx], name, color, ip, wsPort, camPort, autoConnect: auto };
+    }
+    saveUnifiedStorage();
+    this.#render();
+    // ペインのカラーを即時反映
+    this.#applyColors();
+  }
+
+  /**
+   * エントリを削除する。
+   * @private
+   */
+  #deleteEntry(id) {
+    if (!confirm("この接続を削除しますか？")) return;
+    monitorData.appSettings.connections = (monitorData.appSettings.connections || []).filter(c => c.id !== id);
+    // ペイン割り当てをクリア
+    const pa = monitorData.appSettings.paneAssignment;
+    for (const k of Object.keys(pa)) {
+      if (pa[k] === id) pa[k] = null;
+    }
+    saveUnifiedStorage();
+    this.#render();
+  }
+
+  /**
+   * 新しい接続を追加する。
+   * @private
+   */
+  #addConnection() {
+    const newConn = {
+      id:          genId(),
+      name:        `プリンタ ${(monitorData.appSettings.connections?.length || 0) + 1}`,
+      color:       "#4a9eff",
+      ip:          "",
+      wsPort:      9999,
+      camPort:     undefined,
+      autoConnect: false
+    };
+    if (!monitorData.appSettings.connections) {
+      monitorData.appSettings.connections = [];
+    }
+    monitorData.appSettings.connections.push(newConn);
+    saveUnifiedStorage();
+    this.#render();
+  }
+
+  /**
+   * 各ペインのプリンタカラー CSS 変数を更新する。
+   * @private
+   */
+  #applyColors() {
+    const pa = monitorData.appSettings.paneAssignment || {};
+    for (const [pane, connId] of Object.entries(pa)) {
+      if (!connId) continue;
+      const conn = (monitorData.appSettings.connections || []).find(c => c.id === connId);
+      if (!conn) continue;
+      const paneEl = document.getElementById(`pane-${pane}`);
+      if (paneEl) {
+        paneEl.style.setProperty("--printer-color", conn.color);
+        paneEl.style.setProperty("--printer-color-faint", conn.color + "1a");
+      }
+    }
+  }
+
+  /**
+   * HTML エスケープ
+   * @private
+   */
+  #esc(str) {
+    return String(str || "")
+      .replace(/&/g, "&amp;")
+      .replace(/"/g, "&quot;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
+}

--- a/3dp_lib/dashboard_conn_settings.js
+++ b/3dp_lib/dashboard_conn_settings.js
@@ -142,6 +142,9 @@ export class ConnSettingsModal {
           <label class="conn-auto-label">
             <input type="checkbox" class="conn-auto" ${conn.autoConnect ? "checked" : ""}> 自動接続
           </label>
+          <label class="conn-auto-label">
+            <input type="checkbox" class="conn-cam-auto" ${conn.autoCamera ? "checked" : ""}> 接続時カメラON
+          </label>
         </div>
         <div class="conn-addr-row">
           <label>IP <input type="text"   class="conn-ip"  value="${this.#esc(conn.ip)}"     placeholder="192.168.1.x" aria-label="IPアドレス"></label>
@@ -178,12 +181,13 @@ export class ConnSettingsModal {
    * @private
    */
   #saveEntry(div, id) {
-    const name     = div.querySelector(".conn-name")?.value.trim() || "";
-    const color    = div.querySelector(".conn-color")?.value || "#4a9eff";
-    const ip       = div.querySelector(".conn-ip")?.value.trim() || "";
-    const wsPort   = parseInt(div.querySelector(".conn-ws")?.value || "9999", 10);
-    const camPort  = parseInt(div.querySelector(".conn-cam")?.value || "0", 10) || undefined;
-    const auto     = div.querySelector(".conn-auto")?.checked ?? false;
+    const name      = div.querySelector(".conn-name")?.value.trim() || "";
+    const color     = div.querySelector(".conn-color")?.value || "#4a9eff";
+    const ip        = div.querySelector(".conn-ip")?.value.trim() || "";
+    const wsPort    = parseInt(div.querySelector(".conn-ws")?.value || "9999", 10);
+    const camPort   = parseInt(div.querySelector(".conn-cam")?.value || "0", 10) || undefined;
+    const auto      = div.querySelector(".conn-auto")?.checked ?? false;
+    const autoCamera = div.querySelector(".conn-cam-auto")?.checked ?? false;
 
     // 入力検証
     if (ip && !IP_RE.test(ip)) {
@@ -198,7 +202,7 @@ export class ConnSettingsModal {
     const connections = monitorData.appSettings.connections;
     const idx = connections.findIndex(c => c.id === id);
     if (idx !== -1) {
-      connections[idx] = { ...connections[idx], name, color, ip, wsPort, camPort, autoConnect: auto };
+      connections[idx] = { ...connections[idx], name, color, ip, wsPort, camPort, autoConnect: auto, autoCamera };
     }
     saveUnifiedStorage();
     this.#render();
@@ -234,7 +238,8 @@ export class ConnSettingsModal {
       ip:          "",
       wsPort:      9999,
       camPort:     undefined,
-      autoConnect: false
+      autoConnect: false,
+      autoCamera:  false
     };
     if (!monitorData.appSettings.connections) {
       monitorData.appSettings.connections = [];

--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -345,8 +345,10 @@ function handleSocketOpen(host) {
   }
   st.state = "connected";
   updatePrinterListUI();
-  if (monitorData.appSettings.cameraToggle) {
-    startCameraStream();
+  // connections[] から接続先ホストに対応する autoCamera フラグを参照
+  const _connForHost = (monitorData.appSettings.connections || []).find(c => c.ip === host);
+  if (_connForHost?.autoCamera ?? monitorData.appSettings.cameraToggle) {
+    startCameraStream(host);
   }
   // 接続復帰後は通知抑制を解除
   setNotificationSuppressed(false);

--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -25,7 +25,7 @@
  * - {@link updateConnectionUI}：UI 状態更新
  * - {@link simulateReceivedJson}：受信データシミュレート
  *
- * @version 1.390.683 (PR #314)
+ * @version 1.400.684 (PR #303)
  * @since   1.390.451 (PR #205)
  * @lastModified 2025-07-10 15:54:39
  * -----------------------------------------------------------
@@ -286,7 +286,7 @@ function flushBufferedMessages(host) {
  * @returns {void}
  */
 export function connectWs(hostOrDest) {
-  const inputDest = document.getElementById("destination-input")?.value.trim();
+  const inputDest = (document.getElementById("p1-destination-input") || document.getElementById("destination-input"))?.value.trim();
   let dest = hostOrDest || inputDest || monitorData.appSettings.wsDest || "";
   if (!dest) return;
   if (!dest.includes(":")) dest += ":9999";
@@ -384,13 +384,13 @@ function handleSocketOpen(host) {
     const elapsed = Date.now() - st.hostReadyAt;
 
     if (!st.fileReqSent && elapsed >= 2500) {
-      document.getElementById("btn-file-list")?.click();
+      (document.getElementById("p1-btn-file-list") || document.getElementById("btn-file-list"))?.click();
       st.fileReqSent = true;
     }
 
     if (!st.historyReqSent && elapsed >= 7500) {
       if (!st.historyReceived) {
-        document.getElementById("btn-history-list")?.click();
+        (document.getElementById("p1-btn-history-list") || document.getElementById("btn-history-list"))?.click();
       }
       st.historyReqSent = true;
     }
@@ -740,7 +740,7 @@ export function disconnectWs(host = currentHostname) {
  * @returns {void}
  */
 export function setupConnectButton() {
-  const btn = document.getElementById("connect-button");
+  const btn = document.getElementById("p1-connect-button") || document.getElementById("connect-button");
   if (btn) {
     btn.addEventListener("click", connectWs);
   }
@@ -752,8 +752,8 @@ export function setupConnectButton() {
  *
  * @returns {void}
  */
-export function setupPrinterUI() {
-  const sel = document.getElementById("printer-select");
+export function setupPrinterUI(paneIndex = 1) {
+  const sel = document.getElementById(`p${paneIndex}-printer-select`) || document.getElementById("printer-select");
   if (!sel) return;
   sel.addEventListener("change", () => {
     const host = sel.value;
@@ -880,13 +880,13 @@ export function sendGcodeCommand(gcode, host = currentHostname) {
  * @param {{attempt?: number, max?: number, wait?: number}} [opt={}]
  *   connecting/waiting 時に使用する { attempt, max, wait }
  */
-export function updateConnectionUI(state, opt = {}, host = currentHostname) {
-  const ipInput       = document.getElementById("destination-input");
-  const ipDisplay     = document.getElementById("destination-display");
-  const statusEl      = document.getElementById("connection-status");
-  const btnConnect    = document.getElementById("connect-button");
-  const btnDisconnect = document.getElementById("disconnect-button");
-  const muteTag       = document.getElementById("audio-muted-tag");
+export function updateConnectionUI(state, opt = {}, host = currentHostname, paneIndex = 1) {
+  const ipInput       = document.getElementById(`p${paneIndex}-destination-input`)    || document.getElementById("destination-input");
+  const ipDisplay     = document.getElementById(`p${paneIndex}-destination-display`)  || document.getElementById("destination-display");
+  const statusEl      = document.getElementById(`p${paneIndex}-connection-status`)    || document.getElementById("connection-status");
+  const btnConnect    = document.getElementById(`p${paneIndex}-connect-button`)       || document.getElementById("connect-button");
+  const btnDisconnect = document.getElementById(`p${paneIndex}-disconnect-button`)    || document.getElementById("disconnect-button");
+  const muteTag       = document.getElementById(`p${paneIndex}-audio-muted-tag`)      || document.getElementById("audio-muted-tag");
 
   // wsDest からホスト部のみを取り出す（例 "192.168.1.5:9090" → "192.168.1.5"）
   const st = getState(host);
@@ -1000,21 +1000,24 @@ export function updateConnectionUI(state, opt = {}, host = currentHostname) {
  * @returns {void}
  */
 function updatePrinterListUI() {
-  const sel  = document.getElementById("printer-select");
-  const list = document.getElementById("printer-status-list");
-  if (!sel || !list) return;
-
   const hosts = Object.keys(connectionMap).filter(h => h !== PLACEHOLDER_HOSTNAME);
-  sel.innerHTML = hosts.map(h => `<option value="${h}">${h}</option>`).join("");
-  sel.value = hosts.includes(currentHostname) ? currentHostname : "";
+  const listHtml = hosts.map(h => {
+    const st = connectionMap[h];
+    return `<div>${h} : ${st.state}</div>`;
+  }).join("");
+  const optionsHtml = hosts.map(h => `<option value="${h}">${h}</option>`).join("");
 
-  list.innerHTML = hosts
-    .map(h => {
-      const st = connectionMap[h];
-      const label = `${h} : ${st.state}`;
-      return `<div>${label}</div>`;
-    })
-    .join("");
+  for (const pane of [1, 2]) {
+    const sel  = document.getElementById(`p${pane}-printer-select`) || (pane === 1 ? document.getElementById("printer-select") : null);
+    const list = document.getElementById(`p${pane}-printer-status-list`) || (pane === 1 ? document.getElementById("printer-status-list") : null);
+    if (sel) {
+      sel.innerHTML = optionsHtml;
+      sel.value = hosts.includes(currentHostname) ? currentHostname : "";
+    }
+    if (list) {
+      list.innerHTML = listHtml;
+    }
+  }
 }
 
 /**

--- a/3dp_lib/dashboard_data.js
+++ b/3dp_lib/dashboard_data.js
@@ -199,9 +199,25 @@ export const monitorData = {
     logMaxLines: 1000,
     logLevel: "info",
     autoConnect: true,
-    wsDest: "",          // 接続先 IP:PORT
+    wsDest: "",          // 接続先 IP:PORT (後方互換用、connections[]に移行済み)
     cameraToggle: false,  // カメラ ON/OFF
-    notificationSettings: {}
+    notificationSettings: {},
+    /**
+     * 複数プリンタ接続設定リスト
+     * @type {Array<{id:string, name:string, color:string, ip:string, wsPort:number, camPort?:number, autoConnect:boolean}>}
+     */
+    connections: [],
+    /**
+     * アクティブなダッシュボードレイアウト
+     * "preset1" = 1ペイン, "preset2" = 2ペイン
+     * @type {"preset1"|"preset2"}
+     */
+    activeLayout: "preset1",
+    /**
+     * ペイン番号 → 接続設定ID のマッピング
+     * @type {Object.<number, string|null>}
+     */
+    paneAssignment: { 1: null, 2: null }
   },
   machines: {
     [PLACEHOLDER_HOSTNAME]: {

--- a/3dp_lib/dashboard_layout_manager.js
+++ b/3dp_lib/dashboard_layout_manager.js
@@ -1,0 +1,269 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 レイアウト管理モジュール
+ * @file dashboard_layout_manager.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * @author pumpCurry
+ * -----------------------------------------------------------
+ * @module dashboard_layout_manager
+ *
+ * 【機能内容サマリ】
+ * - ダッシュボードプリセット切り替え（1ペイン / 2ペイン）
+ * - ペイン-プリンタ割り当て管理
+ * - プリンタカラーの CSS 変数適用
+ *
+ * 【公開関数一覧】
+ * - {@link setLayout}：レイアウトプリセットを切り替える
+ * - {@link assignPrinterToPane}：ペインにプリンタを割り当てる
+ * - {@link applyPrinterColor}：ペイン要素にプリンタカラーを適用する
+ * - {@link restoreLayout}：保存済みレイアウトを復元する
+ * - {@link showLayoutSelectDialog}：レイアウト選択ダイアログを開く
+ *
+ * @version 1.400.001 (PR #303)
+ * @since   1.400.001 (PR #303)
+ * @lastModified 2025-07-04 10:30:00
+ * -----------------------------------------------------------
+ * @todo
+ * - none
+ */
+
+"use strict";
+
+import { monitorData } from "./dashboard_data.js";
+import { saveUnifiedStorage } from "./dashboard_storage.js";
+
+// ---------------------------------------------------------------------------
+// レイアウトプリセット定義
+// ---------------------------------------------------------------------------
+
+/**
+ * 利用可能なレイアウトプリセット
+ * @type {Array<{id:string, label:string, icon:string, panes:number}>}
+ */
+const LAYOUT_PRESETS = [
+  { id: "preset1", label: "1 台表示",   icon: "⬛",       panes: 1 },
+  { id: "preset2", label: "2 台並列",   icon: "⬛⬛",    panes: 2 }
+];
+
+// ---------------------------------------------------------------------------
+// レイアウト切り替え
+// ---------------------------------------------------------------------------
+
+/**
+ * ダッシュボードのレイアウトプリセットを切り替えます。
+ *
+ * @param {string} layoutName - レイアウト名 ("preset1" | "preset2")
+ * @returns {void}
+ */
+export function setLayout(layoutName) {
+  const root = document.getElementById("dashboard-root");
+  if (!root) {
+    console.warn("setLayout: #dashboard-root が見つかりません");
+    return;
+  }
+
+  // 既存の layout-xxx クラスをすべて除去
+  root.classList.forEach(cls => {
+    if (cls.startsWith("layout-")) root.classList.remove(cls);
+  });
+  root.classList.add(`layout-${layoutName}`);
+
+  monitorData.appSettings.activeLayout = layoutName;
+  saveUnifiedStorage();
+
+  // 2ペインモード時はペイン2も初期化済みの色を適用
+  if (layoutName === "preset2") {
+    _applyAllPaneColors();
+  }
+
+  // レイアウト切り替えイベントを発行（将来拡張用）
+  document.dispatchEvent(new CustomEvent("dashboard:layout-changed", {
+    detail: { layout: layoutName }
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// ペイン-プリンタ割り当て
+// ---------------------------------------------------------------------------
+
+/**
+ * ペインにプリンタを割り当て、カラーを適用します。
+ *
+ * @param {number|string} paneIndex - ペイン番号 (1 or 2)
+ * @param {string|null}   connectionId - 接続 ID (null で割り当て解除)
+ * @returns {void}
+ */
+export function assignPrinterToPane(paneIndex, connectionId) {
+  const pa = monitorData.appSettings.paneAssignment;
+  if (!pa) {
+    monitorData.appSettings.paneAssignment = {};
+  }
+  monitorData.appSettings.paneAssignment[paneIndex] = connectionId;
+  saveUnifiedStorage();
+
+  const paneEl = document.getElementById(`pane-${paneIndex}`);
+  if (!paneEl) return;
+
+  if (!connectionId) {
+    // 割り当て解除 → デフォルトカラーに戻す
+    paneEl.style.removeProperty("--printer-color");
+    paneEl.style.removeProperty("--printer-color-faint");
+    return;
+  }
+
+  const conn = (monitorData.appSettings.connections || []).find(c => c.id === connectionId);
+  if (conn) {
+    applyPrinterColor(paneEl, conn.color);
+  }
+
+  // ペインのセレクタを更新
+  _updatePaneSelectorValue(paneIndex, connectionId);
+}
+
+// ---------------------------------------------------------------------------
+// カラー適用
+// ---------------------------------------------------------------------------
+
+/**
+ * ペイン要素にプリンタカラーを CSS 変数として適用します。
+ *
+ * @param {HTMLElement} paneEl - ペイン DOM 要素
+ * @param {string}      color  - カラーコード (#rrggbb)
+ * @returns {void}
+ */
+export function applyPrinterColor(paneEl, color) {
+  if (!paneEl || !color) return;
+  paneEl.style.setProperty("--printer-color",       color);
+  paneEl.style.setProperty("--printer-color-faint", color + "1a");
+}
+
+/**
+ * 全ペインのカラーを保存済み割り当てから再適用します。
+ * @private
+ */
+function _applyAllPaneColors() {
+  const pa = monitorData.appSettings.paneAssignment || {};
+  for (const [pane, connId] of Object.entries(pa)) {
+    if (!connId) continue;
+    const conn = (monitorData.appSettings.connections || []).find(c => c.id === connId);
+    if (!conn) continue;
+    const paneEl = document.getElementById(`pane-${pane}`);
+    if (paneEl) applyPrinterColor(paneEl, conn.color);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ペインセレクタ更新
+// ---------------------------------------------------------------------------
+
+/**
+ * ページ内の全ペインセレクタを接続一覧で更新します。
+ * @returns {void}
+ */
+export function updatePaneSelectors() {
+  const connections = monitorData.appSettings.connections || [];
+  const pa = monitorData.appSettings.paneAssignment || {};
+
+  for (const pane of [1, 2]) {
+    const sel = document.querySelector(`.pane-printer-select[data-pane="${pane}"]`);
+    if (!sel) continue;
+
+    sel.innerHTML = `<option value="">-- 未割り当て --</option>` +
+      connections.map(c =>
+        `<option value="${c.id}" ${pa[pane] === c.id ? "selected" : ""}>${c.name || c.ip}</option>`
+      ).join("");
+
+    // 変更時に assignPrinterToPane を呼ぶ
+    if (!sel.dataset.bound) {
+      sel.dataset.bound = "1";
+      sel.addEventListener("change", () => {
+        assignPrinterToPane(pane, sel.value || null);
+      });
+    }
+  }
+}
+
+/**
+ * 指定ペインのセレクタ選択値を更新します。
+ * @private
+ */
+function _updatePaneSelectorValue(paneIndex, connectionId) {
+  const sel = document.querySelector(`.pane-printer-select[data-pane="${paneIndex}"]`);
+  if (sel) sel.value = connectionId || "";
+}
+
+// ---------------------------------------------------------------------------
+// レイアウト復元
+// ---------------------------------------------------------------------------
+
+/**
+ * 保存済みレイアウト設定を復元します。
+ * DOMContentLoaded 後に一度だけ呼び出します。
+ *
+ * @returns {void}
+ */
+export function restoreLayout() {
+  const layout = monitorData.appSettings.activeLayout || "preset1";
+  setLayout(layout);
+
+  // ペインセレクタを接続一覧で埋める
+  updatePaneSelectors();
+
+  // 保存済み割り当てのカラーを適用
+  _applyAllPaneColors();
+}
+
+// ---------------------------------------------------------------------------
+// レイアウト選択ダイアログ
+// ---------------------------------------------------------------------------
+
+/**
+ * レイアウト選択ダイアログを表示します。
+ * グローバルメニューの「ダッシュボード選択...」から呼ばれます。
+ *
+ * @returns {void}
+ */
+export function showLayoutSelectDialog() {
+  // 既存ダイアログがあれば閉じる
+  document.querySelector("dialog.layout-select-dialog")?.remove();
+
+  const dialog = document.createElement("dialog");
+  dialog.className = "layout-select-dialog";
+  dialog.setAttribute("aria-label", "ダッシュボード選択");
+
+  const current = monitorData.appSettings.activeLayout || "preset1";
+
+  dialog.innerHTML = `
+    <div class="layout-select-header">
+      <h2>ダッシュボード選択</h2>
+      <button class="layout-close-btn" aria-label="閉じる">×</button>
+    </div>
+    <div class="layout-options">
+      ${LAYOUT_PRESETS.map(p => `
+        <button class="layout-option-btn ${p.id === current ? "active" : ""}" data-layout="${p.id}">
+          <span class="layout-option-icon">${p.icon}</span>
+          <span class="layout-option-label">${p.label}</span>
+        </button>
+      `).join("")}
+    </div>
+  `;
+
+  dialog.querySelector(".layout-close-btn")
+    ?.addEventListener("click", () => { dialog.close(); dialog.remove(); });
+
+  dialog.querySelectorAll(".layout-option-btn").forEach(btn => {
+    btn.addEventListener("click", () => {
+      setLayout(btn.dataset.layout);
+      updatePaneSelectors();
+      dialog.close();
+      dialog.remove();
+    });
+  });
+
+  dialog.addEventListener("click", e => {
+    if (e.target === dialog) { dialog.close(); dialog.remove(); }
+  });
+
+  document.body.appendChild(dialog);
+  dialog.showModal();
+}

--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -1301,18 +1301,20 @@ export function setupUploadUI() {
 }
 
 /** --- 1) タブ切り替えの初期設定 --- */
-export function initHistoryTabs() {
-  const btnH = document.getElementById("tab-print-history");
-  const btnF = document.getElementById("tab-file-list");
-  const pH = document.getElementById("panel-print-history-tab");
-  const pF = document.getElementById("panel-file-list");
+export function initHistoryTabs(paneIndex = 1) {
+  const prefix = `p${paneIndex}-`;
+  const btnH = document.getElementById(`${prefix}tab-print-history`);
+  const btnF = document.getElementById(`${prefix}tab-file-list`);
+  const pH = document.getElementById(`${prefix}panel-print-history-tab`);
+  const pF = document.getElementById(`${prefix}panel-file-list`);
+  if (!btnH || !btnF) return;
   btnH.addEventListener("click", () => {
     btnH.classList.add("active"); btnF.classList.remove("active");
-    pH.classList.remove("hidden"); pF.classList.add("hidden");
+    pH?.classList.remove("hidden"); pF?.classList.add("hidden");
   });
   btnF.addEventListener("click", () => {
     btnF.classList.add("active"); btnH.classList.remove("active");
-    pF.classList.remove("hidden"); pH.classList.add("hidden");
+    pF?.classList.remove("hidden"); pH?.classList.add("hidden");
   });
 }
 

--- a/3dp_lib/dashboard_stage_preview.js
+++ b/3dp_lib/dashboard_stage_preview.js
@@ -14,9 +14,9 @@
  * 【公開関数一覧】
  * - {@link restoreXYPreviewState} など複数を一括エクスポート
  *
-* @version 1.390.748 (PR #345)
+* @version 1.400.749 (PR #303)
 * @since   1.390.214 (PR #95)
-* @lastModified 2025-07-19 19:51:00
+* @lastModified 2025-07-04 10:30:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -54,7 +54,7 @@ let lastZPosition = 0;         // 最後に描画したZ値
  * @param {string} model - プリンタモデル名
  * @returns {void}
  */
-function setPrinterModel(model) {
+function setPrinterModel(model, paneIndex = 1) {
   if (currentModel === model) return;
   currentModel = model;
   if (model === "K1 Max") {
@@ -66,18 +66,21 @@ function setPrinterModel(model) {
   } else {
     return; // 未対応モデルは変更なし
   }
-  const stageElem = document.getElementById("xy-stage");
-  if (!stageElem) return; // テスト環境などでDOMが無い場合
+  const stageElem = document.getElementById(`p${paneIndex}-xy-stage`) ||
+                    document.getElementById("xy-stage");
+  if (!stageElem) return;
   const px = stageSizeMm * STAGE_SCALE;
   stageElem.style.width = `${px}px`;
   stageElem.style.height = `${px}px`;
   stageElem.innerHTML = "";
   xyDots.length = 0;
   xyInitialized = false;
-  const labelBottom = document.querySelector("#z-preview-container .z-label-bottom");
+  const paneEl = document.getElementById(`pane-${paneIndex}`) || document.body;
+  const labelBottom = paneEl.querySelector("#p${paneIndex}-z-preview-container .z-label-bottom") ||
+                      paneEl.querySelector(".z-label-bottom");
   if (labelBottom) labelBottom.textContent = String(stageZMaxMm);
-  updateXYPreview(lastXYPosition.x, lastXYPosition.y);
-  updateZPreview(lastZPosition);
+  updateXYPreview(lastXYPosition.x, lastXYPosition.y, paneIndex);
+  updateZPreview(lastZPosition, paneIndex);
 }
 
 /**
@@ -148,10 +151,12 @@ function restoreXYHistoryDots() {
  * XY ステージの背景格子やラベル、履歴表示用ドットなど
  * 初期描画を行う。
  *
+ * @param {number} [paneIndex=1] - ペイン番号 (1 または 2)
  * @returns {void}
  */
-function initXYPreview() {
-  const container = document.getElementById("xy-stage");
+function initXYPreview(paneIndex = 1) {
+  const container = document.getElementById(`p${paneIndex}-xy-stage`) ||
+                    document.getElementById("xy-stage");
   if (!container) return; // DOM が存在しなければ何もしない
   container.style.userSelect = "none";
   const gridCount = 7;
@@ -309,17 +314,20 @@ function initXYPreview() {
  * @param {number} y - Y 座標値(mm)
  * @returns {void}
  */
-function updateXYPreview(x, y) {
+function updateXYPreview(x, y, paneIndex = 1) {
   if (!xyInitialized) {
-    initXYPreview();
+    initXYPreview(paneIndex);
   }
   // スケール定義
   const stagePx = stageSizeMm * STAGE_SCALE;
   const screenX = stagePx - (x * STAGE_SCALE);
   const screenY = y * STAGE_SCALE;
 
-  const currentDot = document.getElementById("xy-current-dot");
-  const currentCircle = document.getElementById("xy-current-circle");
+  const paneEl = document.getElementById(`pane-${paneIndex}`) || document.body;
+  const currentDot = paneEl.querySelector(`#p${paneIndex}-xy-current-dot`) ||
+                     document.getElementById("xy-current-dot");
+  const currentCircle = paneEl.querySelector(`#p${paneIndex}-xy-current-circle`) ||
+                        document.getElementById("xy-current-circle");
 
   currentDot.style.right = (screenX - 2.5) + "px";
   currentDot.style.bottom = (screenY - 2.5) + "px";
@@ -347,16 +355,18 @@ function updateXYPreview(x, y) {
  * @param {number} z - Z 座標値(mm)
  * @returns {void}
  */
-function updateZPreview(z) {
+function updateZPreview(z, paneIndex = 1) {
   const scale = 0.5;
   const clampedZ = Math.min(z, stageZMaxMm);
   const barHeight = clampedZ * scale;
-  const barDiv = document.getElementById("z-preview");
+  const barDiv = document.getElementById(`p${paneIndex}-z-preview`) ||
+                 document.getElementById("z-preview");
   if (barDiv) {
     barDiv.style.height = barHeight + "px";
     barDiv.style.backgroundColor = (z < 0) ? "magenta" : "";
   }
-  const zValueElem = document.getElementById("z-value");
+  const zValueElem = document.getElementById(`p${paneIndex}-z-value`) ||
+                     document.getElementById("z-value");
   if (zValueElem) {
     zValueElem.textContent = z.toFixed(2);
   }
@@ -369,8 +379,9 @@ function updateZPreview(z) {
  *
  * @returns {void}
  */
-function applyStageTransform() {
-  const container = document.getElementById("xy-stage");
+function applyStageTransform(paneIndex = 1) {
+  const container = document.getElementById(`p${paneIndex}-xy-stage`) ||
+                    document.getElementById("xy-stage");
   if (container) {
     stageRotX = Math.min(Math.max(stageRotX, STAGE_ROT_X_MIN), STAGE_ROT_X_MAX);
     const rotZ = ((stageRotZ % 360) + 360) % 360;

--- a/3dp_lib/dashboard_stage_preview.js
+++ b/3dp_lib/dashboard_stage_preview.js
@@ -76,7 +76,7 @@ function setPrinterModel(model, paneIndex = 1) {
   xyDots.length = 0;
   xyInitialized = false;
   const paneEl = document.getElementById(`pane-${paneIndex}`) || document.body;
-  const labelBottom = paneEl.querySelector("#p${paneIndex}-z-preview-container .z-label-bottom") ||
+  const labelBottom = paneEl.querySelector(`#p${paneIndex}-z-preview-container .z-label-bottom`) ||
                       paneEl.querySelector(".z-label-bottom");
   if (labelBottom) labelBottom.textContent = String(stageZMaxMm);
   updateXYPreview(lastXYPosition.x, lastXYPosition.y, paneIndex);

--- a/3dp_lib/dashboard_ui.js
+++ b/3dp_lib/dashboard_ui.js
@@ -116,7 +116,10 @@ export function updateStoredDataToDOM() {
     if (Array.isArray(map.domProps)) {
       map.domProps.forEach(({ id, prop }) => {
         try {
-          const el = document.getElementById(id);
+          // ID が p1-/p2- 接頭辞付きに変更されているためフォールバック検索
+          const el = document.getElementById("p1-" + id) ||
+                     document.getElementById("p2-" + id) ||
+                     document.getElementById(id);
           if (!el) {
             throw new Error(`element not found`);
           }

--- a/3dp_lib/dashboard_ui.js
+++ b/3dp_lib/dashboard_ui.js
@@ -229,15 +229,24 @@ export function updateStoredDataToDOM() {
     d.isNew = false;
   }
 }
-/** ログ／通知ボックス・タブ ボタンの参照 */
-const tabReceived  = document.getElementById("tab-received");
-const tabNotification = document.getElementById("tab-notification");
-const receivedBox  = document.getElementById("log");
-const notifBox     = document.getElementById("notification-history");
+/** p1-/p2- 接頭辞付きIDにフォールバックして要素を取得するヘルパー */
+function _getEl(id) {
+  return document.getElementById("p1-" + id) ||
+         document.getElementById("p2-" + id) ||
+         document.getElementById(id);
+}
 
-// タイムスタンプ表示エリア
-const tsReceivedEl = document.getElementById("last-log-timestamp");
-const tsErrorEl    = document.getElementById("last-notification-timestamp");
+/** ログ／通知ボックス・タブ ボタンの参照（DOMContentLoaded 後に取得） */
+let tabReceived, tabNotification, receivedBox, notifBox, tsReceivedEl, tsErrorEl;
+
+function _resolveLogEls() {
+  tabReceived    = _getEl("tab-received");
+  tabNotification = _getEl("tab-notification");
+  receivedBox    = _getEl("log");
+  notifBox       = _getEl("notification-history");
+  tsReceivedEl   = _getEl("last-log-timestamp");
+  tsErrorEl      = _getEl("last-notification-timestamp");
+}
 
 /** 自動スクロール状態と最後にアクティブだったタブ */
 let isAutoScrollEnabled = true;
@@ -286,6 +295,7 @@ function initTabHandlers() {
  * 外部から一度だけ呼び出すイニシャライザ
  */
 export function initUIEventHandlers() {
+  _resolveLogEls();
   initAutoScrollHandlers();
   initTabHandlers();
   initializeCommandPalette();
@@ -313,11 +323,11 @@ function adjustPrintCurrentCardPosition() {
     clearTimeout(adjustTimer);
   }
   adjustTimer = setTimeout(() => {
-    const wrapper = document.getElementById("graph-current-wrapper");
+    const wrapper = _getEl("graph-current-wrapper");
     const graph = wrapper ? wrapper.querySelector(".graph-wrapper") : null;
     const info = document.querySelector(".info-wrapper");
-    const printCard = document.getElementById("print-current-card");
-    const historyCard = document.getElementById("print-history-card");
+    const printCard = _getEl("print-current-card");
+    const historyCard = _getEl("print-history-card");
 
     if (!wrapper || !graph || !info || !printCard || !historyCard) return;
 

--- a/3dp_monitor.css
+++ b/3dp_monitor.css
@@ -1,6 +1,6 @@
-/* 
+/*
   3dp_monitor.css
-  Version1.339
+  Version1.340 - 複数プリンタ対応・マルチペインUI
 */
 
 /* ---------------------------------------------------------------
@@ -11,6 +11,7 @@ body {
   background-color: #f4f4f4;
   margin: 0;
   padding: 10px;
+  padding-top: 58px; /* グローバルメニューバー(48px) + 余白 */
 }
 .card {
   background: #fff;
@@ -1212,4 +1213,483 @@ input:checked + .slider:before {
 #btn-resume-print,
 #btn-resume-print-cmd {
   background-color: #d5f5cf;   /* 薄黄緑 */
+}
+
+/* ================================================================
+   マルチペイン対応スタイル (Version 1.340)
+================================================================ */
+
+/* ---------------------------------------------------------------
+   グローバルメニューバー
+--------------------------------------------------------------- */
+#global-menu-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 48px;
+  background: #222;
+  color: #fff;
+  z-index: 2000;
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  gap: 12px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+}
+.gmb-left {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.gmb-right {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+#gmb-menu-btn {
+  background: none;
+  border: 1px solid #555;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 13px;
+  cursor: pointer;
+  padding: 6px 12px;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+#gmb-menu-btn:hover {
+  background: #444;
+}
+#gmb-dropdown {
+  position: absolute;
+  top: 38px;
+  left: 0;
+  background: #2c2c2c;
+  border: 1px solid #555;
+  border-radius: 4px;
+  z-index: 2100;
+  display: flex;
+  flex-direction: column;
+  min-width: 180px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+}
+#gmb-dropdown.hidden {
+  display: none !important;
+}
+#gmb-dropdown button {
+  padding: 10px 20px;
+  color: #fff;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font-size: 13px;
+  width: 100%;
+}
+#gmb-dropdown button:hover {
+  background: #3a3a3a;
+}
+
+/* ---------------------------------------------------------------
+   ダッシュボードルート
+--------------------------------------------------------------- */
+#dashboard-root {
+  box-sizing: border-box;
+}
+/* 1ペインモード */
+#dashboard-root.layout-preset1 #pane-2 {
+  display: none;
+}
+/* 2ペインモード */
+#dashboard-root.layout-preset2 {
+  display: flex;
+  gap: 0;
+  align-items: flex-start;
+}
+#dashboard-root.layout-preset2 .printer-pane {
+  flex: 0 0 50%;
+  width: 50%;
+  min-width: 0;
+  overflow-x: hidden;
+  border-right: 3px solid #bbb;
+  box-sizing: border-box;
+}
+#dashboard-root.layout-preset2 .printer-pane:last-child {
+  border-right: none;
+}
+
+/* ---------------------------------------------------------------
+   プリンタペイン
+--------------------------------------------------------------- */
+.printer-pane {
+  /* CSS変数のデフォルト値（プリンタカラー） */
+  --printer-color: #444444;
+  --printer-color-light: #44444422;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/* ペインヘッダー */
+.pane-header {
+  background: #ddd;
+  border-bottom: 1px solid #bbb;
+  padding: 4px 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.pane-printer-selector {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+.pane-printer-label {
+  color: #555;
+  white-space: nowrap;
+}
+.pane-printer-select {
+  font-size: 12px;
+  padding: 2px 4px;
+  border: 1px solid #bbb;
+  border-radius: 3px;
+  background: #fff;
+  min-width: 120px;
+}
+
+/* ペイン内のタイトルバー: プリンタカラーで左ボーダー */
+.printer-pane .title-bar {
+  border-left: 5px solid var(--printer-color, #444);
+}
+
+/* ペイン内のカードタイトル: プリンタカラーで背景 */
+.printer-pane .card-title {
+  background-color: var(--printer-color, #444);
+}
+
+/* ペイン内のカード: うっすらプリンタカラーのグラデーション */
+.printer-pane .card {
+  background: linear-gradient(
+    135deg,
+    #ffffff 90%,
+    var(--printer-color-light, #eeeeee) 100%
+  );
+}
+
+/* ---------------------------------------------------------------
+   960px対応レイアウト（固定幅の解消）
+--------------------------------------------------------------- */
+/* プレビューラッパー */
+.printer-pane .preview-wrapper {
+  flex: 0 0 260px;
+  max-width: 260px;
+}
+.printer-pane .preview-body {
+  width: auto;
+  max-width: 248px; /* 260px - padding */
+}
+/* 情報ラッパー */
+.printer-pane .info-wrapper {
+  flex: 1 1 360px;
+  min-width: 0;
+  max-width: none;
+}
+/* col1/col2（状態・操作） */
+.printer-pane .col1,
+.printer-pane .col2 {
+  flex: 1 1 170px;
+  width: auto;
+  max-width: none;
+  min-width: 160px;
+}
+/* グラフラッパー */
+.printer-pane .graph-current-wrapper {
+  flex: 1 0 260px;
+  min-width: 260px;
+}
+
+/* ---------------------------------------------------------------
+   縦積みレイアウト（ペイン幅 ≒ 960px 以下）
+--------------------------------------------------------------- */
+/* 2ペインモード時はペイン自体が約960pxになるため常時適用 */
+#dashboard-root.layout-preset2 .printer-pane .monitor-row {
+  flex-direction: column;
+}
+#dashboard-root.layout-preset2 .printer-pane .preview-wrapper,
+#dashboard-root.layout-preset2 .printer-pane .info-wrapper,
+#dashboard-root.layout-preset2 .printer-pane .graph-current-wrapper {
+  flex: none;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+}
+#dashboard-root.layout-preset2 .printer-pane .preview-body {
+  width: auto;
+  max-width: 100%;
+}
+#dashboard-root.layout-preset2 .printer-pane .status-control-row {
+  flex-wrap: wrap;
+}
+#dashboard-root.layout-preset2 .printer-pane .col1,
+#dashboard-root.layout-preset2 .printer-pane .col2 {
+  flex: 1 1 min(100%, 300px);
+  min-width: 200px;
+}
+#dashboard-root.layout-preset2 .printer-pane .row {
+  flex-wrap: wrap;
+}
+#dashboard-root.layout-preset2 .printer-pane .info-card,
+#dashboard-root.layout-preset2 .printer-pane .log-card {
+  flex: 1 1 100%;
+  min-width: 0;
+}
+
+/* 1ペインモードでもブラウザ幅 ≤ 980px なら縦積み */
+@media (max-width: 980px) {
+  #dashboard-root.layout-preset1 .printer-pane .monitor-row {
+    flex-direction: column;
+  }
+  #dashboard-root.layout-preset1 .printer-pane .preview-wrapper,
+  #dashboard-root.layout-preset1 .printer-pane .info-wrapper,
+  #dashboard-root.layout-preset1 .printer-pane .graph-current-wrapper {
+    flex: none;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+  #dashboard-root.layout-preset1 .printer-pane .row {
+    flex-wrap: wrap;
+  }
+}
+
+/* ---------------------------------------------------------------
+   接続設定モーダル
+--------------------------------------------------------------- */
+dialog.conn-settings-dialog {
+  width: min(860px, 95vw);
+  max-height: 85vh;
+  overflow-y: auto;
+  border: none;
+  border-radius: 6px;
+  padding: 0;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.35);
+}
+dialog.conn-settings-dialog::backdrop {
+  background: rgba(0,0,0,0.5);
+}
+.conn-settings-header {
+  background: #333;
+  color: #fff;
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: bold;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.conn-settings-body {
+  padding: 12px;
+}
+.conn-entry {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 10px;
+  margin-bottom: 10px;
+  background: #fafafa;
+  position: relative;
+}
+.conn-entry-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+.conn-indicator {
+  font-size: 16px;
+  line-height: 1;
+}
+.conn-name-input {
+  font-size: 13px;
+  padding: 4px 6px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  width: 130px;
+}
+.conn-color-input {
+  width: 36px;
+  height: 28px;
+  padding: 2px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  cursor: pointer;
+}
+.conn-auto-label {
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+.conn-addr-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+  font-size: 12px;
+}
+.conn-addr-row label {
+  font-size: 12px;
+  color: #555;
+}
+.conn-ip-input {
+  width: 130px;
+  padding: 3px 5px;
+  font-size: 12px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+}
+.conn-port-input {
+  width: 60px;
+  padding: 3px 5px;
+  font-size: 12px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+}
+.conn-entry input[readonly],
+.conn-entry input:disabled {
+  background: #eee;
+  color: #888;
+  cursor: not-allowed;
+}
+.conn-entry-actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.conn-entry-actions button {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 3px;
+  border: 1px solid #ccc;
+  cursor: pointer;
+  background: #fff;
+}
+.conn-entry-actions .btn-connect {
+  background: #4a9eff;
+  color: #fff;
+  border-color: #3a8ede;
+}
+.conn-entry-actions .btn-disconnect {
+  background: #e05050;
+  color: #fff;
+  border-color: #c04040;
+}
+.conn-entry-actions .btn-delete {
+  background: #f5f5f5;
+  color: #c00;
+  border-color: #ddd;
+}
+.conn-settings-add-row {
+  text-align: center;
+  padding: 8px;
+}
+.conn-settings-add-btn {
+  font-size: 13px;
+  padding: 6px 18px;
+  border-radius: 4px;
+  border: 1px dashed #aaa;
+  background: #f5f5f5;
+  cursor: pointer;
+}
+.conn-settings-add-btn:hover {
+  background: #e8e8e8;
+}
+.conn-readonly-note {
+  font-size: 11px;
+  color: #888;
+  display: block;
+  margin-top: 2px;
+}
+
+/* ---------------------------------------------------------------
+   ダッシュボード選択モーダル
+--------------------------------------------------------------- */
+dialog.layout-select-dialog {
+  width: min(500px, 90vw);
+  border: none;
+  border-radius: 6px;
+  padding: 0;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.35);
+}
+dialog.layout-select-dialog::backdrop {
+  background: rgba(0,0,0,0.5);
+}
+.layout-select-header {
+  background: #333;
+  color: #fff;
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: bold;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.layout-select-body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.layout-option-btn {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border: 2px solid #ddd;
+  border-radius: 6px;
+  background: #fafafa;
+  cursor: pointer;
+  font-size: 13px;
+  text-align: left;
+  transition: border-color 0.15s, background 0.15s;
+}
+.layout-option-btn:hover {
+  border-color: #4a9eff;
+  background: #f0f6ff;
+}
+.layout-option-btn.active {
+  border-color: #4a9eff;
+  background: #e8f2ff;
+}
+.layout-option-icon {
+  font-size: 22px;
+  line-height: 1;
+}
+.layout-option-text {
+  flex: 1;
+}
+.layout-option-title {
+  font-weight: bold;
+  margin-bottom: 2px;
+}
+.layout-option-desc {
+  font-size: 11px;
+  color: #777;
+}
+.dialog-close-btn {
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+.dialog-close-btn:hover {
+  opacity: 0.7;
 }

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -16,9 +16,41 @@
 </head>
 <body>
   <!-- ===============================================================
+       グローバルメニューバー（macメニューバー相当・48px固定）
+  =============================================================== -->
+  <div id="global-menu-bar">
+    <div class="gmb-left">
+      <button id="gmb-menu-btn" aria-haspopup="true" aria-expanded="false">≡ Menu ▾</button>
+      <nav id="gmb-dropdown" class="hidden" role="menu">
+        <button id="gmb-conn-settings" role="menuitem">接続設定...</button>
+        <button id="gmb-layout-select" role="menuitem">ダッシュボード選択...</button>
+      </nav>
+    </div>
+    <div class="gmb-right">
+      <!-- グローバル情報スペース（将来拡張用） -->
+    </div>
+  </div>
+
+  <!-- ===============================================================
+       ダッシュボードルート
+  =============================================================== -->
+  <div id="dashboard-root" class="layout-preset1">
+
+  <div class="printer-pane" id="pane-1" data-pane-index="1">
+      <!-- ペインヘッダー -->
+      <div class="pane-header">
+        <div class="pane-printer-selector">
+          <span class="pane-printer-label">表示中:</span>
+          <select class="pane-printer-select" data-pane="1" aria-label="ペイン1 プリンタ選択">
+            <option value="">-- 未選択 --</option>
+          </select>
+        </div>
+      </div>
+
+<!-- ===============================================================
        最新エラー表示（エラー発生時に表示）
   =============================================================== -->
-  <div class="notification-container" id="notification-container"></div>
+  <div class="notification-container" id="p1-notification-container"></div>
 
   <!-- ===============================================================
        タイトルバー
@@ -40,44 +72,31 @@
     <div class="right">
 
       <!-- ミュートインジケータ（自動生成されるので初期は非表示） -->
-      <span id="audio-muted-tag" style="display:none; cursor:pointer; font-size:12px; margin-left:4px;">
+      <span id="p1-audio-muted-tag" style="display:none; cursor:pointer; font-size:12px; margin-left:4px;">
         🔇:ミュート中
       </span>
       <!-- 接続先入力 -->
-      <input id="destination-input" type="text" placeholder="IP アドレス">
-      <span id="destination-display">----</span>
+      <input id="p1-destination-input" type="text" placeholder="IP アドレス">
+      <span id="p1-destination-display">----</span>
 
       <!-- プリンタ選択 -->
-      <select id="printer-select" style="font-size:12px;"></select>
+      <select id="p1-printer-select" style="font-size:12px;"></select>
 
       <!-- 接続状態一覧 -->
-      <div id="printer-status-list" style="font-size:12px;"></div>
+      <div id="p1-printer-status-list" style="font-size:12px;"></div>
 
       <!-- 自動接続(ON/OFF) -->
       <label style="font-size:12px;">
-        <input type="checkbox" id="auto-connect-toggle">
+        <input type="checkbox" id="p1-auto-connect-toggle">
         自動接続
       </label>
 
       <!-- 接続ボタン / 切断ボタン -->
-      <button id="connect-button" style="font-size:12px;" class="hidden">接続</button>
-      <button id="disconnect-button" style="font-size:12px;" class="hidden">切断</button>
-      <span id="connection-status" style="margin-left:5px; font-size:12px;">----</span>
+      <button id="p1-connect-button" style="font-size:12px;" class="hidden">接続</button>
+      <button id="p1-disconnect-button" style="font-size:12px;" class="hidden">切断</button>
+      <span id="p1-connection-status" style="margin-left:5px; font-size:12px;">----</span>
     </div>
   </div>
-
-
-  <!-- ===============================================================
-       Audio‑Unlock ポップアップ（自動挿入）
-  =============================================================== -->
-  <template id="audio-unlock-template">
-    <div id="audio-unlock-pop" class="card" style="position:fixed; inset:20px; z-index:9999;
-         display:flex; flex-direction:column; align-items:center; justify-content:center;
-         background:#0008; color:#fff; backdrop-filter:blur(2px);">
-      <p style="font-size:1.1em; text-align:center;">サウンドテスト<br>画面ををタップしてください</p>
-      <p id="unlock-count" style="font-size:2em; margin:8px 0 0;">8</p>
-    </div>
-  </template>
 
   <!-- ===============================================================
        機器監視カード
@@ -87,17 +106,17 @@
       機器監視
     </h2>
     <label style="font-size:12px; margin-left:10px; display:inline-block;">
-      <input type="checkbox" id="camera-toggle-title"> カメラON/OFF
+      <input type="checkbox" id="p1-camera-toggle-title"> カメラON/OFF
     </label>
     <div class="camera-wrapper">
-      <img id="camera-feed" class="off" alt="カメラ映像">
+      <img id="p1-camera-feed" class="off" alt="カメラ映像">
       <div class="no-signal">- NO SIGNAL -</div>
-      <div id="camera-status" class="camera-status hidden">
-        <span id="camera-status-label"></span>
-        <span id="camera-status-sub"></span>
-        <div id="camera-spinner" class="spinner hidden"></div>
+      <div id="p1-camera-status" class="camera-status hidden">
+        <span id="p1-camera-status-label"></span>
+        <span id="p1-camera-status-sub"></span>
+        <div id="p1-camera-spinner" class="spinner hidden"></div>
         <br>
-        <button id="camera-cancel-button" class="camera-cancel-btn hidden">接続キャンセル</button>
+        <button id="p1-camera-cancel-button" class="camera-cancel-btn hidden">接続キャンセル</button>
       </div>
     </div>
   </div>
@@ -121,8 +140,8 @@
 
           <div class="preview-body">
             <div class="chamber-container">
-              <div class="chamber" id="xy-chamber">
-                <div class="stage" id="xy-stage"></div>
+              <div class="chamber" id="p1-xy-chamber">
+                <div class="stage" id="p1-xy-stage"></div>
               </div>
               <div class="xy-value-extra">
                 X:
@@ -135,18 +154,18 @@
                 </span>
               </div>
               <div class="stage-rotate-buttons">
-                <button id="btn-stage-flat">⊞</button>
-                <button id="btn-stage-45">⏢</button>
-                <button id="btn-stage-65-72">⪩</button>
-                <button id="btn-stage-spin">⟲</button>
+                <button id="p1-btn-stage-flat">⊞</button>
+                <button id="p1-btn-stage-45">⏢</button>
+                <button id="p1-btn-stage-65-72">⪩</button>
+                <button id="p1-btn-stage-spin">⟲</button>
               </div>
             </div>
             <div class="z-container">
-              <div id="z-preview-container">
+              <div id="p1-z-preview-container">
                 <div class="z-label-top">0</div>
                 <div class="z-label-bottom">300</div>
-                <div id="z-preview"></div>
-                <div id="z-value"></div>
+                <div id="p1-z-preview"></div>
+                <div id="p1-z-value"></div>
               </div>
               <div class="z-value-extra">
                 Z:
@@ -169,15 +188,15 @@
 
 
           <!-- フィラメントプレビュー -->
-          <div class="card" id="filament-preview-card" style="margin-top:10px;">
+          <div class="card" id="p1-filament-preview-card" style="margin-top:10px;">
             <div class="filament-header">
               <h2 class="card-title">フィラメント</h2>
               <div class="filament-actions">
-                <button id="filament-change-btn" class="btn" style="font-size:12px;">交換</button>
-                <button id="filament-list-btn" class="btn" style="font-size:12px;">一覧</button>
+                <button id="p1-filament-change-btn" class="btn" style="font-size:12px;">交換</button>
+                <button id="p1-filament-list-btn" class="btn" style="font-size:12px;">一覧</button>
               </div>
             </div>
-            <div id="filament-preview"></div>
+            <div id="p1-filament-preview"></div>
           </div>
         </div>
 
@@ -291,21 +310,21 @@
           <div class="col2">
           <h2 class="card-title">操作パネル</h2>
           <div class="cmd-group">
-            <button id="btn-stop-print">停止</button>
-            <button id="btn-pause-print">一時停止</button>
-            <button id="btn-resume-print">再開</button>
-            <button id="btn-ack-error">エラー了承</button>
-            <button id="btn-pause-home">一時停止時<br>原点復帰</button>
-            <button id="btn-xy-unlock">XYロック解除</button>
+            <button id="p1-btn-stop-print">停止</button>
+            <button id="p1-btn-pause-print">一時停止</button>
+            <button id="p1-btn-resume-print">再開</button>
+            <button id="p1-btn-ack-error">エラー了承</button>
+            <button id="p1-btn-pause-home">一時停止時<br>原点復帰</button>
+            <button id="p1-btn-xy-unlock">XYロック解除</button>
           </div>
           <div class="cmd-group">
-            <button id="btn-history-list">履歴一覧取得</button>
-            <button id="btn-file-list">ファイル一覧取得</button>
-            <button id="btn-send-gcode">G-code送信</button>
-            <button id="btn-send-raw-json">JSONコマンド送信</button>
+            <button id="p1-btn-history-list">履歴一覧取得</button>
+            <button id="p1-btn-file-list">ファイル一覧取得</button>
+            <button id="p1-btn-send-gcode">G-code送信</button>
+            <button id="p1-btn-send-raw-json">JSONコマンド送信</button>
           </div>
           <div class="cmd-group">
-            <button id="btn-test-raw-json">JSONコマンドテスト</button>
+            <button id="p1-btn-test-raw-json">JSONコマンドテスト</button>
           </div>
           <div class="control-temp-area">
             <div class="temp-row" style="margin-top:5px;">
@@ -332,9 +351,9 @@
                   </span>
                 </div>
                 <div class="control-row">
-                  <input type="range" id="nozzleTempSlider" data-field="targetNozzleTemp" min="0" max="0" step="1"/>
-                  <input type="number" id="nozzleTempInput" data-field="targetNozzleTemp" min="0" max="0" style="width:4em" />
-                  <button id="nozzleTempSendBtn" class="send-btn">⏎</button>
+                  <input type="range" id="p1-nozzleTempSlider" data-field="targetNozzleTemp" min="0" max="0" step="1"/>
+                  <input type="number" id="p1-nozzleTempInput" data-field="targetNozzleTemp" min="0" max="0" style="width:4em" />
+                  <button id="p1-nozzleTempSendBtn" class="send-btn">⏎</button>
                   </div>
                 </div>
 
@@ -361,9 +380,9 @@
                   </span>
                 </div>
                 <div class="control-row">
-                  <input type="range"  id="bedTempSlider" data-field="targetBedTemp0" min="0" max="0" step="1" />
-                  <input type="number" id="bedTempInput"  data-field="targetBedTemp0" min="0" max="0" style="width:4em" />
-                  <button id="bedTempSendBtn" class="send-btn">⏎</button>
+                  <input type="range"  id="p1-bedTempSlider" data-field="targetBedTemp0" min="0" max="0" step="1" />
+                  <input type="number" id="p1-bedTempInput"  data-field="targetBedTemp0" min="0" max="0" style="width:4em" />
+                  <button id="p1-bedTempSendBtn" class="send-btn">⏎</button>
                   </div>
                 </div>
 
@@ -382,7 +401,7 @@
               <div class="fan-item">
                 <strong>モデルFAN</strong>
                 <label class="switch">
-                  <input type="checkbox" id="modelFanToggle2" data-field="fan">
+                  <input type="checkbox" id="p1-modelFanToggle2" data-field="fan">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -391,8 +410,8 @@
                   </span>
                 </div>
                 <div>
-                  <input type="range" id="modelFanSlider" min="0" max="100" step="1" data-field="modelFanPct">
-                  <span data-field="modelFanPct" id="modelFanSliderValue">
+                  <input type="range" id="p1-modelFanSlider" min="0" max="100" step="1" data-field="modelFanPct">
+                  <span data-field="modelFanPct" id="p1-modelFanSliderValue">
                     <span class="value">--</span><span class="unit">%</span>
                   </span>
                 </div>
@@ -401,7 +420,7 @@
               <div class="fan-item">
                 <strong>側面FAN</strong>
                 <label class="switch">
-                  <input type="checkbox" id="sideFanToggle2" data-field="fanAuxiliary">
+                  <input type="checkbox" id="p1-sideFanToggle2" data-field="fanAuxiliary">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -409,15 +428,15 @@
                     <span class="value">--</span><span class="unit">%</span>
                   </span>
                 </div>
-                  <input type="range" id="auxiliaryFanSlider" min="0" max="100" step="1" data-field="auxiliaryFanPct">
-                  <span data-field="auxiliaryFanPct" id="auxiliaryFanSliderValue">
+                  <input type="range" id="p1-auxiliaryFanSlider" min="0" max="100" step="1" data-field="auxiliaryFanPct">
+                  <span data-field="auxiliaryFanPct" id="p1-auxiliaryFanSliderValue">
                     <span class="value">--</span><span class="unit">%</span>
                   </span>
               </div>
               <div class="fan-item">
                 <strong>背面FAN</strong>
                 <label class="switch">
-                  <input type="checkbox" id="backFanToggle2" data-field="fanCase">
+                  <input type="checkbox" id="p1-backFanToggle2" data-field="fanCase">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -426,8 +445,8 @@
                   </span>
                 </div>
                 <div>
-                  <input type="range" id="caseFanSlider" min="0" max="100" step="1" data-field="caseFanPct">
-                  <span data-field="caseFanPct" id="caseFanSliderValue">
+                  <input type="range" id="p1-caseFanSlider" min="0" max="100" step="1" data-field="caseFanPct">
+                  <span data-field="caseFanPct" id="p1-caseFanSliderValue">
                     <span class="value">--</span><span class="unit">%</span>
                   </span>
                 </div>
@@ -437,7 +456,7 @@
               <div class="fan-item">
                 <strong>LED照明</strong>
                 <label class="switch">
-                  <input type="checkbox" id="ledToggle2" data-field="lightSw">
+                  <input type="checkbox" id="p1-ledToggle2" data-field="lightSw">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -449,7 +468,7 @@
               <div class="fan-item">
                 <strong>材料切れ検知</strong>
                 <label class="switch">
-                  <input type="checkbox" id="materialDetectToggle" data-field="materialDetect">
+                  <input type="checkbox" id="p1-materialDetectToggle" data-field="materialDetect">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -468,7 +487,7 @@
               <div class="fan-item">
                 <strong class="feature-name"><nobr>印刷前AI</nobr><wbr><nobr>自動調整</nobr></strong>
                 <label class="switch">
-                  <input type="checkbox" id="aiSwToggle" data-field="aiSw">
+                  <input type="checkbox" id="p1-aiSwToggle" data-field="aiSw">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -480,7 +499,7 @@
               <div class="fan-item">
                 <strong class="feature-name"><nobr>異常出力</nobr><wbr><nobr>AI検知</nobr></strong>
                 <label class="switch">
-                  <input type="checkbox" id="aiDetectionToggle" data-field="aiDetection">
+                  <input type="checkbox" id="p1-aiDetectionToggle" data-field="aiDetection">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -492,7 +511,7 @@
               <div class="fan-item">
                 <strong class="feature-name"><nobr>初層出力</nobr><wbr><nobr>AI確認</nobr></strong>
                 <label class="switch">
-                  <input type="checkbox" id="aiFirstFloorToggle" data-field="aiFirstFloor">
+                  <input type="checkbox" id="p1-aiFirstFloorToggle" data-field="aiFirstFloor">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -504,7 +523,7 @@
               <div class="fan-item">
                 <strong class="feature-name"><nobr>異常時</nobr><wbr><nobr>一時停止</nobr></strong>
                 <label class="switch">
-                  <input type="checkbox" id="aiPausePrintToggle" data-field="aiPausePrint">
+                  <input type="checkbox" id="p1-aiPausePrintToggle" data-field="aiPausePrint">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -526,17 +545,17 @@
                 </div>
                 <div class="control-row">
                   <input type="range"
-                         id="feedrateSlider"
+                         id="p1-feedrateSlider"
                          data-field="curFeedratePct"
                          step="1"
                          min="0" max="200" />
                   <input type="number"
-                         id="feedrateInput"
+                         id="p1-feedrateInput"
                          data-field="curFeedratePct"
                          min="0" max="200"
                          step="1"
                          style="width:4em" />
-                  <button id="feedrateSendBtn" class="send-btn">⏎</button>
+                  <button id="p1-feedrateSendBtn" class="send-btn">⏎</button>
                   <div class="quick-buttons">
                     <button class="feedrate-preset" data-value="50">50%</button>
                     <button class="feedrate-preset" data-value="80">80%</button>
@@ -556,16 +575,16 @@
                 </div>
                 <div class="control-row">
                   <input type="range"
-                         id="flowrateSlider"
+                         id="p1-flowrateSlider"
                          data-field="curFlowratePct"
                          step="1"
                          min="0" max="200" />
                   <input type="number"
-                         id="flowrateInput"
+                         id="p1-flowrateInput"
                          data-field="curFlowratePct"
                          min="0" max="200"
                          style="width:4em" />
-                  <button id="flowrateSendBtn" class="send-btn">⏎</button>
+                  <button id="p1-flowrateSendBtn" class="send-btn">⏎</button>
                   <div class="quick-buttons">
                     <button class="flowrate-preset" data-value="90">90%</button>
                     <button class="flowrate-preset" data-value="100">100%</button>
@@ -582,15 +601,15 @@
     </div>
 
     <!-- 右側：温度グラフ -->
-    <div id="graph-current-wrapper" class="graph-current-wrapper">
+    <div id="p1-graph-current-wrapper" class="graph-current-wrapper">
       <div class="graph-wrapper">
         <div class="card" id="temp-graph-card">
           <div style="display:flex; align-items:center;">
             <h2 class="card-title">温度グラフ (過去15分)</h2>
-            <button id="temp-graph-reset-button" style="font-size:12px; margin-left:4px;">リセット</button>
+            <button id="p1-temp-graph-reset-button" style="font-size:12px; margin-left:4px;">リセット</button>
           </div>
           <div style="position: relative; width: 100%; height: 300px;">
-            <canvas id="temp-graph-canvas" style="width:100%; height:300px;"></canvas>
+            <canvas id="p1-temp-graph-canvas" style="width:100%; height:300px;"></canvas>
           </div>
         </div>
       </div>
@@ -668,39 +687,39 @@
       <h2 class="card-title">ログ</h2>
       <div class="log-card-header">
         <div class="tabs">
-          <button id="tab-received" class="active">受信ログ</button>
-          <button id="tab-notification">通知ログ</button>
+          <button id="p1-tab-received" class="active">受信ログ</button>
+          <button id="p1-tab-notification">通知ログ</button>
         </div>
-        <div id="log-controls" class="log-controls">
-          <button id="copy-all-button" data-original="全てコピー" style="font-size:12px;">全てコピー</button>
-          <button id="copy-last-50-button" data-original="最後50行コピー" style="font-size:12px;">最後50行コピー</button>
-          <button id="copy-storeddata-button" data-original="storedDataコピー" style="font-size:12px;">storedDataコピー</button>
+        <div id="p1-log-controls" class="log-controls">
+          <button id="p1-copy-all-button" data-original="全てコピー" style="font-size:12px;">全てコピー</button>
+          <button id="p1-copy-last-50-button" data-original="最後50行コピー" style="font-size:12px;">最後50行コピー</button>
+          <button id="p1-copy-storeddata-button" data-original="storedDataコピー" style="font-size:12px;">storedDataコピー</button>
         </div>
-        <div id="last-log-timestamp" class="log-timestamp" style="font-size:12px;">
+        <div id="p1-last-log-timestamp" class="log-timestamp" style="font-size:12px;">
           最新受信日時:
           <span data-field="lastLogTimestamp" class="old">
             <span class="value">====-==-==T--:--:--.------Z</span><span class="unit"></span>
           </span>
         </div>
-        <div id="last-notification-timestamp" class="log-timestamp hidden" style="font-size:12px;">
+        <div id="p1-last-notification-timestamp" class="log-timestamp hidden" style="font-size:12px;">
           最新通知日時:
           <span data-field="lastNotificationTimestamp" class="old">
             <span class="value">====-==-==T--:--:--.------Z</span><span class="unit"></span>
           </span>
         </div>
-        <div id="notification-controls" class="log-controls hidden">
-          <button id="copy-all-notification-button" data-original="全通知コピー" style="font-size:12px;">全通知コピー</button>
-          <button id="copy-last-50-notification-button" data-original="最後50行通知コピー" style="font-size:12px;">最後50行通知コピー</button>
-          <button id="clear-notification-logs-button" data-original="通知全消去" style="font-size:12px;">通知全消去</button>
+        <div id="p1-notification-controls" class="log-controls hidden">
+          <button id="p1-copy-all-notification-button" data-original="全通知コピー" style="font-size:12px;">全通知コピー</button>
+          <button id="p1-copy-last-50-notification-button" data-original="最後50行通知コピー" style="font-size:12px;">最後50行通知コピー</button>
+          <button id="p1-clear-notification-logs-button" data-original="通知全消去" style="font-size:12px;">通知全消去</button>
         </div>
       </div>
 
       <div class="tab-content">
         <!-- ログ表示エリア -->
-        <div id="log" class="log-box"></div>
+        <div id="p1-log" class="log-box"></div>
 
         <!-- 通知表示エリア (hidden 初期表示) -->
-        <div id="notification-history" class="log-box hidden"></div>
+        <div id="p1-notification-history" class="log-box hidden"></div>
       </div>
     </div>
   </div>
@@ -708,26 +727,26 @@
 
   <!-- ──────────────── 印刷状況カード群 ──────────────── -->
   <!-- ① 現在の印刷カード -->
-  <div class="card" id="print-current-card">
+  <div class="card" id="p1-print-current-card">
     <h2 class="card-title">現在の印刷</h2>
-    <div id="print-current-container" style="font-size:0.9em;">
+    <div id="p1-print-current-container" style="font-size:0.9em;">
       <!-- JavaScript で renderPrintCurrent が埋めます -->
     </div>
   </div>
 
   <!-- ② 印刷履歴カード -->
-  <div class="card print-history-card" id="print-history-card">
+  <div class="card print-history-card" id="p1-print-history-card">
 
     <div class="card-header">
       <div class="tabs">
-        <button id="tab-print-history" class="active">印刷履歴</button>
-        <button id="tab-file-list">ファイル一覧</button>
+        <button id="p1-tab-print-history" class="active">印刷履歴</button>
+        <button id="p1-tab-file-list">ファイル一覧</button>
       </div>
     </div>
 
     <div class="tab-content">
       <!-- ─── 印刷履歴タブ ─── -->
-      <div id="panel-print-history-tab">
+      <div id="p1-panel-print-history-tab">
   
       <h2 class="card-title">印刷履歴</h2>
       <div style="font-size:0.9em;">
@@ -744,21 +763,21 @@
           <span data-field="totalUsageMaterial"><span class="value">----</span><span class="unit"></span>
         </div>
       </div>
-      <button id="history-refresh-btn" class="btn" aria-label="履歴を更新">再読み込み</button>
+      <button id="p1-history-refresh-btn" class="btn" aria-label="履歴を更新">再読み込み</button>
   
       <!-- 暫定配置 ファイル一覧に本来ならあるべき -->
       <div class="cmd-group">
         <label>アップロード GCode:</label>
-        <input type="file" id="gcode-upload-input" accept=".gcode" />
-        <button id="gcode-upload-btn">アップロード</button>
-        <span id="gcode-upload-progress" class="upload-progress hidden">
+        <input type="file" id="p1-gcode-upload-input" accept=".gcode" />
+        <button id="p1-gcode-upload-btn">アップロード</button>
+        <span id="p1-gcode-upload-progress" class="upload-progress hidden">
           <span class="spinner"></span>
-          <span id="gcode-upload-percent">0%</span>
+          <span id="p1-gcode-upload-percent">0%</span>
         </span>
       </div>
       <!-- /暫定配置 -->
-      <div id="print-history-body" class="scrollable-body">
-        <table id="print-history-table" class="fixed-header" border="1" style="border-collapse: collapse; width:100%;">
+      <div id="p1-print-history-body" class="scrollable-body">
+        <table id="p1-print-history-table" class="fixed-header" border="1" style="border-collapse: collapse; width:100%;">
           <thead>
             <tr>
                 <th data-key="command">ｺﾏﾝﾄﾞ</th>
@@ -794,10 +813,10 @@
       </div>
 
       <!-- ─── ファイル一覧タブ ─── -->
-      <div id="panel-file-list" class="hidden">
-      <div>総ファイル数: <span id="file-list-total">0</span></div>
+      <div id="p1-panel-file-list" class="hidden">
+      <div>総ファイル数: <span id="p1-file-list-total">0</span></div>
       <div class="filelist-container scrollable-body">
-        <table id="file-list-table" class="fixed-header" style="width:100%; table-layout:auto;">
+        <table id="p1-file-list-table" class="fixed-header" style="width:100%; table-layout:auto;">
           <thead>
             <tr>
               <th data-key="command">ｺﾏﾝﾄﾞ</th>
@@ -820,23 +839,23 @@
     </div>
 
 
-  <div id="settings-card" class="card">
+  <div id="p1-settings-card" class="card">
     <h2  class="card-title">設定</h2>
-    <div id="storage-panel-container">
+    <div id="p1-storage-panel-container">
       <!-- ─────────────── ストレージ同期パネル ─────────────── -->
-      <details id="storage-panel" style="margin-top:10px;">
+      <details id="p1-storage-panel" style="margin-top:10px;">
         <summary style="cursor:pointer; font-weight:bold;">ストレージ設定</summary>
         <div style="padding:8px; font-size:0.9em;">
-          <div>使用量: <span id="storage-usage">-- / -- (--%)</span></div>
-          <div>最終同期: <span id="storage-last-sync">----</span></div>
-          <button id="storage-save-btn" style="font-size:12px; margin-top:5px;">保存</button>
-          <button id="storage-quota-test-btn" style="font-size:12px; margin-top:5px;">クォータテスト</button>
-          <button id="clear-storage-button" class="btn btn-danger btn-sm ms-2">全ストレージ削除</button>
-          <div id="storage-error" style="color:red; display:none; margin-top:5px;">⚠ 容量取得エラー</div>
+          <div>使用量: <span id="p1-storage-usage">-- / -- (--%)</span></div>
+          <div>最終同期: <span id="p1-storage-last-sync">----</span></div>
+          <button id="p1-storage-save-btn" style="font-size:12px; margin-top:5px;">保存</button>
+          <button id="p1-storage-quota-test-btn" style="font-size:12px; margin-top:5px;">クォータテスト</button>
+          <button id="p1-clear-storage-button" class="btn btn-danger btn-sm ms-2">全ストレージ削除</button>
+          <div id="p1-storage-error" style="color:red; display:none; margin-top:5px;">⚠ 容量取得エラー</div>
         </div>
         <div class="cmd-group">
-          <label for="setting-log-max-lines"><strong>ログ最大行数:</strong></label>
-          <input type="number" id="setting-log-max-lines"
+          <label for="p1-setting-log-max-lines"><strong>ログ最大行数:</strong></label>
+          <input type="number" id="p1-setting-log-max-lines"
             min="100"
             step="100"
             value="1000"
@@ -845,25 +864,25 @@
 
 
         <!-- 確認ダイアログ -->
-        <div id="confirm-delete-modal" class="confirm-modal" style="display:none;">
+        <div id="p1-confirm-delete-modal" class="confirm-modal" style="display:none;">
           <div class="confirm-modal-box">
             <p>全ストレージを本当に削除しますか？</p>
             <div class="btn-group">
-              <button id="confirm-delete-ok" class="btn btn-danger btn-sm">削除する</button>
-              <button id="confirm-delete-cancel" class="btn btn-secondary btn-sm">キャンセル</button>
+              <button id="p1-confirm-delete-ok" class="btn btn-danger btn-sm">削除する</button>
+              <button id="p1-confirm-delete-cancel" class="btn btn-secondary btn-sm">キャンセル</button>
             </div>
           </div>
         </div>
       </details>
     </div>
 
-    <div id="notification-settings-panel">
+    <div id="p1-notification-settings-panel">
       <!-- ───────────── 通知設定パネル ───────────── -->
-      <details id="notification-panel" style="margin-top:10px;">
+      <details id="p1-notification-panel" style="margin-top:10px;">
         <summary style="cursor:pointer; font-weight:bold;">通知設定</summary>
         <fieldset class="notification-panel-field" style="margin-top:1em; padding:0.5em; border:1px solid #ccc; border-radius:4px;">
           <legend style="font-weight:bold;">メッセージ内容設定</legend>
-          <div id="notification-panel-body" style="padding:8px; font-size:0.9em;">
+          <div id="p1-notification-panel-body" style="padding:8px; font-size:0.9em;">
             <!-- 各通知タイプの切り替えUIはここに動的追加 -->
           </div>
         </fieldset>
@@ -871,34 +890,34 @@
 
 
     </div>
-    <div id="spool-settings-panel">
-      <details id="spool-panel" style="margin-top:10px;">
+    <div id="p1-spool-settings-panel">
+      <details id="p1-spool-panel" style="margin-top:10px;">
         <summary style="cursor:pointer; font-weight:bold;">フィラメントスプール</summary>
         <div style="padding:8px; font-size:0.9em;">
-          <ul id="spool-list"></ul>
-          <button id="spool-add-btn" style="font-size:12px;">追加</button>
+          <ul id="p1-spool-list"></ul>
+          <button id="p1-spool-add-btn" style="font-size:12px;">追加</button>
         </div>
       </details>
     </div>
 <!-- 既存の設定カードの直後に追加 -->
-    <div id="command-palette-panel-container">
+    <div id="p1-command-palette-panel-container">
       <!-- ─────────────── ストレージ同期パネル ─────────────── -->
-      <details id="command-palette" style="margin-top:10px;">
+      <details id="p1-command-palette" style="margin-top:10px;">
         <summary style="cursor:pointer; font-weight:bold;">コマンドパレット</summary>
           <!-- 新: 停止・一時停止・再開 -->
           <div class="cmd-group">
-            <button id="btn-stop-print-cmd">停止</button>
-            <button id="btn-pause-print-cmd">一時停止</button>
-            <button id="btn-resume-print-cmd">再開</button>
+            <button id="p1-btn-stop-print-cmd">停止</button>
+            <button id="p1-btn-pause-print-cmd">一時停止</button>
+            <button id="p1-btn-resume-print-cmd">再開</button>
           </div>
           <br/><br/><br/>
           <!-- 新: 履歴一覧取得 -->
           <div class="cmd-group">
-            <button id="btn-history-list-cmd">履歴一覧取得</button>
+            <button id="p1-btn-history-list-cmd">履歴一覧取得</button>
           </div>
           <!-- 新: G-codeファイル一覧取得 -->
           <div class="cmd-group">
-            <button id="btn-file-list-cmd">ファイル一覧取得</button>
+            <button id="p1-btn-file-list-cmd">ファイル一覧取得</button>
           </div>
 
           <div class="col2">
@@ -927,9 +946,9 @@
                   </span>
                 </div>
                 <div class="control-row">
-                  <input type="range" id="nozzleTempSlider" data-field="targetNozzleTemp" min="0" max="0" step="1" />
-                  <input type="number" id="nozzleTempInput" data-field="targetNozzleTemp" min="0" max="0" step="1" style="width:4em" />
-                  <button id="nozzleTempSendBtn" class="send-btn">⏎</button>
+                  <input type="range" id="p1-nozzleTempSlider" data-field="targetNozzleTemp" min="0" max="0" step="1" />
+                  <input type="number" id="p1-nozzleTempInput" data-field="targetNozzleTemp" min="0" max="0" step="1" style="width:4em" />
+                  <button id="p1-nozzleTempSendBtn" class="send-btn">⏎</button>
                   </div>
                 </div>
 
@@ -956,9 +975,9 @@
                   </span>
                 </div>
                 <div class="control-row">
-                  <input type="range"  id="bedTempSlider" data-field="targetBedTemp0" min="0" max="0" step="1" />
-                  <input type="number" id="bedTempInput"  data-field="targetBedTemp0" min="0" max="0" step="1" style="width:4em" />
-                  <button id="bedTempSendBtn" class="send-btn">⏎</button>
+                  <input type="range"  id="p1-bedTempSlider" data-field="targetBedTemp0" min="0" max="0" step="1" />
+                  <input type="number" id="p1-bedTempInput"  data-field="targetBedTemp0" min="0" max="0" step="1" style="width:4em" />
+                  <button id="p1-bedTempSendBtn" class="send-btn">⏎</button>
                   </div>
                 </div>
 
@@ -977,7 +996,7 @@
               <div class="fan-item">
                 <strong>モデルFAN</strong>
                 <label class="switch">
-                  <input type="checkbox" id="modelFanToggle2" data-field="fan">
+                  <input type="checkbox" id="p1-modelFanToggle2" data-field="fan">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -986,8 +1005,8 @@
                   </span>
                 </div>
                 <div>
-                  <input type="range" id="modelFanSlider" min="0" max="100" step="1" data-field="modelFanPct">
-                  <span data-field="modelFanPct" id="modelFanSliderValue">
+                  <input type="range" id="p1-modelFanSlider" min="0" max="100" step="1" data-field="modelFanPct">
+                  <span data-field="modelFanPct" id="p1-modelFanSliderValue">
                     <span class="value">--</span><span class="unit">%</span>
                   </span>
                 </div>
@@ -996,7 +1015,7 @@
               <div class="fan-item">
                 <strong>側面FAN</strong>
                 <label class="switch">
-                  <input type="checkbox" id="sideFanToggle2" data-field="fanAuxiliary">
+                  <input type="checkbox" id="p1-sideFanToggle2" data-field="fanAuxiliary">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -1004,15 +1023,15 @@
                     <span class="value">--</span><span class="unit">%</span>
                   </span>
                 </div>
-                  <input type="range" id="auxiliaryFanSlider" min="0" max="100" step="1" data-field="auxiliaryFanPct">
-                  <span data-field="auxiliaryFanPct" id="auxiliaryFanSliderValue">
+                  <input type="range" id="p1-auxiliaryFanSlider" min="0" max="100" step="1" data-field="auxiliaryFanPct">
+                  <span data-field="auxiliaryFanPct" id="p1-auxiliaryFanSliderValue">
                     <span class="value">--</span><span class="unit">%</span>
                   </span>
               </div>
               <div class="fan-item">
                 <strong>背面FAN</strong>
                 <label class="switch">
-                  <input type="checkbox" id="backFanToggle2" data-field="fanCase">
+                  <input type="checkbox" id="p1-backFanToggle2" data-field="fanCase">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -1021,8 +1040,8 @@
                   </span>
                 </div>
                 <div>
-                  <input type="range" id="caseFanSlider" min="0" max="100" step="1" data-field="caseFanPct">
-                  <span data-field="caseFanPct" id="caseFanSliderValue">
+                  <input type="range" id="p1-caseFanSlider" min="0" max="100" step="1" data-field="caseFanPct">
+                  <span data-field="caseFanPct" id="p1-caseFanSliderValue">
                     <span class="value">--</span><span class="unit">%</span>
                   </span>
                 </div>
@@ -1032,7 +1051,7 @@
               <div class="fan-item">
                 <strong>LED照明</strong>
                 <label class="switch">
-                  <input type="checkbox" id="ledToggle2" data-field="lightSw">
+                  <input type="checkbox" id="p1-ledToggle2" data-field="lightSw">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -1044,7 +1063,7 @@
               <div class="fan-item">
                 <strong>材料切れ検知</strong>
                 <label class="switch">
-                  <input type="checkbox" id="materialDetectToggle" data-field="materialDetect">
+                  <input type="checkbox" id="p1-materialDetectToggle" data-field="materialDetect">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -1063,7 +1082,7 @@
               <div class="fan-item">
                 <strong class="feature-name"><nobr>印刷前AI</nobr><wbr><nobr>自動調整</nobr></strong>
                 <label class="switch">
-                  <input type="checkbox" id="aiSwToggle" data-field="aiSw">
+                  <input type="checkbox" id="p1-aiSwToggle" data-field="aiSw">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -1075,7 +1094,7 @@
               <div class="fan-item">
                 <strong class="feature-name"><nobr>異常出力</nobr><wbr><nobr>AI検知</nobr></strong>
                 <label class="switch">
-                  <input type="checkbox" id="aiDetectionToggle" data-field="aiDetection">
+                  <input type="checkbox" id="p1-aiDetectionToggle" data-field="aiDetection">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -1087,7 +1106,7 @@
               <div class="fan-item">
                 <strong class="feature-name"><nobr>初層出力</nobr><wbr><nobr>AI確認</nobr></strong>
                 <label class="switch">
-                  <input type="checkbox" id="aiFirstFloorToggle" data-field="aiFirstFloor">
+                  <input type="checkbox" id="p1-aiFirstFloorToggle" data-field="aiFirstFloor">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -1099,7 +1118,7 @@
               <div class="fan-item">
                 <strong class="feature-name"><nobr>異常時</nobr><wbr><nobr>一時停止</nobr></strong>
                 <label class="switch">
-                  <input type="checkbox" id="aiPausePrintToggle" data-field="aiPausePrint">
+                  <input type="checkbox" id="p1-aiPausePrintToggle" data-field="aiPausePrint">
                   <span class="slider"></span>
                 </label>
                 <div>
@@ -1113,154 +1132,154 @@
 
           <!-- 新: 温度取得 -->
           <div class="cmd-group">
-            <button id="btn-get-status">温度取得</button>
+            <button id="p1-btn-get-status">温度取得</button>
           </div>
       
           <!-- 新: 印刷開始（ファイルパス指定） -->
           <div class="cmd-group">
             <label>印刷ファイルパス:</label>
-            <input id="cmd-print-filepath" type="text" placeholder="例: /gcode/test.gcode" />
-            <button id="btn-print-file">印刷開始</button>
+            <input id="p1-cmd-print-filepath" type="text" placeholder="例: /gcode/test.gcode" />
+            <button id="p1-btn-print-file">印刷開始</button>
           </div>
       
 
       
           <!-- 新: ホーム復帰・ベッドレベリング -->
           <div class="cmd-group">
-            <button id="btn-autohome">ホーム復帰</button>
-            <button id="btn-autolevel">ベッドレベリング</button>
+            <button id="p1-btn-autohome">ホーム復帰</button>
+            <button id="p1-btn-autolevel">ベッドレベリング</button>
           </div>
       
           <!-- 新: G-code 実行 -->
           <div class="cmd-group">
             <label>G-code:</label>
-            <input id="cmd-gcode-cmd" type="text" placeholder="例: M104 S200" />
-            <button id="btn-run-gcode">実行</button>
+            <input id="p1-cmd-gcode-cmd" type="text" placeholder="例: M104 S200" />
+            <button id="p1-btn-run-gcode">実行</button>
           </div>
       
           <!-- 旧: 履歴取得 -->
           <div class="cmd-group">
             <label>履歴取得 件数:</label>
-            <input type="number" id="cmd-history-limit" value="50" min="1" />
-            <button id="btn-get-history">取得</button>
+            <input type="number" id="p1-cmd-history-limit" value="50" min="1" />
+            <button id="p1-btn-get-history">取得</button>
           </div>
       
           <!-- 旧: ファイルリスト取得 -->
           <div class="cmd-group">
             <label>ファイルリスト パス:</label>
-            <input type="text" id="cmd-filelist-path" value="/" />
-            <button id="btn-get-filelist">取得</button>
+            <input type="text" id="p1-cmd-filelist-path" value="/" />
+            <button id="p1-btn-get-filelist">取得</button>
           </div>
       
           <!-- 新: ファイル削除 -->
           <div class="cmd-group">
             <label>削除パス:</label>
-            <input id="cmd-delete-path" type="text" />
-            <button id="btn-delete-file">削除</button>
+            <input id="p1-cmd-delete-path" type="text" />
+            <button id="p1-btn-delete-file">削除</button>
           </div>
       
           <!-- 新: ファイルアップロード -->
           <div class="cmd-group">
             <label>アップロードパス:</label>
-            <input id="cmd-upload-path" type="text" />
+            <input id="p1-cmd-upload-path" type="text" />
             <label>Base64データ:</label>
-            <textarea id="cmd-upload-data"></textarea>
-            <button id="btn-upload-file">アップロード</button>
+            <textarea id="p1-cmd-upload-data"></textarea>
+            <button id="p1-btn-upload-file">アップロード</button>
           </div>
       
           <!-- 新: タイムラプス一覧取得 -->
           <div class="cmd-group">
-            <button id="btn-elapse-video-list">タイムラプス一覧取得</button>
+            <button id="p1-btn-elapse-video-list">タイムラプス一覧取得</button>
           </div>
       
           <!-- 新: ファームウェアアップグレード / 工場リセット -->
           <div class="cmd-group">
-            <button id="btn-upgrade-firmware">ファームアップグレード</button>
-            <button id="btn-factory-reset">工場リセット</button>
+            <button id="p1-btn-upgrade-firmware">ファームアップグレード</button>
+            <button id="p1-btn-factory-reset">工場リセット</button>
           </div>
       
           <!-- 旧: フィラメント状態取得 -->
           <div class="cmd-group">
-            <button id="btn-get-filament">フィラメント状態取得</button>
+            <button id="p1-btn-get-filament">フィラメント状態取得</button>
           </div>
       
           <!-- 旧: フィラメントロード/アンロード -->
           <div class="cmd-group">
             <label>動作:</label>
-            <select id="cmd-filament-action">
+            <select id="p1-cmd-filament-action">
               <option value="load">ロード</option>
               <option value="unload">アンロード</option>
             </select>
-            <button id="btn-set-filament">実行</button>
+            <button id="p1-btn-set-filament">実行</button>
           </div>
       
           <!-- 旧: ファン風圧設定 -->
           <div class="cmd-group">
             <label>ファンID:</label>
-            <input type="number" id="cmd-fan-id" value="0" min="0" />
+            <input type="number" id="p1-cmd-fan-id" value="0" min="0" />
             <label>速度(%):</label>
-            <input type="number" id="cmd-fan-speed" value="50" min="0" max="100" />
-            <button id="btn-set-fan">設定</button>
+            <input type="number" id="p1-cmd-fan-speed" value="50" min="0" max="100" />
+            <button id="p1-btn-set-fan">設定</button>
           </div>
       
           <!-- 新: モデルファン ON/OFF -->
           <div class="cmd-group">
             <label>モデルファン:</label>
-            <select id="cmd-fan-model-state">
+            <select id="p1-cmd-fan-model-state">
               <option value="true">ON</option>
               <option value="false">OFF</option>
             </select>
-            <button id="btn-set-model-fan">送信</button>
+            <button id="p1-btn-set-model-fan">送信</button>
           </div>
       
           <!-- 新: 側面ファン ON/OFF -->
           <div class="cmd-group">
             <label>側面ファン:</label>
-            <select id="cmd-fan-aux-state">
+            <select id="p1-cmd-fan-aux-state">
               <option value="true">ON</option>
               <option value="false">OFF</option>
             </select>
-            <button id="btn-set-aux-fan">送信</button>
+            <button id="p1-btn-set-aux-fan">送信</button>
           </div>
       
           <!-- 旧: スイッチ ON/OFF -->
           <div class="cmd-group">
             <label>スイッチ:</label>
-            <select id="cmd-switch-name">
+            <select id="p1-cmd-switch-name">
               <option value="power">電源</option>
               <option value="beeper">ブザー</option>
               <option value="camera">カメラ</option>
             </select>
             <label>状態:</label>
-            <select id="cmd-switch-state">
+            <select id="p1-cmd-switch-state">
               <option value="true">ON</option>
               <option value="false">OFF</option>
             </select>
-            <button id="btn-set-switch">設定</button>
+            <button id="p1-btn-set-switch">設定</button>
           </div>
       
           <!-- 旧: ベッド温度変更 -->
           <div class="cmd-group">
             <label>ベッド温度(℃):</label>
-            <input type="number" id="cmd-bed-temp" value="60" min="0" max="120" />
-            <button id="btn-set-bed-temp">設定</button>
+            <input type="number" id="p1-cmd-bed-temp" value="60" min="0" max="120" />
+            <button id="p1-btn-set-bed-temp">設定</button>
           </div>
       
           <!-- 旧 & 新: ノズル温度変更 -->
           <div class="cmd-group">
             <label>ノズル温度(℃):</label>
-            <input type="number" id="cmd-nozzle-temp" value="200" min="0" max="300" />
-            <button id="btn-set-nozzle-temp">設定</button>
+            <input type="number" id="p1-cmd-nozzle-temp" value="200" min="0" max="300" />
+            <button id="p1-btn-set-nozzle-temp">設定</button>
           </div>
       
           <!-- 旧 & 新: LED ON/OFF -->
           <div class="cmd-group">
             <label>LED:</label>
-            <select id="cmd-led-state">
+            <select id="p1-cmd-led-state">
               <option value="true">ON</option>
               <option value="false">OFF</option>
             </select>
-            <button id="btn-set-led">設定</button>
+            <button id="p1-btn-set-led">設定</button>
           </div>
 
 
@@ -1278,14 +1297,1296 @@
   </div>
 
   <!-- ドラッグ&ドロップ用オーバーレイ -->
-  <div id="drop-overlay" class="drop-overlay hidden">
-    <button id="drop-overlay-close" class="drop-close" aria-label="キャンセル">×</button>
+  <div id="p1-drop-overlay" class="drop-overlay hidden">
+    <button id="p1-drop-overlay-close" class="drop-close" aria-label="キャンセル">×</button>
     ファイルをドロップしてアップロード
   </div>
+  </div><!-- /pane-1 -->
+
+    <!-- ペイン2（layout-preset2 クラス時のみ表示） -->
+    <div class="printer-pane" id="pane-2" data-pane-index="2">
+      <!-- ペインヘッダー -->
+      <div class="pane-header">
+        <div class="pane-printer-selector">
+          <span class="pane-printer-label">表示中:</span>
+          <select class="pane-printer-select" data-pane="2" aria-label="ペイン2 プリンタ選択">
+            <option value="">-- 未選択 --</option>
+          </select>
+        </div>
+      </div>
+
+<!-- ===============================================================
+       最新エラー表示（エラー発生時に表示）
+  =============================================================== -->
+  <div class="notification-container" id="p2-notification-container"></div>
+
+  <!-- ===============================================================
+       タイトルバー
+  =============================================================== -->
+  <div class="title-bar">
+    <div class="left">
+      <!-- ver.1.125で定義された data-field="hostname", data-field="printingState" などを継承 -->
+      <span data-field="hostname">
+        <span class="value">----</span><span class="unit"></span>
+      </span>
+      :
+      <span data-field="printState">
+        <span class="value">----</span><span class="unit"></span>
+      </span>
+      <span data-field="printFileName">
+        <span class="value">----</span><span class="unit"></span>
+      </span>
+    </div>
+    <div class="right">
+
+      <!-- ミュートインジケータ（自動生成されるので初期は非表示） -->
+      <span id="p2-audio-muted-tag" style="display:none; cursor:pointer; font-size:12px; margin-left:4px;">
+        🔇:ミュート中
+      </span>
+      <!-- 接続先入力 -->
+      <input id="p2-destination-input" type="text" placeholder="IP アドレス">
+      <span id="p2-destination-display">----</span>
+
+      <!-- プリンタ選択 -->
+      <select id="p2-printer-select" style="font-size:12px;"></select>
+
+      <!-- 接続状態一覧 -->
+      <div id="p2-printer-status-list" style="font-size:12px;"></div>
+
+      <!-- 自動接続(ON/OFF) -->
+      <label style="font-size:12px;">
+        <input type="checkbox" id="p2-auto-connect-toggle">
+        自動接続
+      </label>
+
+      <!-- 接続ボタン / 切断ボタン -->
+      <button id="p2-connect-button" style="font-size:12px;" class="hidden">接続</button>
+      <button id="p2-disconnect-button" style="font-size:12px;" class="hidden">切断</button>
+      <span id="p2-connection-status" style="margin-left:5px; font-size:12px;">----</span>
+    </div>
+  </div>
+
+  <!-- ===============================================================
+       機器監視カード
+  =============================================================== -->
+  <div class="card camera-card">
+    <h2 class="card-title">
+      機器監視
+    </h2>
+    <label style="font-size:12px; margin-left:10px; display:inline-block;">
+      <input type="checkbox" id="p2-camera-toggle-title"> カメラON/OFF
+    </label>
+    <div class="camera-wrapper">
+      <img id="p2-camera-feed" class="off" alt="カメラ映像">
+      <div class="no-signal">- NO SIGNAL -</div>
+      <div id="p2-camera-status" class="camera-status hidden">
+        <span id="p2-camera-status-label"></span>
+        <span id="p2-camera-status-sub"></span>
+        <div id="p2-camera-spinner" class="spinner hidden"></div>
+        <br>
+        <button id="p2-camera-cancel-button" class="camera-cancel-btn hidden">接続キャンセル</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ===============================================================
+       機器状況モニタ(情報印刷状態・制御/温度/照明)
+  =============================================================== -->
+  <div class="card equip-status-card">
+
+    <!-- 1:ヘッドプレビュー -->
+    <div class="row monitor-row">
+
+      <!-- 左側：XY/Zプレビュー領域 -->
+      <div class="card preview-wrapper">
+        <!-- 白い囲み内にタイトル・プレビュー・レイヤー数をまとめる -->
+        <div class="preview-content">
+
+          <div class="preview-header">
+            <h2 class="card-title">ヘッド位置プレビュー</h2>
+          </div>
+
+          <div class="preview-body">
+            <div class="chamber-container">
+              <div class="chamber" id="p2-xy-chamber">
+                <div class="stage" id="p2-xy-stage"></div>
+              </div>
+              <div class="xy-value-extra">
+                X:
+                <span data-field="positionX">
+                  <span class="value">---.--</span><span class="unit"></span>
+                </span>,
+                Y:
+                <span data-field="positionY">
+                  <span class="value">---.--</span><span class="unit"></span>
+                </span>
+              </div>
+              <div class="stage-rotate-buttons">
+                <button id="p2-btn-stage-flat">⊞</button>
+                <button id="p2-btn-stage-45">⏢</button>
+                <button id="p2-btn-stage-65-72">⪩</button>
+                <button id="p2-btn-stage-spin">⟲</button>
+              </div>
+            </div>
+            <div class="z-container">
+              <div id="p2-z-preview-container">
+                <div class="z-label-top">0</div>
+                <div class="z-label-bottom">300</div>
+                <div id="p2-z-preview"></div>
+                <div id="p2-z-value"></div>
+              </div>
+              <div class="z-value-extra">
+                Z:
+                <span data-field="positionZ">
+                  <span class="value">---.--</span><span class="unit"></span>
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div class="preview-footer">
+            <div class="print-status-table">
+                          <strong>レイヤー数:</strong>
+                          <span data-field="layer"><div><span class="value">----</span></span>&nbsp; / &nbsp;<span data-field="TotalLayer"><span class="value">----</span></span></div>
+            </div>
+          </div>
+
+        </div>
+
+
+
+          <!-- フィラメントプレビュー -->
+          <div class="card" id="p2-filament-preview-card" style="margin-top:10px;">
+            <div class="filament-header">
+              <h2 class="card-title">フィラメント</h2>
+              <div class="filament-actions">
+                <button id="p2-filament-change-btn" class="btn" style="font-size:12px;">交換</button>
+                <button id="p2-filament-list-btn" class="btn" style="font-size:12px;">一覧</button>
+              </div>
+            </div>
+            <div id="p2-filament-preview"></div>
+          </div>
+        </div>
+
+      <!-- 中央：状態情報 -->
+      <div class="card info-wrapper">
+        <div class="status-control-row">
+          <div class="col1">
+            <h2 class="card-title">状態</h2>
+            <div class="print-status-table">
+              <strong>エラー状況:</strong>
+              <span data-field="errorStatus">
+                <span class="value">--------</span><span class="unit"></span>
+              </span>
+              <strong>機器状態:</strong>
+              <span data-field="deviceState">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+              <strong>印刷状態:</strong>
+              <span data-field="printState">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+              <strong>印刷開始:</strong>
+              <span data-field="printStartTime">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+              <strong>実印刷開始時刻:</strong>
+              <span data-field="actualStartTime">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+
+              <strong>(開始時残り時間):</strong>
+              <span data-field="initialLeftTime">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+              
+              <strong>(開始時終了日時):</strong>
+              <span data-field="initialLeftAt">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+
+              <strong>印刷終了(見込):</strong>
+              <span data-field="printFinishTime">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+              <strong>印刷進捗率:</strong>
+              <span data-field="printProgress">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+              <strong>ジョブ時間:</strong>
+              <span data-field="printJobTime">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+              <strong>残り時間:</strong>
+              <span data-field="printLeftTime">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+              <strong>予想残り:</strong>
+              <span data-field="estimatedRemainingTime">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+              <strong>予想終了:</strong>
+              <span data-field="estimatedCompletionTime">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+              <strong>終了時刻:</strong>
+              <span data-field="expectedEndTime">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+              <strong>印刷前準備時間:</strong>
+              <span data-field="preparationTime">
+                <span class="value">-----</span><span class="unit"></span>
+              </span>
+              <strong>印刷中確認時間:</strong>
+              <span data-field="firstLayerCheckTime">
+                <span class="value">-----</span><span class="unit"></span>
+              </span>
+              <strong>一時停止時間:</strong>
+              <span data-field="pauseTime">
+                <span class="value">-----</span><span class="unit"></span>
+              </span>
+             
+              <strong>完了後経過時間:</strong>
+              <span data-field="completionElapsedTime">
+                <span class="value">-----</span><span class="unit"></span>
+              </span>
+              <strong>セルフテスト:</strong>
+              <span data-field="selfTest">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+              <strong>ｾﾙﾌﾃｽﾄ進捗:</strong>
+              <span data-field="withSelfTest">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+              <strong>印刷速度:</strong>
+              <span data-field="curFeedratePct">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+              <strong>材料消費量:</strong>
+              <span data-field="materialLength">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+              <strong>残りフィラメント:</strong>
+              <span data-field="filamentRemainingMm">
+                <span class="value">----</span><span class="unit"></span>
+              </span>
+            </div>
+          </div>
+
+
+
+          <div class="col2">
+          <h2 class="card-title">操作パネル</h2>
+          <div class="cmd-group">
+            <button id="p2-btn-stop-print">停止</button>
+            <button id="p2-btn-pause-print">一時停止</button>
+            <button id="p2-btn-resume-print">再開</button>
+            <button id="p2-btn-ack-error">エラー了承</button>
+            <button id="p2-btn-pause-home">一時停止時<br>原点復帰</button>
+            <button id="p2-btn-xy-unlock">XYロック解除</button>
+          </div>
+          <div class="cmd-group">
+            <button id="p2-btn-history-list">履歴一覧取得</button>
+            <button id="p2-btn-file-list">ファイル一覧取得</button>
+            <button id="p2-btn-send-gcode">G-code送信</button>
+            <button id="p2-btn-send-raw-json">JSONコマンド送信</button>
+          </div>
+          <div class="cmd-group">
+            <button id="p2-btn-test-raw-json">JSONコマンドテスト</button>
+          </div>
+          <div class="control-temp-area">
+            <div class="temp-row" style="margin-top:5px;">
+              <div class="temp-box">
+                <div style="font-weight:bold;">ノズル温度</div>
+                <div>上限:
+                  <span data-field="maxNozzleTemp">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div>目標:
+                  <span data-field="targetNozzleTemp">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div>現在:
+                  <span data-field="nozzleTemp">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div>差:
+                  <span data-field="nozzleDiff">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div class="control-row">
+                  <input type="range" id="p2-nozzleTempSlider" data-field="targetNozzleTemp" min="0" max="0" step="1"/>
+                  <input type="number" id="p2-nozzleTempInput" data-field="targetNozzleTemp" min="0" max="0" style="width:4em" />
+                  <button id="p2-nozzleTempSendBtn" class="send-btn">⏎</button>
+                  </div>
+                </div>
+
+              <div class="temp-box">
+                <div style="font-weight:bold;">ベッド温度</div>
+                <div>上限:
+                  <span data-field="maxBedTemp">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div>目標:
+                  <span data-field="targetBedTemp0">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div>現在:
+                  <span data-field="bedTemp0">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div>差:
+                  <span data-field="bedDiff">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div class="control-row">
+                  <input type="range"  id="p2-bedTempSlider" data-field="targetBedTemp0" min="0" max="0" step="1" />
+                  <input type="number" id="p2-bedTempInput"  data-field="targetBedTemp0" min="0" max="0" style="width:4em" />
+                  <button id="p2-bedTempSendBtn" class="send-btn">⏎</button>
+                  </div>
+                </div>
+
+              <div class="temp-box">
+                <div style="font-weight:bold;">箱内温度</div>
+                <div>&nbsp;<span><br /></span></div>
+                <div>&nbsp;<span><br /></span></div>
+                <div>現在:
+                  <span data-field="boxTemp">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div class="fan-lights-row">
+              <div class="fan-item">
+                <strong>モデルFAN</strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-modelFanToggle2" data-field="fan">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="modelFanPct">
+                    <span class="value">--</span><span class="unit">%</span>
+                  </span>
+                </div>
+                <div>
+                  <input type="range" id="p2-modelFanSlider" min="0" max="100" step="1" data-field="modelFanPct">
+                  <span data-field="modelFanPct" id="p2-modelFanSliderValue">
+                    <span class="value">--</span><span class="unit">%</span>
+                  </span>
+                </div>
+
+              </div>
+              <div class="fan-item">
+                <strong>側面FAN</strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-sideFanToggle2" data-field="fanAuxiliary">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="auxiliaryFanPct">
+                    <span class="value">--</span><span class="unit">%</span>
+                  </span>
+                </div>
+                  <input type="range" id="p2-auxiliaryFanSlider" min="0" max="100" step="1" data-field="auxiliaryFanPct">
+                  <span data-field="auxiliaryFanPct" id="p2-auxiliaryFanSliderValue">
+                    <span class="value">--</span><span class="unit">%</span>
+                  </span>
+              </div>
+              <div class="fan-item">
+                <strong>背面FAN</strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-backFanToggle2" data-field="fanCase">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="caseFanPct">
+                    <span class="value">--</span><span class="unit">%</span>
+                  </span>
+                </div>
+                <div>
+                  <input type="range" id="p2-caseFanSlider" min="0" max="100" step="1" data-field="caseFanPct">
+                  <span data-field="caseFanPct" id="p2-caseFanSliderValue">
+                    <span class="value">--</span><span class="unit">%</span>
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div class="fan-lights-row">
+              <div class="fan-item">
+                <strong>LED照明</strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-ledToggle2" data-field="lightSw">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="lightSw">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+              <div class="fan-item">
+                <strong>材料切れ検知</strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-materialDetectToggle" data-field="materialDetect">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="materialDetect">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div>
+                  <span data-field="materialStatus">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div class="fan-lights-row ai-row">
+              <div class="fan-item">
+                <strong class="feature-name"><nobr>印刷前AI</nobr><wbr><nobr>自動調整</nobr></strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-aiSwToggle" data-field="aiSw">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="aiSw">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+              <div class="fan-item">
+                <strong class="feature-name"><nobr>異常出力</nobr><wbr><nobr>AI検知</nobr></strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-aiDetectionToggle" data-field="aiDetection">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="aiDetection">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+              <div class="fan-item">
+                <strong class="feature-name"><nobr>初層出力</nobr><wbr><nobr>AI確認</nobr></strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-aiFirstFloorToggle" data-field="aiFirstFloor">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="aiFirstFloor">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+              <div class="fan-item">
+                <strong class="feature-name"><nobr>異常時</nobr><wbr><nobr>一時停止</nobr></strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-aiPausePrintToggle" data-field="aiPausePrint">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="aiPausePrint">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <!-- ─────────── 印刷速度・フロー率 ─────────── -->
+            <div class="temp-row" style="margin-top:5px;">
+              <div class="temp-box">
+                <div style="font-weight:bold;">印刷速度</div>
+                <div>現在:
+                  <span data-field="curFeedratePct">
+                    <span class="value">--</span><span class="unit">%</span>
+                  </span>
+                </div>
+                <div class="control-row">
+                  <input type="range"
+                         id="p2-feedrateSlider"
+                         data-field="curFeedratePct"
+                         step="1"
+                         min="0" max="200" />
+                  <input type="number"
+                         id="p2-feedrateInput"
+                         data-field="curFeedratePct"
+                         min="0" max="200"
+                         step="1"
+                         style="width:4em" />
+                  <button id="p2-feedrateSendBtn" class="send-btn">⏎</button>
+                  <div class="quick-buttons">
+                    <button class="feedrate-preset" data-value="50">50%</button>
+                    <button class="feedrate-preset" data-value="80">80%</button>
+                    <button class="feedrate-preset" data-value="100">等速</button>
+                    <button class="feedrate-preset" data-value="120">120%</button>
+                    <button class="feedrate-preset" data-value="150">150%</button>
+                  </div>
+                </div>
+              </div>
+
+              <div class="temp-box">
+                <div style="font-weight:bold;">フロー率</div>
+                <div>現在:
+                  <span data-field="curFlowratePct">
+                    <span class="value">--</span><span class="unit">%</span>
+                  </span>
+                </div>
+                <div class="control-row">
+                  <input type="range"
+                         id="p2-flowrateSlider"
+                         data-field="curFlowratePct"
+                         step="1"
+                         min="0" max="200" />
+                  <input type="number"
+                         id="p2-flowrateInput"
+                         data-field="curFlowratePct"
+                         min="0" max="200"
+                         style="width:4em" />
+                  <button id="p2-flowrateSendBtn" class="send-btn">⏎</button>
+                  <div class="quick-buttons">
+                    <button class="flowrate-preset" data-value="90">90%</button>
+                    <button class="flowrate-preset" data-value="100">100%</button>
+                    <button class="flowrate-preset" data-value="103">103%</button>
+                    <button class="flowrate-preset" data-value="106">106%</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 右側：温度グラフ -->
+    <div id="p2-graph-current-wrapper" class="graph-current-wrapper">
+      <div class="graph-wrapper">
+        <div class="card" id="temp-graph-card">
+          <div style="display:flex; align-items:center;">
+            <h2 class="card-title">温度グラフ (過去15分)</h2>
+            <button id="p2-temp-graph-reset-button" style="font-size:12px; margin-left:4px;">リセット</button>
+          </div>
+          <div style="position: relative; width: 100%; height: 300px;">
+            <canvas id="p2-temp-graph-canvas" style="width:100%; height:300px;"></canvas>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+  <!-- ===============================================================
+       下段：機器情報＆ログカード
+  =============================================================== -->
+  <div class="row">
+    <div class="card info-card">
+      <h2 class="card-title">機器情報</h2>
+      <div class="equip-info-table">
+        <strong>加速度制限:</strong>
+          <span data-field="accelerationLimits">
+            <span class="value">----</span><span class="unit"></span>
+          </span>
+        <strong>速度制限:</strong>
+          <span data-field="velocityLimits">
+            <span class="value">----</span><span class="unit"></span>
+          </span>
+        <strong>コーナー速度制限:</strong>
+          <span data-field="cornerVelocityLimits">
+            <span class="value">----</span><span class="unit"></span>
+          </span>
+        <strong>加減速制御:</strong>
+          <span data-field="accelToDecelLimits">
+            <span class="value">----</span><span class="unit"></span>
+          </span>
+        <strong>圧力先行:</strong>
+          <span data-field="pressureAdvance">
+            <span class="value">----</span><span class="unit"></span>
+          </span>
+        <strong>リアルタイムフロー:</strong>
+          <span data-field="realTimeFlow">
+            <span class="value">----</span><span class="unit"></span>
+          </span>
+        <strong>リアルタイム印刷速度:</strong>
+          <span data-field="realTimeSpeed">
+            <span class="value">----</span><span class="unit"></span>
+          </span>
+        <strong>ホーミング情報:</strong>
+          <span data-field="autohome">
+            <span class="value">----</span><span class="unit"></span>
+          </span>
+        <strong>接続状態:</strong>
+          <span data-field="sysConnection">
+            <span class="value">----</span><span class="unit"></span>
+          </span>
+        <strong>プリンタモデル:</strong>
+          <span data-field="model">
+            <span class="value">----</span><span class="unit"></span>
+          </span>
+        <strong>モデルVer:</strong>
+          <span data-field="modelVersion">
+            <span class="value">----</span><span class="unit"></span>
+          </span>
+        <strong>総ジョブ数:</strong>
+          <span data-field="totalJob">
+            <span class="value">----</span><span class="unit"></span>
+          </span>
+        <strong>総稼働時間:</strong>
+          <span data-field="totalUsageTime">
+            <span class="value">----</span><span class="unit"></span>
+          </span>
+        <strong>総材料量:</strong>
+          <span data-field="totalUsageMaterial">
+            <span class="value">----</span><span class="unit"></span>
+          </span>
+      </div>
+    </div>
+
+    <div class="card log-card">
+      <h2 class="card-title">ログ</h2>
+      <div class="log-card-header">
+        <div class="tabs">
+          <button id="p2-tab-received" class="active">受信ログ</button>
+          <button id="p2-tab-notification">通知ログ</button>
+        </div>
+        <div id="p2-log-controls" class="log-controls">
+          <button id="p2-copy-all-button" data-original="全てコピー" style="font-size:12px;">全てコピー</button>
+          <button id="p2-copy-last-50-button" data-original="最後50行コピー" style="font-size:12px;">最後50行コピー</button>
+          <button id="p2-copy-storeddata-button" data-original="storedDataコピー" style="font-size:12px;">storedDataコピー</button>
+        </div>
+        <div id="p2-last-log-timestamp" class="log-timestamp" style="font-size:12px;">
+          最新受信日時:
+          <span data-field="lastLogTimestamp" class="old">
+            <span class="value">====-==-==T--:--:--.------Z</span><span class="unit"></span>
+          </span>
+        </div>
+        <div id="p2-last-notification-timestamp" class="log-timestamp hidden" style="font-size:12px;">
+          最新通知日時:
+          <span data-field="lastNotificationTimestamp" class="old">
+            <span class="value">====-==-==T--:--:--.------Z</span><span class="unit"></span>
+          </span>
+        </div>
+        <div id="p2-notification-controls" class="log-controls hidden">
+          <button id="p2-copy-all-notification-button" data-original="全通知コピー" style="font-size:12px;">全通知コピー</button>
+          <button id="p2-copy-last-50-notification-button" data-original="最後50行通知コピー" style="font-size:12px;">最後50行通知コピー</button>
+          <button id="p2-clear-notification-logs-button" data-original="通知全消去" style="font-size:12px;">通知全消去</button>
+        </div>
+      </div>
+
+      <div class="tab-content">
+        <!-- ログ表示エリア -->
+        <div id="p2-log" class="log-box"></div>
+
+        <!-- 通知表示エリア (hidden 初期表示) -->
+        <div id="p2-notification-history" class="log-box hidden"></div>
+      </div>
+    </div>
+  </div>
+
+
+  <!-- ──────────────── 印刷状況カード群 ──────────────── -->
+  <!-- ① 現在の印刷カード -->
+  <div class="card" id="p2-print-current-card">
+    <h2 class="card-title">現在の印刷</h2>
+    <div id="p2-print-current-container" style="font-size:0.9em;">
+      <!-- JavaScript で renderPrintCurrent が埋めます -->
+    </div>
+  </div>
+
+  <!-- ② 印刷履歴カード -->
+  <div class="card print-history-card" id="p2-print-history-card">
+
+    <div class="card-header">
+      <div class="tabs">
+        <button id="p2-tab-print-history" class="active">印刷履歴</button>
+        <button id="p2-tab-file-list">ファイル一覧</button>
+      </div>
+    </div>
+
+    <div class="tab-content">
+      <!-- ─── 印刷履歴タブ ─── -->
+      <div id="p2-panel-print-history-tab">
+  
+      <h2 class="card-title">印刷履歴</h2>
+      <div style="font-size:0.9em;">
+        <div>
+          <strong>総ジョブ数:</strong>
+          <span data-field="totalJob"><span class="value">----</span><span class="unit"></span>
+        </div>
+        <div>
+          <strong>総稼働時間:</strong>
+          <span data-field="totalUsageTime"><span class="value">----</span><span class="unit"></span>
+        </div>
+        <div>
+          <strong>総材料量:</strong>
+          <span data-field="totalUsageMaterial"><span class="value">----</span><span class="unit"></span>
+        </div>
+      </div>
+      <button id="p2-history-refresh-btn" class="btn" aria-label="履歴を更新">再読み込み</button>
+  
+      <!-- 暫定配置 ファイル一覧に本来ならあるべき -->
+      <div class="cmd-group">
+        <label>アップロード GCode:</label>
+        <input type="file" id="p2-gcode-upload-input" accept=".gcode" />
+        <button id="p2-gcode-upload-btn">アップロード</button>
+        <span id="p2-gcode-upload-progress" class="upload-progress hidden">
+          <span class="spinner"></span>
+          <span id="p2-gcode-upload-percent">0%</span>
+        </span>
+      </div>
+      <!-- /暫定配置 -->
+      <div id="p2-print-history-body" class="scrollable-body">
+        <table id="p2-print-history-table" class="fixed-header" border="1" style="border-collapse: collapse; width:100%;">
+          <thead>
+            <tr>
+                <th data-key="command">ｺﾏﾝﾄﾞ</th>
+                <th data-key="number">#</th>
+                <th data-key="id">ID</th>
+                <th data-key="thumbnail">ｻﾑﾈｲﾙ</th>
+                <th data-key="filename">ファイル名</th>
+                <th data-key="startway">開始方式</th>
+                <th data-key="size">サイズ</th>
+                <th data-key="ctime">作成時間</th>
+                <th data-key="starttime">開始時間</th>
+                <th data-key="actualstart">実印刷開始</th>
+                <th data-key="endtime">終了時間</th>
+                <th data-key="preptime">印刷前準備</th>
+                <th data-key="checktime">印刷中確認</th>
+                <th data-key="pausetime">一時停止</th>
+                <th data-key="usagetime">使用時間</th>
+                <th data-key="usagematerial">使用量（mm）</th>
+                <th data-key="printfinish">is成功?</th>
+                <th data-key="filemd5">ファイルMD5</th>
+                <th data-key="video">動画</th>
+                <th data-key="spool">フィラメント情報</th>
+                <th data-key="spoolchange">交換</th>
+                <th data-key="spoolcount">同一リール印刷数</th>
+                <th data-key="remain">想定残量</th>
+            </tr>
+          </thead>
+          <tbody>
+          <tr><td colspan='22'>データ読み込み待ち</td></tr>
+          </tbody>
+        </table>
+      </div>
+      </div>
+
+      <!-- ─── ファイル一覧タブ ─── -->
+      <div id="p2-panel-file-list" class="hidden">
+      <div>総ファイル数: <span id="p2-file-list-total">0</span></div>
+      <div class="filelist-container scrollable-body">
+        <table id="p2-file-list-table" class="fixed-header" style="width:100%; table-layout:auto;">
+          <thead>
+            <tr>
+              <th data-key="command">ｺﾏﾝﾄﾞ</th>
+              <th data-key="number">#</th>
+              <th data-key="thumb">ｻﾑﾈｲﾙ</th>
+              <th data-key="filename">ファイル名</th>
+              <th data-key="layer">積層厚さ(mm)</th>
+              <th data-key="size">サイズ(バイト)</th>
+              <th data-key="mtime">更新日時</th>
+              <th data-key="expect">予定使用量(mm)</th>
+              <th data-key="prints">印刷回数</th>
+              <th data-key="md5">MD5</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      </div>
+
+    </div>
+
+
+  <div id="p2-settings-card" class="card">
+    <h2  class="card-title">設定</h2>
+    <div id="p2-storage-panel-container">
+      <!-- ─────────────── ストレージ同期パネル ─────────────── -->
+      <details id="p2-storage-panel" style="margin-top:10px;">
+        <summary style="cursor:pointer; font-weight:bold;">ストレージ設定</summary>
+        <div style="padding:8px; font-size:0.9em;">
+          <div>使用量: <span id="p2-storage-usage">-- / -- (--%)</span></div>
+          <div>最終同期: <span id="p2-storage-last-sync">----</span></div>
+          <button id="p2-storage-save-btn" style="font-size:12px; margin-top:5px;">保存</button>
+          <button id="p2-storage-quota-test-btn" style="font-size:12px; margin-top:5px;">クォータテスト</button>
+          <button id="p2-clear-storage-button" class="btn btn-danger btn-sm ms-2">全ストレージ削除</button>
+          <div id="p2-storage-error" style="color:red; display:none; margin-top:5px;">⚠ 容量取得エラー</div>
+        </div>
+        <div class="cmd-group">
+          <label for="p2-setting-log-max-lines"><strong>ログ最大行数:</strong></label>
+          <input type="number" id="p2-setting-log-max-lines"
+            min="100"
+            step="100"
+            value="1000"
+            style="width:6em;" />
+        </div>
+
+
+        <!-- 確認ダイアログ -->
+        <div id="p2-confirm-delete-modal" class="confirm-modal" style="display:none;">
+          <div class="confirm-modal-box">
+            <p>全ストレージを本当に削除しますか？</p>
+            <div class="btn-group">
+              <button id="p2-confirm-delete-ok" class="btn btn-danger btn-sm">削除する</button>
+              <button id="p2-confirm-delete-cancel" class="btn btn-secondary btn-sm">キャンセル</button>
+            </div>
+          </div>
+        </div>
+      </details>
+    </div>
+
+    <div id="p2-notification-settings-panel">
+      <!-- ───────────── 通知設定パネル ───────────── -->
+      <details id="p2-notification-panel" style="margin-top:10px;">
+        <summary style="cursor:pointer; font-weight:bold;">通知設定</summary>
+        <fieldset class="notification-panel-field" style="margin-top:1em; padding:0.5em; border:1px solid #ccc; border-radius:4px;">
+          <legend style="font-weight:bold;">メッセージ内容設定</legend>
+          <div id="p2-notification-panel-body" style="padding:8px; font-size:0.9em;">
+            <!-- 各通知タイプの切り替えUIはここに動的追加 -->
+          </div>
+        </fieldset>
+      </details>
+
+
+    </div>
+    <div id="p2-spool-settings-panel">
+      <details id="p2-spool-panel" style="margin-top:10px;">
+        <summary style="cursor:pointer; font-weight:bold;">フィラメントスプール</summary>
+        <div style="padding:8px; font-size:0.9em;">
+          <ul id="p2-spool-list"></ul>
+          <button id="p2-spool-add-btn" style="font-size:12px;">追加</button>
+        </div>
+      </details>
+    </div>
+<!-- 既存の設定カードの直後に追加 -->
+    <div id="p2-command-palette-panel-container">
+      <!-- ─────────────── ストレージ同期パネル ─────────────── -->
+      <details id="p2-command-palette" style="margin-top:10px;">
+        <summary style="cursor:pointer; font-weight:bold;">コマンドパレット</summary>
+          <!-- 新: 停止・一時停止・再開 -->
+          <div class="cmd-group">
+            <button id="p2-btn-stop-print-cmd">停止</button>
+            <button id="p2-btn-pause-print-cmd">一時停止</button>
+            <button id="p2-btn-resume-print-cmd">再開</button>
+          </div>
+          <br/><br/><br/>
+          <!-- 新: 履歴一覧取得 -->
+          <div class="cmd-group">
+            <button id="p2-btn-history-list-cmd">履歴一覧取得</button>
+          </div>
+          <!-- 新: G-codeファイル一覧取得 -->
+          <div class="cmd-group">
+            <button id="p2-btn-file-list-cmd">ファイル一覧取得</button>
+          </div>
+
+          <div class="col2">
+          <div class="control-temp-area">
+            <div class="temp-row" style="margin-top:5px;">
+              <div class="temp-box">
+                <div style="font-weight:bold;">ノズル温度</div>
+                <div>上限:
+                  <span data-field="maxNozzleTemp">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div>目標:
+                  <span data-field="targetNozzleTemp">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div>現在:
+                  <span data-field="nozzleTemp">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div>差:
+                  <span data-field="nozzleDiff">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div class="control-row">
+                  <input type="range" id="p2-nozzleTempSlider" data-field="targetNozzleTemp" min="0" max="0" step="1" />
+                  <input type="number" id="p2-nozzleTempInput" data-field="targetNozzleTemp" min="0" max="0" step="1" style="width:4em" />
+                  <button id="p2-nozzleTempSendBtn" class="send-btn">⏎</button>
+                  </div>
+                </div>
+
+              <div class="temp-box">
+                <div style="font-weight:bold;">ベッド温度</div>
+                <div>上限:
+                  <span data-field="maxBedTemp">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div>目標:
+                  <span data-field="targetBedTemp0">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div>現在:
+                  <span data-field="bedTemp0">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div>差:
+                  <span data-field="bedDiff">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div class="control-row">
+                  <input type="range"  id="p2-bedTempSlider" data-field="targetBedTemp0" min="0" max="0" step="1" />
+                  <input type="number" id="p2-bedTempInput"  data-field="targetBedTemp0" min="0" max="0" step="1" style="width:4em" />
+                  <button id="p2-bedTempSendBtn" class="send-btn">⏎</button>
+                  </div>
+                </div>
+
+              <div class="temp-box">
+                <div style="font-weight:bold;">箱内温度</div>
+                <div>&nbsp;<span><br /></span></div>
+                <div>&nbsp;<span><br /></span></div>
+                <div>現在:
+                  <span data-field="boxTemp">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div class="fan-lights-row">
+              <div class="fan-item">
+                <strong>モデルFAN</strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-modelFanToggle2" data-field="fan">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="modelFanPct">
+                    <span class="value">--</span><span class="unit">%</span>
+                  </span>
+                </div>
+                <div>
+                  <input type="range" id="p2-modelFanSlider" min="0" max="100" step="1" data-field="modelFanPct">
+                  <span data-field="modelFanPct" id="p2-modelFanSliderValue">
+                    <span class="value">--</span><span class="unit">%</span>
+                  </span>
+                </div>
+
+              </div>
+              <div class="fan-item">
+                <strong>側面FAN</strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-sideFanToggle2" data-field="fanAuxiliary">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="auxiliaryFanPct">
+                    <span class="value">--</span><span class="unit">%</span>
+                  </span>
+                </div>
+                  <input type="range" id="p2-auxiliaryFanSlider" min="0" max="100" step="1" data-field="auxiliaryFanPct">
+                  <span data-field="auxiliaryFanPct" id="p2-auxiliaryFanSliderValue">
+                    <span class="value">--</span><span class="unit">%</span>
+                  </span>
+              </div>
+              <div class="fan-item">
+                <strong>背面FAN</strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-backFanToggle2" data-field="fanCase">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="caseFanPct">
+                    <span class="value">--</span><span class="unit">%</span>
+                  </span>
+                </div>
+                <div>
+                  <input type="range" id="p2-caseFanSlider" min="0" max="100" step="1" data-field="caseFanPct">
+                  <span data-field="caseFanPct" id="p2-caseFanSliderValue">
+                    <span class="value">--</span><span class="unit">%</span>
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div class="fan-lights-row">
+              <div class="fan-item">
+                <strong>LED照明</strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-ledToggle2" data-field="lightSw">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="lightSw">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+              <div class="fan-item">
+                <strong>材料切れ検知</strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-materialDetectToggle" data-field="materialDetect">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="materialDetect">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+                <div>
+                  <span data-field="materialStatus">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div class="fan-lights-row ai-row">
+              <div class="fan-item">
+                <strong class="feature-name"><nobr>印刷前AI</nobr><wbr><nobr>自動調整</nobr></strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-aiSwToggle" data-field="aiSw">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="aiSw">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+              <div class="fan-item">
+                <strong class="feature-name"><nobr>異常出力</nobr><wbr><nobr>AI検知</nobr></strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-aiDetectionToggle" data-field="aiDetection">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="aiDetection">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+              <div class="fan-item">
+                <strong class="feature-name"><nobr>初層出力</nobr><wbr><nobr>AI確認</nobr></strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-aiFirstFloorToggle" data-field="aiFirstFloor">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="aiFirstFloor">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+              <div class="fan-item">
+                <strong class="feature-name"><nobr>異常時</nobr><wbr><nobr>一時停止</nobr></strong>
+                <label class="switch">
+                  <input type="checkbox" id="p2-aiPausePrintToggle" data-field="aiPausePrint">
+                  <span class="slider"></span>
+                </label>
+                <div>
+                  <span data-field="aiPausePrint">
+                    <span class="value">--</span><span class="unit"></span>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- 新: 温度取得 -->
+          <div class="cmd-group">
+            <button id="p2-btn-get-status">温度取得</button>
+          </div>
+      
+          <!-- 新: 印刷開始（ファイルパス指定） -->
+          <div class="cmd-group">
+            <label>印刷ファイルパス:</label>
+            <input id="p2-cmd-print-filepath" type="text" placeholder="例: /gcode/test.gcode" />
+            <button id="p2-btn-print-file">印刷開始</button>
+          </div>
+      
+
+      
+          <!-- 新: ホーム復帰・ベッドレベリング -->
+          <div class="cmd-group">
+            <button id="p2-btn-autohome">ホーム復帰</button>
+            <button id="p2-btn-autolevel">ベッドレベリング</button>
+          </div>
+      
+          <!-- 新: G-code 実行 -->
+          <div class="cmd-group">
+            <label>G-code:</label>
+            <input id="p2-cmd-gcode-cmd" type="text" placeholder="例: M104 S200" />
+            <button id="p2-btn-run-gcode">実行</button>
+          </div>
+      
+          <!-- 旧: 履歴取得 -->
+          <div class="cmd-group">
+            <label>履歴取得 件数:</label>
+            <input type="number" id="p2-cmd-history-limit" value="50" min="1" />
+            <button id="p2-btn-get-history">取得</button>
+          </div>
+      
+          <!-- 旧: ファイルリスト取得 -->
+          <div class="cmd-group">
+            <label>ファイルリスト パス:</label>
+            <input type="text" id="p2-cmd-filelist-path" value="/" />
+            <button id="p2-btn-get-filelist">取得</button>
+          </div>
+      
+          <!-- 新: ファイル削除 -->
+          <div class="cmd-group">
+            <label>削除パス:</label>
+            <input id="p2-cmd-delete-path" type="text" />
+            <button id="p2-btn-delete-file">削除</button>
+          </div>
+      
+          <!-- 新: ファイルアップロード -->
+          <div class="cmd-group">
+            <label>アップロードパス:</label>
+            <input id="p2-cmd-upload-path" type="text" />
+            <label>Base64データ:</label>
+            <textarea id="p2-cmd-upload-data"></textarea>
+            <button id="p2-btn-upload-file">アップロード</button>
+          </div>
+      
+          <!-- 新: タイムラプス一覧取得 -->
+          <div class="cmd-group">
+            <button id="p2-btn-elapse-video-list">タイムラプス一覧取得</button>
+          </div>
+      
+          <!-- 新: ファームウェアアップグレード / 工場リセット -->
+          <div class="cmd-group">
+            <button id="p2-btn-upgrade-firmware">ファームアップグレード</button>
+            <button id="p2-btn-factory-reset">工場リセット</button>
+          </div>
+      
+          <!-- 旧: フィラメント状態取得 -->
+          <div class="cmd-group">
+            <button id="p2-btn-get-filament">フィラメント状態取得</button>
+          </div>
+      
+          <!-- 旧: フィラメントロード/アンロード -->
+          <div class="cmd-group">
+            <label>動作:</label>
+            <select id="p2-cmd-filament-action">
+              <option value="load">ロード</option>
+              <option value="unload">アンロード</option>
+            </select>
+            <button id="p2-btn-set-filament">実行</button>
+          </div>
+      
+          <!-- 旧: ファン風圧設定 -->
+          <div class="cmd-group">
+            <label>ファンID:</label>
+            <input type="number" id="p2-cmd-fan-id" value="0" min="0" />
+            <label>速度(%):</label>
+            <input type="number" id="p2-cmd-fan-speed" value="50" min="0" max="100" />
+            <button id="p2-btn-set-fan">設定</button>
+          </div>
+      
+          <!-- 新: モデルファン ON/OFF -->
+          <div class="cmd-group">
+            <label>モデルファン:</label>
+            <select id="p2-cmd-fan-model-state">
+              <option value="true">ON</option>
+              <option value="false">OFF</option>
+            </select>
+            <button id="p2-btn-set-model-fan">送信</button>
+          </div>
+      
+          <!-- 新: 側面ファン ON/OFF -->
+          <div class="cmd-group">
+            <label>側面ファン:</label>
+            <select id="p2-cmd-fan-aux-state">
+              <option value="true">ON</option>
+              <option value="false">OFF</option>
+            </select>
+            <button id="p2-btn-set-aux-fan">送信</button>
+          </div>
+      
+          <!-- 旧: スイッチ ON/OFF -->
+          <div class="cmd-group">
+            <label>スイッチ:</label>
+            <select id="p2-cmd-switch-name">
+              <option value="power">電源</option>
+              <option value="beeper">ブザー</option>
+              <option value="camera">カメラ</option>
+            </select>
+            <label>状態:</label>
+            <select id="p2-cmd-switch-state">
+              <option value="true">ON</option>
+              <option value="false">OFF</option>
+            </select>
+            <button id="p2-btn-set-switch">設定</button>
+          </div>
+      
+          <!-- 旧: ベッド温度変更 -->
+          <div class="cmd-group">
+            <label>ベッド温度(℃):</label>
+            <input type="number" id="p2-cmd-bed-temp" value="60" min="0" max="120" />
+            <button id="p2-btn-set-bed-temp">設定</button>
+          </div>
+      
+          <!-- 旧 & 新: ノズル温度変更 -->
+          <div class="cmd-group">
+            <label>ノズル温度(℃):</label>
+            <input type="number" id="p2-cmd-nozzle-temp" value="200" min="0" max="300" />
+            <button id="p2-btn-set-nozzle-temp">設定</button>
+          </div>
+      
+          <!-- 旧 & 新: LED ON/OFF -->
+          <div class="cmd-group">
+            <label>LED:</label>
+            <select id="p2-cmd-led-state">
+              <option value="true">ON</option>
+              <option value="false">OFF</option>
+            </select>
+            <button id="p2-btn-set-led">設定</button>
+          </div>
+
+
+
+
+
+        </div>
+      </div>
+
+
+
+
+
+
+  </div>
+
+  <!-- ドラッグ&ドロップ用オーバーレイ -->
+  <div id="p2-drop-overlay" class="drop-overlay hidden">
+    <button id="p2-drop-overlay-close" class="drop-close" aria-label="キャンセル">×</button>
+    ファイルをドロップしてアップロード
+  </div>
+    </div><!-- /pane-2 -->
+
+  </div><!-- /dashboard-root -->
+
+<!-- ===============================================================
+       Audio‑Unlock ポップアップ（自動挿入）
+  =============================================================== -->
+  <template id="audio-unlock-template">
+    <div id="audio-unlock-pop" class="card" style="position:fixed; inset:20px; z-index:9999;
+         display:flex; flex-direction:column; align-items:center; justify-content:center;
+         background:#0008; color:#fff; backdrop-filter:blur(2px);">
+      <p style="font-size:1.1em; text-align:center;">サウンドテスト<br>画面ををタップしてください</p>
+      <p id="unlock-count" style="font-size:2em; margin:8px 0 0;">8</p>
+    </div>
+  </template>
 
   <!-- スクリプト読み込み -->
   <script type="module" src="3dp_lib/3dp_dashboard_main.js"></script>
 
 </body>
 </html>
-

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -75,21 +75,14 @@
       <span id="p1-audio-muted-tag" style="display:none; cursor:pointer; font-size:12px; margin-left:4px;">
         🔇:ミュート中
       </span>
-      <!-- 接続先入力 -->
-      <input id="p1-destination-input" type="text" placeholder="IP アドレス">
-      <span id="p1-destination-display">----</span>
+      <!-- 接続先表示（updateConnectionUI が更新） -->
+      <span id="p1-destination-display" style="font-size:12px;">----</span>
 
       <!-- プリンタ選択 -->
       <select id="p1-printer-select" style="font-size:12px;"></select>
 
       <!-- 接続状態一覧 -->
       <div id="p1-printer-status-list" style="font-size:12px;"></div>
-
-      <!-- 自動接続(ON/OFF) -->
-      <label style="font-size:12px;">
-        <input type="checkbox" id="p1-auto-connect-toggle">
-        自動接続
-      </label>
 
       <!-- 接続ボタン / 切断ボタン -->
       <button id="p1-connect-button" style="font-size:12px;" class="hidden">接続</button>
@@ -105,9 +98,6 @@
     <h2 class="card-title">
       機器監視
     </h2>
-    <label style="font-size:12px; margin-left:10px; display:inline-block;">
-      <input type="checkbox" id="p1-camera-toggle-title"> カメラON/OFF
-    </label>
     <div class="camera-wrapper">
       <img id="p1-camera-feed" class="off" alt="カメラ映像">
       <div class="no-signal">- NO SIGNAL -</div>
@@ -1343,21 +1333,14 @@
       <span id="p2-audio-muted-tag" style="display:none; cursor:pointer; font-size:12px; margin-left:4px;">
         🔇:ミュート中
       </span>
-      <!-- 接続先入力 -->
-      <input id="p2-destination-input" type="text" placeholder="IP アドレス">
-      <span id="p2-destination-display">----</span>
+      <!-- 接続先表示（updateConnectionUI が更新） -->
+      <span id="p2-destination-display" style="font-size:12px;">----</span>
 
       <!-- プリンタ選択 -->
       <select id="p2-printer-select" style="font-size:12px;"></select>
 
       <!-- 接続状態一覧 -->
       <div id="p2-printer-status-list" style="font-size:12px;"></div>
-
-      <!-- 自動接続(ON/OFF) -->
-      <label style="font-size:12px;">
-        <input type="checkbox" id="p2-auto-connect-toggle">
-        自動接続
-      </label>
 
       <!-- 接続ボタン / 切断ボタン -->
       <button id="p2-connect-button" style="font-size:12px;" class="hidden">接続</button>
@@ -1373,9 +1356,6 @@
     <h2 class="card-title">
       機器監視
     </h2>
-    <label style="font-size:12px; margin-left:10px; display:inline-block;">
-      <input type="checkbox" id="p2-camera-toggle-title"> カメラON/OFF
-    </label>
     <div class="camera-wrapper">
       <img id="p2-camera-feed" class="off" alt="カメラ映像">
       <div class="no-signal">- NO SIGNAL -</div>


### PR DESCRIPTION
## Summary

- **1ペイン↔2ペイン切り替え**: グローバルメニューバー（48px固定）から「ダッシュボード選択...」でプリセット切り替え。`#dashboard-root` に `layout-preset1` / `layout-preset2` クラスを付け外し
- **2台プリンタのリアルタイム同時監視**: `chartStateMap`（キャンバス要素キー）、`cameraStateMap`（ホストキー）でグラフ・カメラをマルチインスタンス化。各ペインに `p1-` / `p2-` ID接頭辞を付与し `getPaneEl(id, paneIndex)` で解決
- **接続設定UI**: 新規 `ConnSettingsModal`（`<dialog>` ベース）でプリンタ名・色・IP・WSポート・CAMポート・自動接続を CRUD 管理。`connections[]` を `appSettings` に永続化
- **プリンタカラー変数**: `.printer-pane` に `--printer-color` / `--printer-color-faint` CSS 変数を適用し、カードタイトルバーとカード背景をペイン別に色分け
- **自動接続復元**: 起動時に `connections[]` の `autoConnect: true` エントリへ 200ms 間隔で順次 `connectWs()` を呼び出し

## 変更ファイル (11ファイル、+3216/-607行)

| ファイル | 種別 | 主要変更 |
|---|---|---|
| `dashboard_data.js` | 変更 | `connections[]`, `activeLayout`, `paneAssignment` 追加 |
| `3dp_monitor.html` | 変更 | グローバルメニューバー、2ペイン構造、p1-/p2- ID接頭辞 |
| `3dp_monitor.css` | 変更 | 960px対応レスポンシブ、2ペインflex、プリンタカラー変数 |
| `3dp_dashboard_init.js` | 変更 | `getPaneEl()` export、全`getElementById`をpaneIndex対応に置換 |
| `dashboard_chart.js` | 変更 | `chartStateMap`（Map）でcanvas別マルチインスタンス化 |
| `dashboard_camera_ctrl.js` | 変更 | `cameraStateMap` でホスト別マルチインスタンス化 |
| `dashboard_stage_preview.js` | 変更 | 全関数に `paneIndex` 引数追加 |
| `dashboard_connection.js` | 変更 | `updateConnectionUI` / `updatePrinterListUI` ペイン対応 |
| `dashboard_conn_settings.js` | **新規** | `ConnSettingsModal` クラス |
| `dashboard_layout_manager.js` | **新規** | `setLayout` / `restoreLayout` / `assignPrinterToPane` / `showLayoutSelectDialog` |
| `3dp_dashboard_main.js` | 変更 | GMBイベント登録、ペイン2初期化、`connections[]`自動接続 |

## Test plan

- [ ] `start.bat` → `http://localhost:8000/3dp_monitor.html` で既存1ペイン機能（接続・温度グラフ・カメラ・ログ）が正常動作すること
- [ ] ≡ Menu クリックでドロップダウンが開閉すること（外クリックで閉じる）
- [ ] 「接続設定...」でモーダルが開き、プリンタ追加・色設定・自動接続チェック・保存が動作すること
- [ ] 「ダッシュボード選択...」→ Preset 2 で左右2列に分割されること
- [ ] 各ペインのプリンタ選択ドロップダウンで表示プリンタを切り替えられること
- [ ] ブラウザ幅960pxで各ペイン内が縦積みレイアウトになること
- [ ] 色設定後にカードタイトルバーの色が変わること
- [ ] 2台接続時に両ペインがリアルタイムで独立更新されること
- [ ] ページリロード後にレイアウト設定・接続設定・自動接続が復元されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)