### PR TITLE
chore(build): package-lock version ドリフト根本修正を main へ同期

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "3dpmon",
-  "version": "2.2.003",
+  "version": "2.2.1020",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "3dpmon",
-      "version": "2.2.003",
+      "version": "2.2.1020",
       "license": "BSD-3-Clause",
       "dependencies": {
         "gridstack": "^10.3.1",

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -56,4 +56,25 @@ for (const t of targets) {
   console.log(`[sync-version] 更新: ${t.file} (${t.label}) → ${VERSION}`);
 }
 
+// ─── package-lock.json: ルート version を同期（バージョンドリフト再発防止） ───
+// lockfileVersion 3 では先頭2件の "version"（ルート と packages[""]）のみがパッケージ
+// 本体のバージョン。依存パッケージの version を壊さぬよう、先頭2件に限定して置換する。
+// （従来 sync-version は package-lock を対象外としており、リリースのたびに lock の
+//   version だけ取り残されてドリフトしていた。本処理で恒久的に同期する。）
+const lockFile = path.join(ROOT, "package-lock.json");
+if (fs.existsSync(lockFile)) {
+  const orig = fs.readFileSync(lockFile, "utf-8");
+  let n = 0;
+  const next = orig.replace(/"version": "[^"]*"/g, (m) => (n++ < 2 ? `"version": "${VERSION}"` : m));
+  if (next !== orig) {
+    fs.writeFileSync(lockFile, next, "utf-8");
+    updated++;
+    console.log(`[sync-version] 更新: package-lock.json (root version) → ${VERSION}`);
+  } else {
+    console.log(`[sync-version] 変更なし: package-lock.json (root version)`);
+  }
+} else {
+  console.warn(`[sync-version] スキップ: package-lock.json (見つかりません)`);
+}
+
 console.log(`[sync-version] 完了: ${updated} ファイル更新`);


### PR DESCRIPTION
## 概要
`chore/sync-lock-version`（PR #372）を `main` へ反映。`sync-version.js` の package-lock 同期対応 ＋ lock version の 2.2.003→2.2.1020 同期。

🤖 Generated with [Claude Code](https://claude.com/claude-code)