### PR TITLE
v2.2.1011: リレー操作モード昇格UI + 使用量m/mmトグル + オフラインフィラメント継続 + 残量小数1桁

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,19 @@
 # Node / Vite
 node_modules/
 dist/
+dist_build/
 .cache/
 .vite/
 
 # IDE
 .idea/
 .vscode/
+
+# Claude Code worktrees / session
+.claude/
+
+# エディタ/リンタが生成する一時ファイル
+*.tmp.*
+
+# ローカル検証用スクリプト
+scripts/test_multi_ws*.js

--- a/3dp_lib/dashboard_client_sync.js
+++ b/3dp_lib/dashboard_client_sync.js
@@ -184,10 +184,27 @@ function _handleRelayMessage(msg) {
       _clientId = msg.clientId;
       _relayMode = msg.mode;
       console.info(`[client-sync] 初期化: clientId=${_clientId}, mode=${_relayMode}`);
-      // body にモードクラスを設定（readonly制御CSSが適用される）
-      document.body.classList.add(`relay-${_relayMode}`);
-      // トップバーにモードバッジを表示
-      _showModeBadge(_relayMode);
+      _updateRelayModeUI(_relayMode);
+      _setupPromoteButton();
+      break;
+
+    case "relay-promote-granted":
+      console.info("[client-sync] 操作モードへ昇格しました");
+      _relayMode = "satellite";
+      _updateRelayModeUI("satellite");
+      _notifyModeChange("operate");
+      break;
+
+    case "relay-promote-denied":
+      console.warn(`[client-sync] 昇格拒否: ${msg.reason}`);
+      _onPromoteDenied(msg.reason);
+      break;
+
+    case "relay-demote-granted":
+      console.info("[client-sync] 閲覧専用に戻りました");
+      _relayMode = "readonly";
+      _updateRelayModeUI("readonly");
+      _notifyModeChange("view");
       break;
 
     case "relay-snapshot":
@@ -367,6 +384,20 @@ export function sendRelayCommand(method, params, hostname) {
  * @returns {boolean} 送信成功なら true
  */
 /**
+ * リレーモードに応じてUI（body クラス・バッジ・昇格ボタン）を一括更新する。
+ *
+ * @private
+ * @param {string} mode - "readonly" | "satellite"
+ */
+function _updateRelayModeUI(mode) {
+  // body クラス: 旧モードを除去して現モードを設定（readonly制御CSSの切替）
+  document.body.classList.remove("relay-readonly", "relay-satellite");
+  document.body.classList.add(`relay-${mode}`);
+  _showModeBadge(mode);
+  _updatePromoteButton(mode);
+}
+
+/**
  * トップバーにリレーモードバッジを表示する。
  *
  * @private
@@ -382,6 +413,141 @@ function _showModeBadge(mode) {
   badge.textContent = labels[mode] || mode;
   badge.className = `relay-mode-badge ${mode}`;
   badge.style.display = "";
+}
+
+/**
+ * 昇格/降格ボタンのラベル・表示をモードに合わせて更新する。
+ *
+ * @private
+ * @param {string} mode - "readonly" | "satellite"
+ */
+function _updatePromoteButton(mode) {
+  const btn = document.getElementById("relay-promote-btn");
+  if (!btn) return;
+  if (mode === "readonly") {
+    btn.textContent = "🛰 操作モードへ昇格";
+    btn.title = "プリンタを直接操作できるモードに切り替えます";
+    btn.style.display = "";
+  } else if (mode === "satellite") {
+    btn.textContent = "👁 閲覧専用に戻す";
+    btn.title = "操作を無効化し閲覧専用に戻します";
+    btn.style.display = "";
+  } else {
+    btn.style.display = "none";
+  }
+}
+
+/** 昇格ボタンのリスナー登録済みフラグ */
+let _promoteBtnWired = false;
+
+/**
+ * 昇格/降格ボタンにクリックリスナーを登録する（1度だけ）。
+ *
+ * @private
+ */
+function _setupPromoteButton() {
+  if (_promoteBtnWired) return;
+  const btn = document.getElementById("relay-promote-btn");
+  if (!btn) return;
+  _promoteBtnWired = true;
+  btn.addEventListener("click", _onPromoteButtonClick);
+}
+
+/**
+ * 昇格/降格ボタンのクリック処理。
+ * readonly→確認ダイアログ→昇格要求、satellite→確認ダイアログ→降格要求。
+ *
+ * @private
+ */
+async function _onPromoteButtonClick() {
+  const { showConfirmDialog } = await import("./dashboard_ui_confirm.js");
+  if (_relayMode === "readonly") {
+    const ok = await showConfirmDialog({
+      level: "warn",
+      title: "操作モードへ昇格",
+      message: "プリンタを直接操作できるようになります。昇格しますか？",
+      confirmText: "昇格する",
+      cancelText: "キャンセル"
+    });
+    if (!ok) return;
+    _sendPromoteRequest("");  // まず PIN なしで要求。親が必要と判定したら PIN を促す
+  } else if (_relayMode === "satellite") {
+    const ok = await showConfirmDialog({
+      level: "info",
+      title: "閲覧専用に戻す",
+      message: "操作を無効化し、閲覧専用モードに戻します。よろしいですか？",
+      confirmText: "戻す",
+      cancelText: "キャンセル"
+    });
+    if (!ok) return;
+    if (_relayWs && _relayWs.readyState === 1) {
+      _relayWs.send(JSON.stringify({ type: "relay-demote-request" }));
+    }
+  }
+}
+
+/**
+ * 昇格要求をサーバへ送信する。
+ *
+ * @private
+ * @param {string} pin - 入力PIN（不要なら空文字）
+ */
+function _sendPromoteRequest(pin) {
+  if (!_relayWs || _relayWs.readyState !== 1) {
+    console.warn("[client-sync] リレー未接続のため昇格要求を送れません");
+    return;
+  }
+  _relayWs.send(JSON.stringify({ type: "relay-promote-request", pin: pin || "" }));
+}
+
+/**
+ * 昇格拒否時の処理。PIN 要求/不一致なら PIN 入力ダイアログを出して再要求する。
+ *
+ * @private
+ * @param {string} reason - 拒否理由
+ */
+async function _onPromoteDenied(reason) {
+  const { showConfirmDialog, showInputDialog } = await import("./dashboard_ui_confirm.js");
+  if (reason === "pin-required" || reason === "pin-mismatch") {
+    const message = reason === "pin-mismatch"
+      ? "PINが一致しません。もう一度入力してください。"
+      : "操作モードへの昇格にはPINが必要です。親機で設定されたPINを入力してください。";
+    const pin = await showInputDialog({
+      level: "warn",
+      title: "昇格PINの入力",
+      message,
+      placeholder: "PIN",
+      confirmText: "認証",
+      cancelText: "キャンセル"
+    });
+    if (pin == null || String(pin).trim() === "") return;
+    _sendPromoteRequest(String(pin).trim());
+  } else {
+    await showConfirmDialog({
+      level: "error",
+      title: "昇格できません",
+      message: `操作モードへの昇格が拒否されました (${reason || "denied"})`,
+      confirmText: "OK"
+    });
+  }
+}
+
+/**
+ * モード変更をトースト等で通知する（任意UI）。
+ *
+ * @private
+ * @param {string} kind - "operate" | "view"
+ */
+function _notifyModeChange(kind) {
+  try {
+    const label = kind === "operate" ? "操作モードに切り替えました" : "閲覧専用に戻しました";
+    const el = document.getElementById("relay-mode-badge");
+    if (el) {
+      el.classList.add("relay-mode-flash");
+      setTimeout(() => el.classList.remove("relay-mode-flash"), 1200);
+    }
+    console.info(`[client-sync] ${label}`);
+  } catch { /* 通知失敗は無視 */ }
 }
 
 export function sendRelayFilament(action, data) {

--- a/3dp_lib/dashboard_data.js
+++ b/3dp_lib/dashboard_data.js
@@ -208,6 +208,8 @@ export const monitorData = {
     cameraToggle: false,  // カメラ ON/OFF
     cameraPort: 8080,     // カメラストリームポート（デフォルト。per-host は connectionTargets.cameraPort）
     httpPort: 80,         // HTTP ポート（デフォルト。印刷履歴・ファイル取得用）
+    relayPromotePin: "",  // リレー操作モード昇格PIN（空=確認のみ）。親でのみ設定・参照可
+    filamentUnit: "m",    // 使用量表示単位 "m" | "mm"（印刷履歴・ファイル一覧共通トグル）
     notificationSettings: {}
   },
   machines: {

--- a/3dp_lib/dashboard_panel_boot.js
+++ b/3dp_lib/dashboard_panel_boot.js
@@ -415,6 +415,14 @@ function _initTopMenuBar() {
       const camPort = document.getElementById("conn-modal-camera-port");
       if (camPort) camPort.value = monitorData.appSettings.cameraPort || DEFAULT_CAMERA_PORT;
 
+      /* ★ リレー操作昇格PIN: 親(Electron)モードのみ表示・編集可。
+         子クライアント(ブラウザ)からは参照も変更もできない。 */
+      const relayPinLabel = document.getElementById("conn-modal-relay-pin-label");
+      const relayPin = document.getElementById("conn-modal-relay-pin");
+      const isParent = !!(window.electronAPI?.isElectron?.());
+      if (relayPinLabel) relayPinLabel.style.display = isParent ? "" : "none";
+      if (relayPin && isParent) relayPin.value = monitorData.appSettings.relayPromotePin || "";
+
       /* 入力欄をクリア */
       const modalIp = document.getElementById("conn-modal-ip");
       if (modalIp) modalIp.value = "";
@@ -453,6 +461,12 @@ function _initTopMenuBar() {
     const camPort = document.getElementById("conn-modal-camera-port");
     if (camPort && camPort.value) {
       monitorData.appSettings.cameraPort = parseInt(camPort.value, 10) || DEFAULT_CAMERA_PORT;
+    }
+
+    // ★ リレー操作昇格PIN: 親モードのみ保存（子は要素が非表示で値も持たない）
+    const relayPin = document.getElementById("conn-modal-relay-pin");
+    if (relayPin && window.electronAPI?.isElectron?.()) {
+      monitorData.appSettings.relayPromotePin = String(relayPin.value || "").trim();
     }
     // ★ 設定変更を即時保存（保存漏れでリスタート時に設定消失するバグ修正）
     saveUnifiedStorage(true);

--- a/3dp_lib/dashboard_panel_init.js
+++ b/3dp_lib/dashboard_panel_init.js
@@ -673,11 +673,20 @@ function initCurrentPrintPanel(body, hostname) {
  * @param {string} hostname - ホスト名
  */
 function initHistoryPanel(body, hostname) {
-  // 履歴再読み込みボタン
+  // 履歴再読み込みボタン（印刷履歴: reqHistory）
   const refreshBtn = body.querySelector("#history-refresh-btn");
   if (refreshBtn) {
     refreshBtn.addEventListener("click", () => {
       sendCommand("get", { reqHistory: 1 }, hostname);
+    });
+  }
+
+  // 使用量 単位トグル（m/mm、全パネル共通・即時保存）
+  const unitToggle = body.querySelector("#history-unit-toggle");
+  if (unitToggle) {
+    unitToggle.addEventListener("click", () => {
+      const next = printManager.getFilamentUnit() === "m" ? "mm" : "m";
+      printManager.setFilamentUnit(next);
     });
   }
 
@@ -693,6 +702,9 @@ function initHistoryPanel(body, hostname) {
   } catch (e) {
     console.warn("[panel-init] history render エラー:", e);
   }
+
+  // 現在の単位設定をこのパネルのヘッダー/ボタン/セルへ反映
+  try { printManager.applyFilamentUnitToUI(); } catch { /* 無視 */ }
 }
 
 /**
@@ -708,6 +720,23 @@ function initFileListPanel(body, hostname) {
     console.warn("[panel-init] upload UI 初期化エラー:", e);
   }
 
+  // ファイル一覧再読み込みボタン（ファイル一覧: reqGcodeFile）
+  const refreshBtn = body.querySelector("#filelist-refresh-btn");
+  if (refreshBtn) {
+    refreshBtn.addEventListener("click", () => {
+      sendCommand("get", { reqGcodeFile: 1 }, hostname);
+    });
+  }
+
+  // 予定量 単位トグル（m/mm、全パネル共通・即時保存）
+  const unitToggle = body.querySelector("#filelist-unit-toggle");
+  if (unitToggle) {
+    unitToggle.addEventListener("click", () => {
+      const next = printManager.getFilamentUnit() === "m" ? "mm" : "m";
+      printManager.setFilamentUnit(next);
+    });
+  }
+
   // キャッシュ済みファイル一覧を表示（パネル生成前にデータ受信済みの場合）
   try {
     const machine = monitorData.machines[hostname];
@@ -719,6 +748,9 @@ function initFileListPanel(body, hostname) {
   } catch (e) {
     console.warn("[panel-init] file list render エラー:", e);
   }
+
+  // 現在の単位設定をこのパネルのヘッダー/ボタン/セルへ反映
+  try { printManager.applyFilamentUnitToUI(); } catch { /* 無視 */ }
 }
 
 /**

--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -38,6 +38,7 @@ import {
   savePrintHistory,
   loadPrintVideos,
   savePrintVideos,
+  saveUnifiedStorage,
   MAX_PRINT_HISTORY
 } from "./dashboard_storage.js";
 
@@ -53,6 +54,8 @@ import {
   getSpoolById,
   updateSpool,
   formatFilamentAmount,
+  formatUsageHtml,
+  usageHeaderLabel,
   formatSpoolDisplayId,
   buildFilamentRecommendations
 } from "./dashboard_spool.js";
@@ -62,6 +65,60 @@ import { showSpoolDialog, showSpoolSelectDialog } from "./dashboard_spool_ui.js"
 import { showHistoryFilamentDialog, updatePreview as updateFilamentPreview } from "./dashboard_filament_change.js";
 import { PRINT_STATE_CODE } from "./dashboard_ui_mapping.js";
 import { getCurrentPrintID } from "./dashboard_aggregator.js";
+
+/**
+ * 現在の使用量表示単位を返す。
+ * @returns {"m"|"mm"}
+ */
+export function getFilamentUnit() {
+  return monitorData.appSettings.filamentUnit === "mm" ? "mm" : "m";
+}
+
+/**
+ * 使用量表示単位(m/mm)を設定し、即時保存して開いている全パネルの
+ * ヘッダー・トグルボタン・使用量セルを再描画なしで更新する。
+ *
+ * @param {"m"|"mm"} unit - 設定する単位
+ * @returns {void}
+ */
+export function setFilamentUnit(unit) {
+  const u = unit === "mm" ? "mm" : "m";
+  monitorData.appSettings.filamentUnit = u;
+  saveUnifiedStorage(true);  // ★ 即時保存
+  applyFilamentUnitToUI(u);
+}
+
+/**
+ * 現在の単位設定を全 UI（ヘッダー・トグルボタン・使用量セル）へ反映する。
+ * DOM を直接更新するため再フェッチ不要。
+ *
+ * @param {"m"|"mm"} [unit] - 適用する単位（省略時は設定値）
+ * @returns {void}
+ */
+export function applyFilamentUnitToUI(unit) {
+  const u = unit || getFilamentUnit();
+
+  // 1) ヘッダーラベル（data-unit-base を持つ th）
+  document.querySelectorAll("th[data-unit-base]").forEach(th => {
+    th.textContent = usageHeaderLabel(th.getAttribute("data-unit-base"), u);
+  });
+
+  // 2) トグルボタンのラベル
+  document.querySelectorAll(".unit-toggle-btn").forEach(btn => {
+    btn.textContent = `単位: ${u}`;
+  });
+
+  // 3) 使用量セル（data-mm を持つ .usage-cell）を再計算
+  document.querySelectorAll(".usage-cell[data-mm]").forEach(td => {
+    const mmStr = td.getAttribute("data-mm");
+    if (mmStr === "" || mmStr == null) return;  // "—" 等はそのまま
+    const mm = Number(mmStr);
+    if (!Number.isFinite(mm)) return;
+    const spoolId = td.getAttribute("data-spool") || "";
+    const spool = spoolId ? (getSpoolById(spoolId) || null) : null;
+    td.innerHTML = formatUsageHtml(mm, spool, u);
+  });
+}
 
 /**
  * 履歴エントリのスプール変更が現在印刷中ジョブに対するものか判定し、
@@ -1185,9 +1242,11 @@ export function renderHistoryTable(rawArray, baseUrl, hostname) {
     // フィラメント消費量: スプール情報があれば g/¥ 換算も表示
     const spoolForFmt = spoolInfos.length > 0
       ? (getSpoolById(spoolInfos[0].spoolId) || null) : null;
+    // ★ 単位トグル(m/mm)に応じて距離を切替、距離と (g, ¥) を2段表示
+    const _unit = monitorData.appSettings.filamentUnit === "mm" ? "mm" : "m";
     const umaterial =
       raw.usagematerial != null
-        ? formatFilamentAmount(raw.usagematerial, spoolForFmt).display
+        ? formatUsageHtml(raw.usagematerial, spoolForFmt, _unit)
         : "—";
     /* 成否表示: 印刷中/一時停止中のジョブは ▶/⏸ で表示
        ★ 「印刷中」は『現在印刷しているID(currentPrintID)と一致 かつ
@@ -1278,7 +1337,7 @@ export function renderHistoryTable(rawArray, baseUrl, hostname) {
         ${timeDetailHtml}
       </td>
       <td data-key="printfinish" class="col-finish"><span class="${finishCls}">${finish}</span></td>
-      <td data-key="usagematerial">${umaterial}</td>
+      <td data-key="usagematerial" class="usage-cell" data-mm="${raw.usagematerial != null ? raw.usagematerial : ''}" data-spool="${spoolForFmt?.id || ''}">${umaterial}</td>
       <td data-key="spool" class="col-spool">${spoolHtml}</td>
       <td data-key="filemd5" class="col-extra">
         ${videoLink}
@@ -2623,7 +2682,9 @@ export function renderFileList(info, baseUrl, hostname) {
 
     // ファイル別実績
     const insight = buildFileInsight(item.filename, hostname);
-    const expectFmt = formatFilamentAmount(item.expect, null);
+    // ★ 単位トグル(m/mm)に応じて予定量を表示（ファイル一覧は g/¥ 換算なし）
+    const _unit = monitorData.appSettings.filamentUnit === "mm" ? "mm" : "m";
+    const expectHtml = formatUsageHtml(item.expect, null, _unit);
 
     // 実績列: "4/5" (成功/全体) or "0"
     let printsLabel;
@@ -2662,7 +2723,7 @@ export function renderFileList(info, baseUrl, hostname) {
       <td data-key="layer">${item.layer.toLocaleString()}</td>
       <td data-key="size">${item.size.toLocaleString()}</td>
       <td data-key="mtime">${mtimeStr}</td>
-      <td data-key="expect">${expectFmt.display}</td>
+      <td data-key="expect" class="usage-cell" data-mm="${item.expect != null ? item.expect : ''}">${expectHtml}</td>
       <td data-key="prints">${printsLabel}</td>
       <td data-key="avgtime">${avgTimeLabel}</td>
       <td data-key="md5" class="col-md5" title="${item.filemd5 || ''}">${md5short}</td>

--- a/3dp_lib/dashboard_relay_bridge.js
+++ b/3dp_lib/dashboard_relay_bridge.js
@@ -100,9 +100,44 @@ export function initRelayBridge() {
     console.debug(`[relay-bridge] スナップショット送信: ${data.clientId}`);
   });
 
+  // 子クライアントからの操作モード昇格要求の PIN 検証（親側のみが PIN を保持）
+  window.electronAPI.onRelayPromoteRequest?.((data) => {
+    const result = verifyPromotePin(data.pin);
+    window.electronAPI.relayPromoteResponse(data.clientId, result.granted, result.reason);
+    console.info(`[relay-bridge] 昇格要求 ${data.clientId}: ${result.granted ? "許可" : "拒否(" + result.reason + ")"}`);
+  });
+
   _initialized = true;
   console.info("[relay-bridge] 親側リレーブリッジ初期化完了");
   return true;
+}
+
+/**
+ * 子クライアントの昇格 PIN を親の設定と照合する純関数。
+ *
+ * - 親に PIN 未設定（空）なら確認ダイアログのみで昇格許可（granted）。
+ * - PIN 設定済みなら、入力 PIN が一致したときのみ許可。
+ *   入力が空 → "pin-required"、不一致 → "pin-mismatch" を理由に拒否。
+ *
+ * @param {string} inputPin - 子が入力した PIN
+ * @param {string} [configuredPin] - 親の設定 PIN（省略時は appSettings から取得）
+ * @returns {{granted: boolean, reason: string}}
+ */
+export function verifyPromotePin(inputPin, configuredPin) {
+  const pin = String(
+    configuredPin != null ? configuredPin : (monitorData.appSettings.relayPromotePin || "")
+  ).trim();
+  if (!pin) {
+    return { granted: true, reason: "" };           // PIN 未設定 → 許可
+  }
+  const entered = String(inputPin == null ? "" : inputPin).trim();
+  if (!entered) {
+    return { granted: false, reason: "pin-required" };
+  }
+  if (entered === pin) {
+    return { granted: true, reason: "" };
+  }
+  return { granted: false, reason: "pin-mismatch" };
 }
 
 /**

--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -45,7 +45,7 @@ import {
 import { saveUnifiedStorage, trimUsageHistory } from "./dashboard_storage.js";
 import { consumeInventory } from "./dashboard_filament_inventory.js";
 import { updateStoredDataToDOM } from "./dashboard_ui.js";
-import { updateHistoryList, loadHistory } from "./dashboard_printmanager.js";
+import { updateHistoryList, loadHistory, saveHistory } from "./dashboard_printmanager.js";
 import { getDeviceIp, getHttpPort } from "./dashboard_connection.js";
 
 /**
@@ -210,6 +210,47 @@ export function formatFilamentAmount(mm, spool = null) {
   }
 
   return { mm: val, m, g, cost, currency, display };
+}
+
+/**
+ * 使用量を「距離」と「(重量, 費用)」の2段に分けた HTML を返す。
+ *
+ * - 単位トグル(unit)に応じて距離を m / mm 表示で切り替える。
+ * - スプールが渡され重量/費用が算出できる場合は2行目に括弧表示。
+ * - 右寄せ・改行は呼び出し側CSS(.usage-cell)で制御する。
+ *
+ * @function formatUsageHtml
+ * @param {number} mm - フィラメント量 (mm)
+ * @param {Object|null} spool - スプール（g/¥算出用、無ければ距離のみ）
+ * @param {string} [unit="m"] - "m" | "mm"
+ * @returns {string} 2段表示の HTML 文字列
+ */
+export function formatUsageHtml(mm, spool = null, unit = "m") {
+  const f = formatFilamentAmount(mm, spool);
+  if (f.mm == null) return `<span class="usage-dist">---</span>`;
+  const distance = unit === "mm"
+    ? `${Math.round(f.mm)}mm`
+    : `${f.m}m`;
+  let second = "";
+  if (f.g != null) {
+    second = f.cost != null ? `(${f.g}g, ${f.currency}${f.cost})` : `(${f.g}g)`;
+  }
+  const distHtml = `<span class="usage-dist">${distance}</span>`;
+  return second
+    ? `${distHtml}<span class="usage-sub">${second}</span>`
+    : distHtml;
+}
+
+/**
+ * 使用量カラムのヘッダーラベルを単位に応じて返す。
+ *
+ * @function usageHeaderLabel
+ * @param {string} base - ベース名（"使用量" / "予定量"）
+ * @param {string} [unit="m"] - "m" | "mm"
+ * @returns {string} 例 "使用量(m)" / "予定量(mm)"
+ */
+export function usageHeaderLabel(base, unit = "m") {
+  return `${base}(${unit === "mm" ? "mm" : "m"})`;
 }
 
 /**
@@ -1149,6 +1190,80 @@ export function addSpoolFromPreset(preset, override = {}) {
 }
 
 /**
+ * オフライン完了ジョブに付与する filamentInfo エントリを構築する純関数。
+ *
+ * @function buildOfflineFilamentInfo
+ * @param {Object} spool - 現在装着スプール
+ * @param {number} usedMm - そのジョブの消費量(mm)
+ * @returns {Object} filamentInfo エントリ（isOfflineInferred=true）
+ */
+export function buildOfflineFilamentInfo(spool, usedMm) {
+  return {
+    spoolId: spool.id,
+    serialNo: spool.serialNo,
+    spoolName: spool.name,
+    colorName: spool.colorName,
+    filamentColor: spool.filamentColor,
+    material: spool.material,
+    spoolCount: spool.printCount,
+    expectedRemain: spool.remainingLengthMm,
+    usedMm: Number(usedMm) || 0,
+    isOfflineInferred: true   // 3dpmon 停止中に完了→現在装着から推定したフラグ
+  };
+}
+
+/**
+ * 履歴ジョブにフィラメント継続紐付けを行うべきか判定する純関数。
+ * 既に filamentInfo を持つジョブは尊重し、上書きしない。
+ *
+ * @function shouldLinkOfflineJob
+ * @param {Object} job - 履歴ジョブ
+ * @returns {boolean} 紐付けすべきなら true
+ */
+export function shouldLinkOfflineJob(job) {
+  if (!job) return false;
+  if (Array.isArray(job.filamentInfo) && job.filamentInfo.length > 0) return false;
+  if (job.filamentId) return false;  // 既に紐付け済み
+  return true;
+}
+
+/**
+ * 指定ジョブID群（オフライン中に完了した印刷）に、現在装着スプールの
+ * filamentInfo を遡及的に紐付ける。フィラメント交換していなければ
+ * 現在のフィラメントで印刷が継続されたとみなす要望に対応。
+ *
+ * @private
+ * @param {string} hostname - ホスト名
+ * @param {Object} spool - 現在装着スプール
+ * @param {Set<string>} jobIds - 紐付け対象ジョブID（文字列）
+ * @returns {number} 紐付けたジョブ数
+ */
+function _linkOfflineJobsToSpool(hostname, spool, jobIds) {
+  if (!spool || !jobIds || jobIds.size === 0) return 0;
+  let jobs;
+  try { jobs = loadHistory(hostname); } catch { return 0; }
+  if (!Array.isArray(jobs) || !jobs.length) return 0;
+  let linked = 0;
+  for (const job of jobs) {
+    if (!jobIds.has(String(job.id))) continue;
+    if (!shouldLinkOfflineJob(job)) continue;
+    const usedMm = Number(job.materialUsedMm ?? job.usagematerial ?? 0) || 0;
+    job.filamentInfo = [buildOfflineFilamentInfo(spool, usedMm)];
+    job.filamentId = spool.id;
+    linked++;
+  }
+  if (linked > 0) {
+    try {
+      saveHistory(jobs, hostname);
+      console.log(`[autoCorrect] ${hostname}: ${linked}件のオフライン完了印刷に現在フィラメント(${spool.id})を継続紐付け`);
+    } catch (e) {
+      console.warn("[autoCorrect] オフライン紐付けの saveHistory 失敗:", e);
+    }
+  }
+  return linked;
+}
+
+/**
  * 使用履歴から現在スプールの残量や印刷回数を補正する。
  *
  * @function autoCorrectCurrentSpool
@@ -1158,6 +1273,9 @@ export function addSpoolFromPreset(preset, override = {}) {
  * 交換記録を見つけた場合、その後の使用量合計から残量を再計算
  * する。途中で別スプールへの交換が記録されていれば補正は行わ
  * ない。
+ * ★ 3dpmon 停止中に完了した印刷は、フィラメント交換していなければ
+ *   現在装着スプールで継続印刷したとみなし、当該ジョブへ filamentInfo を
+ *   遡及紐付けする。残量は0までクランプ（0到達後もそのまま）。
  */
 export function autoCorrectCurrentSpool(hostname) {
   if (!hostname || hostname === "_$_NO_MACHINE_$_") {
@@ -1195,6 +1313,7 @@ export function autoCorrectCurrentSpool(hostname) {
     const persistedHistory = loadHistory(hostname);
     let fallbackTotal = 0;
     let fallbackCount = 0;
+    const fallbackJobIds = new Set();
     for (const entry of persistedHistory) {
       if (!entry.printfinish) continue;
       const used = Number(entry.materialUsedMm ?? NaN);
@@ -1206,17 +1325,20 @@ export function autoCorrectCurrentSpool(hostname) {
       if (trackedJobIds.has(String(entry.id))) continue;
       fallbackTotal += used;
       fallbackCount += 1;
+      fallbackJobIds.add(String(entry.id));
       console.log(`[autoCorrect:fallback] ${hostname}: jobId=${entry.id} から ${used.toFixed(0)}mm を遡及加算 (updatedAt=${updatedAt})`);
     }
     if (fallbackTotal > 0) {
-      const expected = spool.remainingLengthMm - fallbackTotal;
-      if (expected < 0) {
-        console.warn(`[autoCorrect:fallback] ${hostname}: total(${fallbackTotal.toFixed(0)}) > remaining(${spool.remainingLengthMm.toFixed(0)}) → 変更なし`);
-        return;
+      // ★ 残量は0までクランプ（消費が残量を超えても0で進行。ユーザー要望）
+      const raw = spool.remainingLengthMm - fallbackTotal;
+      if (raw < 0) {
+        console.warn(`[autoCorrect:fallback] ${hostname}: total(${fallbackTotal.toFixed(0)}) > remaining(${spool.remainingLengthMm.toFixed(0)}) → 残量0にクランプ`);
       }
-      spool.remainingLengthMm = expected;
+      spool.remainingLengthMm = Math.max(0, raw);
       spool.updatedAt = Date.now();
       spool.printCount = (spool.printCount || 0) + fallbackCount;
+      // ★ オフライン完了印刷へ現在フィラメントを継続紐付け
+      _linkOfflineJobsToSpool(hostname, spool, fallbackJobIds);
       saveUnifiedStorage();
     }
     return;
@@ -1261,6 +1383,7 @@ export function autoCorrectCurrentSpool(hostname) {
   // ★ 遡及補正: プリンター報告履歴（printStore.history）から未記録の完了印刷を加算
   // アプリOFF中の印刷はusageHistoryに記録されないが、プリンター履歴には残っている
   const persistedHistory = loadHistory(hostname);
+  const offlineJobIds = new Set();
   if (startPrintIdNum > 0) {
     for (const entry of persistedHistory) {
       const entryId = String(entry.id ?? "");
@@ -1276,19 +1399,20 @@ export function autoCorrectCurrentSpool(hostname) {
 
       total += used;
       count += 1;
+      offlineJobIds.add(entryId);
       console.log(`[autoCorrect] ${hostname}: 未記録印刷 jobId=${entryId} から ${used.toFixed(0)}mm を遡及加算`);
     }
   }
 
-  // 計算された残量
-  const expected = startLen - total;
-  if (!Number.isFinite(expected)) return;
-
-  // 異常検知: 消費合計が起点残量を超える場合は変更せず警告
+  // 計算された残量（消費が起点を超えても0までクランプ。ユーザー要望: 0到達後もそのまま進行）
+  if (!Number.isFinite(startLen - total)) return;
   if (total > startLen) {
-    console.warn(`[autoCorrect] ${hostname}: total(${total.toFixed(0)}) > startLen(${startLen.toFixed(0)}) → 残量変更なし`);
-    return;
+    console.warn(`[autoCorrect] ${hostname}: total(${total.toFixed(0)}) > startLen(${startLen.toFixed(0)}) → 残量0にクランプ`);
   }
+  const expected = Math.max(0, startLen - total);
+
+  // ★ オフライン完了印刷へ現在フィラメントを継続紐付け（残量変化の有無に関わらず実施）
+  _linkOfflineJobsToSpool(hostname, spool, offlineJobIds);
 
   const diff = Math.abs(expected - spool.remainingLengthMm);
   if (Number.isFinite(diff) && (diff > 0.1 || spool.printCount !== count)) {

--- a/3dp_lib/dashboard_ui_mapping.js
+++ b/3dp_lib/dashboard_ui_mapping.js
@@ -218,7 +218,7 @@ export const dashboardMapping = {
 
   // --- 材料関連 ---
   usedMaterialLength:    { elementKey: "materialLength",          process: v => ({ value: String(v), unit: "mm" }) },
-  filamentRemainingMm:  { elementKey: "filamentRemainingMm",    process: v => ({ value: String(v), unit: "mm" }) },
+  filamentRemainingMm:  { elementKey: "filamentRemainingMm",    process: v => ({ value: (Number.isFinite(parseFloat(v)) ? parseFloat(v).toFixed(1) : String(v)), unit: "mm" }) },
   materialDetect:        { elementKey: "materialDetect",          process: v => ({ value: utils.formatBinary(v), unit: "" }) },
   materialStatus:        { elementKey: "materialStatus",          process: v => mapValue(MATERIAL_STATUS_MAP, v) },
 

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <!-- ★ app-version: ビルド時に scripts/sync-version.js が package.json から自動更新する -->
-  <meta name="app-version" content="2.2.1010" />
-  <title>3dpmon - 3Dプリンタ監視ダッシュボード</title>
+  <meta name="app-version" content="2.2.1011" />
+  <title>3dpmon - 3Dプリンタ監視ダッシュボード v2.2.1011</title>
   <!-- サイトアイコン -->
   <link rel="icon" href="favicon.ico">
 

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -36,6 +36,8 @@
     <div class="menu-section">
       <strong>3dpmon</strong>
       <span id="relay-mode-badge" class="relay-mode-badge" style="display:none"></span>
+      <!-- リレー子クライアント用: 操作モード昇格/閲覧専用降格トグル（親では非表示） -->
+      <button id="relay-promote-btn" class="relay-promote-btn" style="display:none"></button>
       <span class="status-dot disconnected" id="top-status-dot"></span>
       <span id="top-conn-label" style="font-size:12px;">未接続</span>
     </div>
@@ -81,6 +83,10 @@
           </label>
           <label style="white-space:nowrap;">
             カメラポート: <input type="number" id="conn-modal-camera-port" min="1" max="65535" step="1" inputmode="numeric" style="width:5em;font-size:12px;padding:4px;border:1px solid #ccc;border-radius:3px;" placeholder="8080">
+          </label>
+          <!-- リレー操作昇格PIN（親モードのみ表示。子クライアントからは参照・変更不可） -->
+          <label id="conn-modal-relay-pin-label" style="white-space:nowrap;display:none;" title="ビューモードの端末が操作モードへ昇格する際に要求するPIN。空欄なら確認のみで昇格可。">
+            操作昇格PIN: <input type="text" id="conn-modal-relay-pin" autocomplete="off" style="width:6em;font-size:12px;padding:4px;border:1px solid #ccc;border-radius:3px;" placeholder="未設定">
           </label>
           <span style="flex:1"></span>
           <button id="conn-modal-notif-btn" style="font-size:11px;padding:3px 10px;cursor:pointer;background:#f0f4ff;border:1px solid #c0d0e0;border-radius:3px;">🔔 通知設定</button>
@@ -846,7 +852,9 @@
     <!-- ─── 印刷履歴セクション ─── -->
     <div id="panel-print-history-section" class="history-panel-content">
       <div class="history-toolbar">
-        <button id="history-refresh-btn" class="btn btn-sm" aria-label="履歴を更新">再読み込み</button>
+        <button id="history-refresh-btn" class="icon-btn" aria-label="履歴を再読み込み" title="印刷履歴を再読み込み">🔄</button>
+        <span class="toolbar-spacer"></span>
+        <button id="history-unit-toggle" class="btn btn-sm unit-toggle-btn" aria-label="使用量の単位を切替" title="使用量の単位 m / mm を切替">単位: m</button>
       </div>
       <div id="print-history-body" class="scrollable-body">
         <table id="print-history-table" class="fixed-header sortable-table history-table">
@@ -860,7 +868,7 @@
                 <th data-key="size">サイズ</th>
                 <th data-key="starttime">時間</th>
                 <th data-key="printfinish" class="th-narrow">成否</th>
-                <th data-key="usagematerial">使用量(mm)</th>
+                <th data-key="usagematerial" data-unit-base="使用量">使用量(m)</th>
                 <th data-key="spool">フィラメント</th>
                 <th data-key="filemd5">MD5</th>
             </tr>
@@ -885,6 +893,9 @@
           </span>
         </div>
         <span class="file-list-count">総数: <span id="file-list-total">0</span></span>
+        <button id="filelist-refresh-btn" class="icon-btn" aria-label="ファイル一覧を再読み込み" title="ファイル一覧を再読み込み">🔄</button>
+        <span class="toolbar-spacer"></span>
+        <button id="filelist-unit-toggle" class="btn btn-sm unit-toggle-btn" aria-label="予定量の単位を切替" title="予定量の単位 m / mm を切替">単位: m</button>
       </div>
       <div class="filelist-container scrollable-body">
         <table id="file-list-table" class="fixed-header sortable-table filelist-table">
@@ -897,7 +908,7 @@
               <th data-key="layer" class="th-narrow" title="積層厚さ(mm)">積層</th>
               <th data-key="size" title="サイズ(バイト)">サイズ</th>
               <th data-key="mtime" title="更新日時">更新日時</th>
-              <th data-key="expect" title="予定使用量">予定量</th>
+              <th data-key="expect" data-unit-base="予定量" title="予定使用量">予定量(m)</th>
               <th data-key="prints" class="th-narrow" title="印刷回数(成功/全)">実績</th>
               <th data-key="avgtime" class="th-narrow" title="平均所要時間">平均時間</th>
               <th data-key="md5" class="th-narrow" title="MD5">MD5</th>

--- a/3dp_panel.css
+++ b/3dp_panel.css
@@ -1629,6 +1629,27 @@ body.panel-mode .notification-container {
   align-items: center;
   gap: 6px;
 }
+
+/* ツールバー内の右寄せスペーサー（再読み込み・単位トグルを右端へ） */
+.toolbar-spacer { flex: 1 1 auto; }
+
+/* 使用量/予定量の単位トグルボタン */
+.unit-toggle-btn {
+  white-space: nowrap;
+  font-size: var(--font-xs, 11px);
+}
+
+/* 使用量セル: 右寄せ・距離と(g,¥)を2段表示 */
+.usage-cell {
+  text-align: right;
+  white-space: nowrap;
+}
+.usage-cell .usage-dist { display: block; }
+.usage-cell .usage-sub {
+  display: block;
+  font-size: var(--font-xs, 11px);
+  color: var(--color-text-muted, #64748b);
+}
 .panel-body .history-panel .scrollable-body {
   flex: 1;
   min-height: 0;
@@ -3541,6 +3562,38 @@ body.panel-mode .notification-container {
 .relay-mode-badge.parent {
   background: var(--color-warning-bg, #fef3c7);
   color: var(--color-warning, #f59e0b);
+}
+
+/* モード切替時の強調フラッシュ */
+.relay-mode-badge.relay-mode-flash {
+  animation: relay-mode-flash-anim 1.2s ease;
+}
+@keyframes relay-mode-flash-anim {
+  0%, 100% { box-shadow: none; }
+  30% { box-shadow: 0 0 0 3px rgba(34,197,94,0.6); }
+}
+
+/* リレー操作モード昇格/降格トグルボタン（トップバー） */
+.relay-promote-btn {
+  font-size: 11px;
+  padding: 3px 10px;
+  margin-left: 6px;
+  cursor: pointer;
+  background: var(--color-accent-bg, #ecfeff);
+  border: 1px solid var(--color-accent, #06b6d4);
+  border-radius: 4px;
+  color: var(--color-accent, #0e7490);
+  white-space: nowrap;
+}
+.relay-promote-btn:hover {
+  background: var(--color-accent, #06b6d4);
+  color: #fff;
+}
+/* satellite 中（操作可能）は「閲覧専用に戻す」を控えめ表示 */
+body.relay-satellite .relay-promote-btn {
+  background: var(--color-bg-subtle, #f1f5f9);
+  border-color: var(--color-border, #cbd5e1);
+  color: var(--color-text-muted, #64748b);
 }
 
 /* Readonly モード: コマンド系ボタンを無効化 */

--- a/electron/main.js
+++ b/electron/main.js
@@ -492,6 +492,11 @@ app.whenReady().then(async () => {
     if (relayServer) relayServer.sendToClient(clientId, { type: "relay-snapshot", state });
   });
 
+  // レンダラー(親) → リレー: 昇格PIN検証結果を反映
+  ipcMain.on("relay-promote-response", (_, { clientId, granted, reason }) => {
+    if (relayServer) relayServer.resolvePromote(clientId, granted, reason);
+  });
+
   // リレーサーバ情報の問い合わせ
   ipcMain.handle("relay-get-config", () => ({
     enabled: !!relayServer,

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -111,6 +111,24 @@ contextBridge.exposeInMainWorld("electronAPI", {
    */
   onRelayRequestSnapshot: (callback) => ipcRenderer.on("relay-request-snapshot", (_, data) => callback(data)),
 
+  /**
+   * 子クライアントからの操作モード昇格要求を受信するリスナーを登録する（親側）。
+   * 親レンダラーが appSettings の PIN と照合して検証する。
+   *
+   * @param {Function} callback - (data: {clientId, pin}) => void
+   */
+  onRelayPromoteRequest: (callback) => ipcRenderer.on("relay-promote-request", (_, data) => callback(data)),
+
+  /**
+   * 昇格PIN検証結果をリレーサーバへ返す（親側）。
+   *
+   * @param {string} clientId - 対象クライアントID
+   * @param {boolean} granted - 許可するか
+   * @param {string} [reason] - 拒否理由
+   */
+  relayPromoteResponse: (clientId, granted, reason) =>
+    ipcRenderer.send("relay-promote-response", { clientId, granted, reason }),
+
   /* ─── ARP 解決 API ─── */
 
   /**

--- a/electron/relay_server.js
+++ b/electron/relay_server.js
@@ -111,9 +111,33 @@ function startRelayServer(httpServer, options = {}) {
   return {
     broadcastDelta,
     sendToClient,
+    resolvePromote,
     getClientCount: () => _clients.size,
     getClients: () => [..._clients].map(c => ({ id: c.id, mode: c.mode, connectedAt: c.connectedAt }))
   };
+}
+
+/**
+ * 親レンダラーの PIN 検証結果を受けて、対象クライアントの昇格を確定/拒否する。
+ *
+ * @param {string} clientId - 対象クライアントID
+ * @param {boolean} granted - 昇格を許可するか
+ * @param {string} [reason] - 拒否理由（"pin-required" | "pin-mismatch" 等）
+ * @returns {void}
+ */
+function resolvePromote(clientId, granted, reason) {
+  for (const client of _clients) {
+    if (client.id !== clientId) continue;
+    if (granted) {
+      client.mode = "satellite";
+      _safeSend(client.ws, { type: "relay-promote-granted" });
+      console.log(`[relay] ${clientId} を satellite に昇格`);
+    } else {
+      _safeSend(client.ws, { type: "relay-promote-denied", reason: reason || "denied" });
+      console.log(`[relay] ${clientId} の昇格を拒否 (${reason || "denied"})`);
+    }
+    break;
+  }
 }
 
 /**
@@ -158,13 +182,37 @@ function sendToClient(clientId, data) {
  * @param {Object} msg - 受信メッセージ
  */
 function _handleClientMessage(client, msg) {
-  // readonly モードはコマンド送信不可
-  if (client.mode === "readonly" && msg.type !== "relay-ping") {
+  // readonly モードはコマンド送信不可。
+  // ただし昇格/降格リクエストと ping は readonly でも受け付ける。
+  const ALWAYS_ALLOWED = new Set([
+    "relay-ping", "relay-promote-request", "relay-demote-request"
+  ]);
+  if (client.mode === "readonly" && !ALWAYS_ALLOWED.has(msg.type)) {
     _safeSend(client.ws, { type: "relay-error", message: "Readonly mode: commands not allowed" });
     return;
   }
 
   switch (msg.type) {
+    case "relay-promote-request":
+      // ★ 操作モードへの昇格要求。PIN 検証は親レンダラー（appSettings 保持側）に委譲する。
+      //   子クライアントは PIN を参照できないため、入力 PIN を親へ送り検証させる。
+      if (_sendToRenderer) {
+        _sendToRenderer("relay-promote-request", {
+          clientId: client.id,
+          pin: typeof msg.pin === "string" ? msg.pin : ""
+        });
+      } else {
+        _safeSend(client.ws, { type: "relay-promote-denied", reason: "no-parent" });
+      }
+      break;
+
+    case "relay-demote-request":
+      // ★ 閲覧専用への降格はサーバ側で即時実行（PIN 不要）
+      client.mode = "readonly";
+      _safeSend(client.ws, { type: "relay-demote-granted" });
+      console.log(`[relay] ${client.id} を readonly に降格`);
+      break;
+
     case "relay-command":
       // プリンタコマンドの中継: 子 → 親レンダラー → プリンタ
       if (_sendToRenderer && msg.target && msg.method) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3dpmon",
-  "version": "2.2.1010",
+  "version": "2.2.1011",
   "description": "3Dプリンタ監視ダッシュボード - Electron版",
   "main": "electron/main.js",
   "scripts": {

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -22,6 +22,15 @@ const targets = [
     pattern: /<meta name="app-version" content="[^"]*"\s*\/?>/,
     replace: `<meta name="app-version" content="${VERSION}" />`,
     label: "HTML meta tag"
+  },
+  {
+    // ★ CI の「HTML title version check」が v${VERSION} を grep する。
+    //   静的タイトルにもバージョンを反映する（実行時に JS が再設定するが、
+    //   静的検証・初期表示のため v 付きで埋め込む）。
+    file: "3dp_monitor.html",
+    pattern: /<title>3dpmon - 3Dプリンタ監視ダッシュボード(?: v[\d.]+)?<\/title>/,
+    replace: `<title>3dpmon - 3Dプリンタ監視ダッシュボード v${VERSION}</title>`,
+    label: "HTML title"
   }
 ];
 

--- a/tests/unit/dashboard_relay_promote.test.js
+++ b/tests/unit/dashboard_relay_promote.test.js
@@ -1,0 +1,57 @@
+/**
+ * dashboard_relay_bridge.js 昇格PIN検証テスト
+ *
+ * 仕様:
+ *   - 親に PIN 未設定(空) → 確認のみで昇格許可 (granted=true)
+ *   - PIN 設定済み + 入力一致 → 許可
+ *   - PIN 設定済み + 入力空 → 拒否 reason="pin-required"
+ *   - PIN 設定済み + 入力不一致 → 拒否 reason="pin-mismatch"
+ *   - PIN は親(appSettings)のみが保持。子は参照不可。
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../3dp_lib/dashboard_data.js', () => ({
+  monitorData: { appSettings: { relayPromotePin: '' }, machines: {} },
+  PLACEHOLDER_HOSTNAME: '_$_NO_MACHINE_$_',
+}));
+vi.mock('../../3dp_lib/dashboard_connection.js', () => ({
+  sendCommand: vi.fn(),
+}));
+
+const { verifyPromotePin } = await import('../../3dp_lib/dashboard_relay_bridge.js');
+
+describe('verifyPromotePin — 昇格PIN検証', () => {
+  it('PIN未設定(空)なら入力に関わらず許可', () => {
+    expect(verifyPromotePin('', '')).toEqual({ granted: true, reason: '' });
+    expect(verifyPromotePin('anything', '')).toEqual({ granted: true, reason: '' });
+    expect(verifyPromotePin(null, '   ')).toEqual({ granted: true, reason: '' }); // 空白のみも未設定扱い
+  });
+
+  it('PIN設定済み + 一致 → 許可', () => {
+    expect(verifyPromotePin('1234', '1234')).toEqual({ granted: true, reason: '' });
+  });
+
+  it('PIN設定済み + 前後空白は許容して一致判定', () => {
+    expect(verifyPromotePin(' 1234 ', '1234')).toEqual({ granted: true, reason: '' });
+  });
+
+  it('★PIN設定済み + 入力空 → pin-required', () => {
+    expect(verifyPromotePin('', '1234')).toEqual({ granted: false, reason: 'pin-required' });
+    expect(verifyPromotePin(null, '1234')).toEqual({ granted: false, reason: 'pin-required' });
+    expect(verifyPromotePin('   ', '1234')).toEqual({ granted: false, reason: 'pin-required' });
+  });
+
+  it('★PIN設定済み + 不一致 → pin-mismatch', () => {
+    expect(verifyPromotePin('0000', '1234')).toEqual({ granted: false, reason: 'pin-mismatch' });
+    expect(verifyPromotePin('12345', '1234')).toEqual({ granted: false, reason: 'pin-mismatch' });
+  });
+
+  it('configuredPin 省略時は appSettings.relayPromotePin を参照（既定は空=許可）', () => {
+    // モックの monitorData.appSettings.relayPromotePin は ''
+    expect(verifyPromotePin('whatever')).toEqual({ granted: true, reason: '' });
+  });
+
+  it('数値型PINでも文字列化して比較', () => {
+    expect(verifyPromotePin(1234, 1234)).toEqual({ granted: true, reason: '' });
+  });
+});

--- a/tests/unit/dashboard_spool.test.js
+++ b/tests/unit/dashboard_spool.test.js
@@ -32,6 +32,8 @@ vi.mock('../../3dp_lib/dashboard_ui.js', () => ({
 }));
 vi.mock('../../3dp_lib/dashboard_printmanager.js', () => ({
   updateHistoryList: vi.fn(),
+  loadHistory: vi.fn(() => []),
+  saveHistory: vi.fn(),
 }));
 vi.mock('../../3dp_lib/dashboard_connection.js', () => ({
   getDeviceIp: vi.fn(),
@@ -45,9 +47,13 @@ import {
   getSpoolStateLabel,
   formatSpoolDisplayId,
   formatFilamentAmount,
+  formatUsageHtml,
+  usageHeaderLabel,
   weightFromLength,
   lengthFromWeight,
   getMaterialDensity,
+  buildOfflineFilamentInfo,
+  shouldLinkOfflineJob,
 } from '../../3dp_lib/dashboard_spool.js';
 
 // =============================================
@@ -319,6 +325,109 @@ describe('formatFilamentAmount', () => {
     const result = formatFilamentAmount(12340);
     expect(typeof result.display).toBe('string');
     expect(result.display.length).toBeGreaterThan(0);
+  });
+});
+
+// =============================================
+// formatUsageHtml（単位トグル + 2段表示）
+// =============================================
+describe('formatUsageHtml', () => {
+  const spool = { density: 1.24, filamentDiameter: 1.75, totalLengthMm: 336000, purchasePrice: 1699, currencySymbol: '¥' };
+
+  it('m単位: 距離を m 表示', () => {
+    const html = formatUsageHtml(22800, null, 'm');
+    expect(html).toContain('22.8m');
+    expect(html).toContain('usage-dist');
+  });
+
+  it('mm単位: 距離を mm 表示（整数）', () => {
+    const html = formatUsageHtml(22800, null, 'mm');
+    expect(html).toContain('22800mm');
+    expect(html).not.toContain('22.8m');
+  });
+
+  it('スプール付き: 距離と (g, ¥) が別 span（2段）', () => {
+    const html = formatUsageHtml(168000, spool, 'm');
+    expect(html).toContain('usage-dist');
+    expect(html).toContain('usage-sub');
+    expect(html).toMatch(/\(\d+g, ¥\d+\)/);
+  });
+
+  it('スプールなし: 2行目(usage-sub)は出さない', () => {
+    const html = formatUsageHtml(22800, null, 'm');
+    expect(html).not.toContain('usage-sub');
+  });
+
+  it('mm単位でもスプールの g/¥ は維持される', () => {
+    const html = formatUsageHtml(168000, spool, 'mm');
+    expect(html).toContain('168000mm');
+    expect(html).toContain('usage-sub');
+  });
+
+  it('非有限値(NaN/undefined)は --- 表示', () => {
+    // null は Number(null)=0 として 0 表示（formatFilamentAmount 既存仕様）
+    expect(formatUsageHtml(NaN, null, 'mm')).toContain('---');
+    expect(formatUsageHtml(undefined, null, 'm')).toContain('---');
+    expect(formatUsageHtml(null, null, 'm')).toContain('0');
+  });
+
+  it('単位省略時は m', () => {
+    expect(formatUsageHtml(5000)).toContain('5.0m');
+  });
+});
+
+// =============================================
+// usageHeaderLabel
+// =============================================
+describe('usageHeaderLabel', () => {
+  it('m単位ヘッダー', () => {
+    expect(usageHeaderLabel('使用量', 'm')).toBe('使用量(m)');
+    expect(usageHeaderLabel('予定量', 'm')).toBe('予定量(m)');
+  });
+  it('mm単位ヘッダー', () => {
+    expect(usageHeaderLabel('使用量', 'mm')).toBe('使用量(mm)');
+  });
+  it('単位省略時は m', () => {
+    expect(usageHeaderLabel('使用量')).toBe('使用量(m)');
+  });
+});
+
+// =============================================
+// オフライン完了印刷のフィラメント継続紐付け
+// =============================================
+describe('buildOfflineFilamentInfo', () => {
+  const spool = {
+    id: 'sp-1', serialNo: 12, name: 'PLA+ 黒', colorName: '黒',
+    filamentColor: '#000', material: 'PLA+', printCount: 5, remainingLengthMm: 100000,
+  };
+  it('現在スプールの情報を filamentInfo に写す', () => {
+    const fi = buildOfflineFilamentInfo(spool, 22800);
+    expect(fi.spoolId).toBe('sp-1');
+    expect(fi.material).toBe('PLA+');
+    expect(fi.usedMm).toBe(22800);
+    expect(fi.expectedRemain).toBe(100000);
+    expect(fi.isOfflineInferred).toBe(true);
+  });
+  it('usedMm 不正値は 0', () => {
+    expect(buildOfflineFilamentInfo(spool, undefined).usedMm).toBe(0);
+    expect(buildOfflineFilamentInfo(spool, NaN).usedMm).toBe(0);
+  });
+});
+
+describe('shouldLinkOfflineJob', () => {
+  it('★紐付けなしジョブ → 紐付け対象(true)', () => {
+    expect(shouldLinkOfflineJob({ id: 1 })).toBe(true);
+    expect(shouldLinkOfflineJob({ id: 1, filamentInfo: [] })).toBe(true);
+  });
+  it('既に filamentInfo を持つジョブは尊重(上書きしない)', () => {
+    expect(shouldLinkOfflineJob({ id: 1, filamentInfo: [{ spoolId: 'x' }] })).toBe(false);
+  });
+  it('既に filamentId を持つジョブは尊重', () => {
+    expect(shouldLinkOfflineJob({ id: 1, filamentId: 'x' })).toBe(false);
+  });
+  it('null/undefined は false', () => {
+    expect(shouldLinkOfflineJob(null)).toBe(false);
+    expect(shouldLinkOfflineJob(undefined)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## 概要
ビューモード(:5313 readonly)から操作モードへの昇格UI、使用量のm/mmトグル、オフライン完了印刷のフィラメント継続紐付け、状態パネルの残量小数1桁表示を実装。

## 変更内容

### リレー操作モード昇格/降格（ビューモード→操作モード）
- トップバーに昇格/降格トグルボタン（子クライアントのみ表示）
- 昇格: 確認ダイアログ。親でPIN設定済みなら親側で検証（子はPIN参照不可）
- 降格（閲覧専用に戻す）: ダイアログのみ
- `relay_server`: `relay-promote-request`/`relay-demote-request` 処理、`resolvePromote`
- `main.js`/`preload.js`: 昇格IPCブリッジ
- `relay_bridge`: 親側 `verifyPromotePin` で `appSettings.relayPromotePin` 照合
- 接続設定モーダルに操作昇格PIN欄（親モードのみ表示・編集）

### 使用量 m/mm 単位トグル + 2段表示
- 印刷履歴・ファイル一覧に単位トグル（右寄せ）、再読み込みアイコン（🔄、左）
- ファイル一覧に再読み込み追加（`reqGcodeFile`）
- カラム名 使用量(m)/(mm)・予定量(m)/(mm) をトグル連動
- 使用量を「距離」と「(g, ¥)」の2段右寄せ表示（`formatUsageHtml`）
- `appSettings.filamentUnit`、即時保存。DOM直接更新で全パネル即反映

### オフライン完了印刷のフィラメント継続紐付け
- 3dpmon停止中に完了した印刷へ現在装着スプールの `filamentInfo` を遡及紐付け
- `buildOfflineFilamentInfo` / `shouldLinkOfflineJob`（既存filamentInfoは尊重）
- 残量は0までクランプ（0到達後もそのまま進行）
- 二重消費ガード（`recordedJobIds`/`trackedJobIds`）は維持

### 状態パネルの残りフィラメントを小数1桁表示
- `filamentRemainingMm` の表示を `parseFloat(v).toFixed(1)` に（保存値は生精度維持）

### その他
- `.gitignore` に `*.tmp.*` / `.claude/` / `dist_build/` を追加

## テスト
- 全320件通過 + Electron 起動 3件通過 + ESLint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)