### PR TITLE
chore(build): package-lock の version ドリフトを根本修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "3dpmon",
-  "version": "2.2.003",
+  "version": "2.2.1020",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "3dpmon",
-      "version": "2.2.003",
+      "version": "2.2.1020",
       "license": "BSD-3-Clause",
       "dependencies": {
         "gridstack": "^10.3.1",

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -56,4 +56,25 @@ for (const t of targets) {
   console.log(`[sync-version] 更新: ${t.file} (${t.label}) → ${VERSION}`);
 }
 
+// ─── package-lock.json: ルート version を同期（バージョンドリフト再発防止） ───
+// lockfileVersion 3 では先頭2件の "version"（ルート と packages[""]）のみがパッケージ
+// 本体のバージョン。依存パッケージの version を壊さぬよう、先頭2件に限定して置換する。
+// （従来 sync-version は package-lock を対象外としており、リリースのたびに lock の
+//   version だけ取り残されてドリフトしていた。本処理で恒久的に同期する。）
+const lockFile = path.join(ROOT, "package-lock.json");
+if (fs.existsSync(lockFile)) {
+  const orig = fs.readFileSync(lockFile, "utf-8");
+  let n = 0;
+  const next = orig.replace(/"version": "[^"]*"/g, (m) => (n++ < 2 ? `"version": "${VERSION}"` : m));
+  if (next !== orig) {
+    fs.writeFileSync(lockFile, next, "utf-8");
+    updated++;
+    console.log(`[sync-version] 更新: package-lock.json (root version) → ${VERSION}`);
+  } else {
+    console.log(`[sync-version] 変更なし: package-lock.json (root version)`);
+  }
+} else {
+  console.warn(`[sync-version] スキップ: package-lock.json (見つかりません)`);
+}
+
 console.log(`[sync-version] 完了: ${updated} ファイル更新`);


### PR DESCRIPTION
## 概要
`sync-version.js` が `package-lock.json` を同期対象外としていたため、リリースのたびに lock のルート `version` だけ取り残され **`2.2.003`** で長期固着していた（依存ツリー自体は正常）。本 PR で恒久同期する。

## 変更
- `scripts/sync-version.js`: lockfileVersion 3 の先頭2件の `"version"`（ルート / `packages[""]`）のみを限定置換する処理を追加（依存パッケージの version は不変）。
- `package-lock.json`: `2.2.003` → `2.2.1020` に同期（差分は version 2行のみ）。

## 効果
今後 `npm run prebuild`（=リリース時）に package-lock の version も自動同期され、ドリフトが再発しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)