### PR TITLE
v2.2.1018: 受信生データのログ出力を既定で抑制（バックグラウンドCPU/ログ汚染の軽減）

### DIFF
--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -936,7 +936,10 @@ function handleSocketMessage(event, host) {
   let hostKey = host;
   // 1) --- 生データ "ok" はスキップ ---
   if (event.data === "ok") {
-    pushLog("受信: heart beat:" + event.data, "success", false, hostKey);
+    // ★ 生ハートビートのログは既定で抑制（毎回の "ok" でログを汚さない）。logLevel="debug" 時のみ。
+    if (monitorData.appSettings.logLevel === "debug") {
+      pushLog("受信: heart beat:" + event.data, "success", false, hostKey);
+    }
     return;
   }
 
@@ -946,8 +949,13 @@ function handleSocketMessage(event, host) {
   const tsField = tsEl?.querySelector(".value");
   if (tsField) tsField.textContent = now;
 
-// --- 3) ログ出力 (受信した JSON 生データ) ---
-  pushLog("受信: " + event.data, "normal", false, hostKey);
+// --- 3) ログ出力 (受信した JSON 生データ) — ★ 既定で抑制 (fix/bg-cpu) ---
+  //   生パケットを毎メッセージ "normal" で記録すると、(行数)×(ログパネル数) の同期DOM処理が
+  //   最小化中も throttle されずに走り CPU を浪費し、意味あるログを埋もれさせる。
+  //   logLevel="debug" 時のみ生ダンプを出力（エラー/状態変化等の意味あるログは別 pushLog で従来どおり記録）。
+  if (monitorData.appSettings.logLevel === "debug") {
+    pushLog("受信: " + event.data, "normal", false, hostKey);
+  }
 
 // --- 4) JSON パース ---
   let data;

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <!-- ★ app-version: ビルド時に scripts/sync-version.js が package.json から自動更新する -->
-  <meta name="app-version" content="2.2.1017" />
-  <title>3dpmon - 3Dプリンタ監視ダッシュボード v2.2.1017</title>
+  <meta name="app-version" content="2.2.1018" />
+  <title>3dpmon - 3Dプリンタ監視ダッシュボード v2.2.1018</title>
   <!-- サイトアイコン -->
   <link rel="icon" href="favicon.ico">
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3dpmon",
-  "version": "2.2.1017",
+  "version": "2.2.1018",
   "description": "3Dプリンタ監視ダッシュボード - Electron版",
   "main": "electron/main.js",
   "scripts": {


### PR DESCRIPTION
## 概要
WS `onmessage` で毎メッセージ実行していた生パケットダンプ `pushLog("受信: "+data)`（および `"ok"` ハートビート受信ログ）が、`(ログ行数)×(ログパネル数)` の同期DOM処理を **最小化中も throttle されずに** 走らせ、バックグラウンド CPU を浪費し、意味あるログを埋もれさせていた。

## 修正
- 生ダンプ（受信データ / ハートビート）は **`logLevel="debug"` のときのみ** 出力。既定(`info`)では抑制。
- エラー / 状態変化 / 印刷開始など **意味あるログは別の `pushLog` で従来どおり記録**。
- 併せて `v2.2.1018` に version bump（`3dp_monitor.html` の title/meta 同期済み）。

## 実測（クリーンルーム, 5機, camera OFF, #1=WS多重接続修正 適用済の上で）
| 指標 | 修正前 | 修正後 |
|---|---|---|
| logManager 蓄積 | 1000（上限張り付き） | **59** |
| DOM ログ行 | 1895 | **63** |
| 最小化中CPU | 2.7–4.8% one-core | **0.3%**（ほぼアイドル） |
| フォアグラウンド | 7.9% one-core | **5.5%** |

全 **398 テスト** pass、eslint エラー 0。

## 補足
- (3) Page Visibility ゲーティングは**不要**と判断（カメラ MJPEG は最小化時にデコードが自動停止＝CPU≈0、WS 由来の負荷は本修正で解消）。
- (4) ホスト名変更時のカメラパネル孤立（MJPEG 重複）は別タスクで対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
