### PR TITLE
v2.2.1019: 同一機器へのカメラ(MJPEG)多重接続を防止（ホスト名変更/IP再利用時）

### DIFF
--- a/3dp_lib/dashboard_camera_ctrl.js
+++ b/3dp_lib/dashboard_camera_ctrl.js
@@ -145,6 +145,7 @@ export function registerCameraPanel(hostname, img, body, toggle) {
     countdownTimer: null,
     watchdogTimer: null,
     pollTimeout: null,
+    streamTarget: null,
     _generation: 0,
     firstConnected: false,
     userStopped: false,
@@ -338,9 +339,42 @@ function _clearWatchdog(entry) {
 function _stopEntry(entry) {
   _cancelTimers(entry);
   entry.attempts = 0;
+  entry.streamTarget = null;
   if (entry.img) {
     entry.img.src = "";
     entry.img.classList.add("off");
+  }
+}
+
+/**
+ * 同一の物理カメラ (ip:port) へ既にストリーム中の「別ホスト」エントリを停止する。
+ * IP 再利用やホスト名変更で connectionMap キーが二重化した際、同一機器へ
+ * MJPEG が重複接続するのを防ぐ（最後に開始したストリームを優先＝newest wins）。
+ * 別 IP（別機器）の正規ストリームには影響しない。
+ *
+ * @private
+ * @param {CameraPanelEntry} keepEntry - 維持するエントリ（停止対象から除外）
+ * @param {string} target - "ip:port"
+ * @returns {void}
+ */
+function _stopDuplicateTargetStreams(keepEntry, target) {
+  for (const [, other] of cameraRegistry) {
+    if (other === keepEntry) continue;
+    if (other.userStopped) continue;
+    if (other.streamTarget !== target) continue;
+    _cancelTimers(other);
+    other._generation = (other._generation || 0) + 1; // 旧 async コールバックを stale 化
+    other.userStopped = true;
+    other.streamTarget = null;
+    if (other.img) {
+      other.img.src = "";
+      other.img.classList.add("off");
+    }
+    _updateUI(other, "disconnected");
+    pushLog(
+      `同一カメラ(${target})への重複接続を検出 → 旧ホスト「${other.hostname}」のストリームを停止しました`,
+      "warn", false, other.hostname
+    );
   }
 }
 
@@ -448,6 +482,12 @@ function _connectStream(entry, host) {
     /* リトライをスケジュール */
     _scheduleRetry(entry, host, delayMs, waitSec);
   };
+
+  /* ★ 多重動画接続防止 (fix/camera-dedup):
+     同一物理カメラ(ip:port)へ既にストリーム中の別ホストを停止し、1機器=1 MJPEG に収束させる。
+     IP再利用/ホスト名変更で connectionMap キーが二重化しても重複接続を防ぐ。 */
+  entry.streamTarget = `${host}:${port}`;
+  _stopDuplicateTargetStreams(entry, entry.streamTarget);
 
   /* ストリーム開始 */
   entry.img.src = url;

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <!-- ★ app-version: ビルド時に scripts/sync-version.js が package.json から自動更新する -->
-  <meta name="app-version" content="2.2.1018" />
-  <title>3dpmon - 3Dプリンタ監視ダッシュボード v2.2.1018</title>
+  <meta name="app-version" content="2.2.1019" />
+  <title>3dpmon - 3Dプリンタ監視ダッシュボード v2.2.1019</title>
   <!-- サイトアイコン -->
   <link rel="icon" href="favicon.ico">
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3dpmon",
-  "version": "2.2.1018",
+  "version": "2.2.1019",
   "description": "3Dプリンタ監視ダッシュボード - Electron版",
   "main": "electron/main.js",
   "scripts": {

--- a/tests/unit/dashboard_camera_ctrl_dedup.test.js
+++ b/tests/unit/dashboard_camera_ctrl_dedup.test.js
@@ -1,0 +1,95 @@
+/**
+ * @fileoverview dashboard_camera_ctrl.js 多重動画接続防止 (fix/camera-dedup) のユニットテスト
+ *
+ * 仕様:
+ *   - 同一の物理カメラ (ip:port) へストリームを開始すると、既に同じ ip:port を
+ *     ストリーム中の「別ホスト」エントリは停止される（最後に開始した方が優先＝newest wins）。
+ *     → IP 再利用 / ホスト名変更で connectionMap キーが二重化しても 1機器=1 MJPEG に収束。
+ *   - 別 IP（別機器）への正規ストリームには影響しない。
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockMonitorData = {
+  appSettings: { connectionTargets: [], cameraPort: 8080, cameraToggle: true },
+  hostCameraToggle: {},
+  machines: {}
+};
+vi.doMock("../../3dp_lib/dashboard_data.js", () => ({
+  monitorData: mockMonitorData,
+  PLACEHOLDER_HOSTNAME: "_$_NO_MACHINE_$_"
+}));
+vi.doMock("../../3dp_lib/dashboard_log_util.js", () => ({ pushLog: vi.fn() }));
+vi.doMock("../../3dp_lib/dashboard_notification_manager.js", () => ({
+  notificationManager: { notify: vi.fn() }, showAlert: vi.fn()
+}));
+// dup-A と dup-B は同一IP(=同一物理カメラ)、other は別IP
+vi.doMock("../../3dp_lib/dashboard_connection.js", () => ({
+  getDeviceIp: vi.fn((h) => ({ "dup-A": "192.168.1.50", "dup-B": "192.168.1.50", "other": "192.168.1.99" }[h] || "")),
+  getDeviceDest: vi.fn((h) => ({ "dup-A": "192.168.1.50:9999", "dup-B": "192.168.1.50:9999", "other": "192.168.1.99:9999" }[h] || ""))
+}));
+global.fetch = vi.fn(() => Promise.resolve({ ok: true }));
+
+const { registerCameraPanel, unregisterCameraPanel, startCameraStream, stopCameraStream } =
+  await import("../../3dp_lib/dashboard_camera_ctrl.js");
+
+function mkImg() { return document.createElement("img"); }
+function mkBody() { const d = document.createElement("div"); return d; }
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockMonitorData.hostCameraToggle = { "dup-A": true, "dup-B": true, "other": true };
+});
+afterEach(() => {
+  vi.useRealTimers(); vi.clearAllMocks();
+  unregisterCameraPanel("dup-A"); unregisterCameraPanel("dup-B"); unregisterCameraPanel("other");
+});
+
+describe("カメラ多重接続防止 (fix/camera-dedup)", () => {
+  it("同一IPの別ホストへストリーム開始すると旧ホストのストリームは停止される(newest wins)", () => {
+    const imgA = mkImg(), imgB = mkImg(), body = mkBody();
+    registerCameraPanel("dup-A", imgA, body, null);
+    registerCameraPanel("dup-B", imgB, body, null);
+
+    startCameraStream("dup-A");
+    expect(imgA.src).toMatch(/192\.168\.1\.50:8080/);   // A がストリーム中
+    expect(imgA.classList.contains("off")).toBe(false);
+
+    startCameraStream("dup-B");                          // 同一IPでBを開始
+    expect(imgB.src).toMatch(/192\.168\.1\.50:8080/);   // B がストリーム中
+    expect(imgB.classList.contains("off")).toBe(false);
+    // A は重複として停止（src クリア + off）
+    expect(imgA.classList.contains("off")).toBe(true);
+    expect(/action=stream/.test(imgA.src)).toBe(false);
+  });
+
+  it("別IP(別機器)のストリームには影響しない", () => {
+    const imgA = mkImg(), imgO = mkImg(), body = mkBody();
+    registerCameraPanel("dup-A", imgA, body, null);
+    registerCameraPanel("other", imgO, body, null);
+
+    startCameraStream("dup-A");
+    startCameraStream("other");
+
+    // 異なるIPなので両方ストリーム中
+    expect(imgA.src).toMatch(/192\.168\.1\.50:8080/);
+    expect(imgO.src).toMatch(/192\.168\.1\.99:8080/);
+    expect(imgA.classList.contains("off")).toBe(false);
+    expect(imgO.classList.contains("off")).toBe(false);
+  });
+
+  it("停止した重複ストリームはリトライしない(userStopped)", () => {
+    const imgA = mkImg(), imgB = mkImg(), body = mkBody();
+    registerCameraPanel("dup-A", imgA, body, null);
+    registerCameraPanel("dup-B", imgB, body, null);
+    startCameraStream("dup-A");
+    startCameraStream("dup-B");   // A を停止
+
+    const before = vi.getTimerCount();
+    vi.advanceTimersByTime(30_000); // A の watchdog/retry が動かないこと（停止済み）
+    // 例外なく、Aのstreamは復活しない（off のまま）
+    expect(imgA.classList.contains("off")).toBe(true);
+    expect(before).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## 概要
ホスト名変更 / IP 再利用で `connectionMap` キーが二重化すると、同一の物理カメラ (ip:port) へ複数のホストエントリが MJPEG ストリームを張り、**1 機器に対し動画接続が重複**することがあった（PR #367 が WebSocket 多重接続を、本 PR がカメラ MJPEG 多重接続を解消）。

## 修正
- カメラ層に **dest(`ip:port`) ベースの重複排除**を追加（`dashboard_camera_ctrl.js`）。ストリーム開始時に、同一 `ip:port` を既にストリーム中の「別ホスト」エントリを停止し、**1 機器 = 1 MJPEG** に収束させる（最後に開始したストリームを優先＝newest wins）。
- 別 IP（別機器）の正規ストリームには不干渉。停止された重複ストリームは `userStopped` でリトライしない。
- `v2.2.1019` に bump（`3dp_monitor.html` の title/meta 同期済み）。

## テスト
- 新規 `tests/unit/dashboard_camera_ctrl_dedup.test.js`（同一IP→旧停止 / 別IP→不干渉 / 停止後リトライなし）3 件。
- 既存カメラ 12 件含む **全 401 テスト pass**、eslint エラー 0。
- クリーンルーム実機で通常の単機カメラが **1 接続**で正常動作（回帰チェック, mjpeg=1）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
