### PR TITLE
fix(connection): 同一機器へのWebSocket多重接続を防止

### DIFF
--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -795,6 +795,35 @@ export function connectWs(hostOrDest) {
   updatePrinterListUI();
   pushLog(`WS接続を試みます...(試行${state.reconnect}回目/${MAX_RECONNECT}回)`, "warn", false, host);
 
+  /* ★ 多重接続防止 (fix/ws-duplicate-connection):
+     既存ソケットが残ったまま新規接続を張ると、同一機器に対して WebSocket が
+     重複し（onmessage が多重発火して CPU を多重計上）、リークが蓄積する。
+     初回接続では connectionMap のキーが IP→ホスト名へ移行する過程で、
+     IP キーとホスト名キーの双方に生ソケットが並存し得る（updateConnectionHost
+     は newHost キーが既存の場合のみ移行するため）。特定キーの state.ws だけを
+     見ると取りこぼすので、同一 dest を指す全エントリの生ソケットを閉じる。
+     旧ソケットの onclose は handleSocketClose 経由で自動再接続を誘発するため、
+     close() 前にハンドラを全無効化し、意図的クローズと自然切断を区別する。 */
+  let _closedStale = 0;
+  for (const key of Object.keys(connectionMap)) {
+    const stOld = connectionMap[key];
+    if (!stOld || !stOld.ws || stOld.dest !== dest) continue;
+    const rs = stOld.ws.readyState;
+    if (rs === WebSocket.CONNECTING || rs === WebSocket.OPEN) {
+      try {
+        stOld.ws.onopen = stOld.ws.onmessage = stOld.ws.onerror = stOld.ws.onclose = null;
+        stOld.ws.close();
+        _closedStale++;
+      } catch (e) {
+        console.debug(`[ws] 旧ソケットのクローズに失敗 (${key}):`, e?.message);
+      }
+    }
+    stOld.ws = null;
+  }
+  if (_closedStale > 0) {
+    pushLog(`既存のWS接続(${_closedStale})を閉じてから再接続します（多重接続防止）`, "info", false, host);
+  }
+
   const protocol = location.protocol === "https:" ? "wss://" : "ws://";
   const ws = new WebSocket(protocol + dest);
   // ★ バイナリフレーム対応: K1が非UTF-8テキストフレームを送る場合にデコードエラーを防ぐ

--- a/tests/unit/dashboard_connection_ws_dedup.test.js
+++ b/tests/unit/dashboard_connection_ws_dedup.test.js
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview dashboard_connection.js connectWs の多重接続防止（fix/ws-duplicate-connection）テスト
+ *
+ * 仕様:
+ *   - 同一 dest に対して connectWs を再度呼ぶと、既存の生ソケット(CONNECTING/OPEN)を
+ *     close() してから新規ソケットを生成する（WebSocket リーク/多重 onmessage を防ぐ）。
+ *   - close() の前に旧ソケットの onopen/onmessage/onerror/onclose を無効化し、
+ *     handleSocketClose 経由の自動再接続が誘発されないようにする。
+ *   - 既存ソケットが既に CLOSED の場合は何も閉じずに新規接続する（自動再接続を壊さない）。
+ *
+ * 注: connectWs は connectionMap / reconnect カウンタをモジュールスコープに持ち、
+ *     テスト間で状態が残るため、各テストで vi.resetModules() し再 import する。
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../3dp_lib/dashboard_data.js", () => ({
+  monitorData: { appSettings: { httpPort: 80, connectionTargets: [] }, machines: {} },
+  PLACEHOLDER_HOSTNAME: "_$_NO_MACHINE_$_",
+  setNotificationSuppressed: vi.fn(), setStoredDataForHost: vi.fn(),
+  ensureMachineData: vi.fn(), markAllKeysDirty: vi.fn(), scopedById: vi.fn(),
+}));
+vi.mock("../../3dp_lib/dashboard_log_util.js", () => ({ pushLog: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_aggregator.js", () => ({
+  aggregatorUpdate: vi.fn(), restoreAggregatorState: vi.fn(),
+  restartAggregatorTimer: vi.fn(), stopAggregatorTimer: vi.fn(),
+}));
+vi.mock("../../3dp_lib/3dp_dashboard_init.js", () => ({ restorePrintResume: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_msg_handler.js", () => ({ processData: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_printmanager.js", () => ({}));
+vi.mock("../../3dp_lib/dashboard_notification_manager.js", () => ({ showAlert: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_camera_ctrl.js", () => ({
+  startCameraStream: vi.fn(), stopCameraStream: vi.fn(),
+}));
+vi.mock("../../3dp_lib/dashboard_utils.js", () => ({ getCurrentTimestamp: vi.fn(() => "t") }));
+vi.mock("../../3dp_lib/dashboard_panel_menu.js", () => ({ updatePanelMenuHosts: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_panel_factory.js", () => ({
+  migratePanelsToHost: vi.fn(), renamePanelsHost: vi.fn(), ensureHostPanels: vi.fn(),
+  removePanelsForHost: vi.fn(), updateAllPanelHeaders: vi.fn(),
+}));
+vi.mock("../../3dp_lib/dashboard_storage.js", () => ({ saveUnifiedStorage: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_ui_confirm.js", () => ({ showConfirmDialog: vi.fn() }));
+
+/** new WebSocket() を記録するフェイク実装 */
+class FakeWebSocket {
+  static CONNECTING = 0; static OPEN = 1; static CLOSING = 2; static CLOSED = 3;
+  static instances = [];
+  constructor(url) {
+    this.url = url; this.binaryType = "";
+    this.readyState = FakeWebSocket.OPEN; // 生成直後から OPEN とみなす
+    this.closeCalls = 0;
+    this.onopen = this.onmessage = this.onerror = this.onclose = null;
+    FakeWebSocket.instances.push(this);
+  }
+  close() { this.closeCalls++; this.readyState = FakeWebSocket.CLOSED; }
+  send() {}
+}
+
+let connectWs;
+beforeEach(async () => {
+  vi.resetModules();                 // connectionMap / reconnect を毎回まっさら化
+  FakeWebSocket.instances = [];
+  global.WebSocket = FakeWebSocket;
+  window.WebSocket = FakeWebSocket;
+  delete window._3dpmonRelayChild;
+  ({ connectWs } = await import("../../3dp_lib/dashboard_connection.js"));
+});
+afterEach(() => { delete window._3dpmonRelayChild; });
+
+describe("connectWs — 多重接続防止 (fix/ws-duplicate-connection)", () => {
+  it("同一destへ再接続すると旧ソケットを閉じ、ハンドラを無効化し、生存は1本だけ", () => {
+    connectWs("127.0.0.1:9999");
+    expect(FakeWebSocket.instances.length).toBe(1);
+    const first = FakeWebSocket.instances[0];
+    expect(first.closeCalls).toBe(0);
+
+    connectWs("127.0.0.1:9999"); // 再接続: 旧を閉じてから新規
+    expect(FakeWebSocket.instances.length).toBe(2);
+    expect(first.closeCalls).toBe(1);            // 旧ソケットは閉じられた
+    expect(first.onmessage).toBeNull();          // 多重 onmessage を防止
+    expect(first.onclose).toBeNull();            // 自動再接続の誘発を防止
+
+    const alive = FakeWebSocket.instances.filter(w => w.readyState !== FakeWebSocket.CLOSED);
+    expect(alive.length).toBe(1);                // 生きているのは新ソケット1本だけ
+  });
+
+  it("既存ソケットが既にCLOSEDなら追加で閉じない（自動再接続を壊さない）", () => {
+    connectWs("127.0.0.1:9999");
+    const first = FakeWebSocket.instances[0];
+    first.readyState = FakeWebSocket.CLOSED;      // 自然切断済みを模擬
+    connectWs("127.0.0.1:9999");
+    expect(first.closeCalls).toBe(0);            // CLOSED には close() を呼ばない
+    expect(FakeWebSocket.instances.length).toBe(2); // 新規接続は張られる
+  });
+});


### PR DESCRIPTION
## 概要
`connectWs` が新規 WS 生成前に旧ソケットを close していなかったため、再接続（再接続ボタン / 接続追加）のたびに同一機器への WebSocket が重複し、各ソケットの `onmessage` が多重発火 → CPU 多重計上 + ソケットリーク蓄積（最小化中 CPU 高騰の増幅要因）になっていた。

## 修正
- 新規接続前に、同一 `dest` を指す `connectionMap` 内の全生ソケット (CONNECTING/OPEN) を close。
- 初回接続で IP→ホスト名へキー移行する過程で両キーに生ソケットが並存し得るため、特定キーではなく `dest` 一致の全エントリを対象。
- close 前にハンドラを無効化し、`handleSocketClose` 経由の自動再接続誘発を防止（意図的クローズと自然切断を区別）。
- 自動再接続（自然切断後 = CLOSED）には影響なし。

## 検証
- クリーンルーム実機 (v2.2.1016, モック WS + CDP 駆動): 1接続 + 8再接続後の ESTABLISHED WS = 従来 **10本超 → 1本**（netstat 実測、サーバ側も 1）。
- 既存 **396 テスト**全 pass + 新規 `tests/unit/dashboard_connection_ws_dedup.test.js`（2件）pass。
- eslint エラー 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
