### PR TITLE
v2.2.1021: 外部連携UI + ItemKeeper連携(印刷履歴プッシュ) + 汎用Webhook独立化

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -47,6 +47,7 @@ import { addSpoolFromPreset, getCurrentSpool, getCurrentSpoolId, setCurrentSpool
 import { FILAMENT_PRESETS } from "./dashboard_filament_presets.js";
 import { notificationManager } from "./dashboard_notification_manager.js";
 import { showAlert } from "./dashboard_notification_manager.js";
+import { itemKeeperIntegration } from "./dashboard_integration_itemkeeper.js";
 import {
   persistAggregatorState,
   stopAggregatorTimer,
@@ -70,6 +71,8 @@ export async function initializeDashboard() {
   // ★ v2.2.0: cleanupLegacy は削除済み。v2.1.017 で最終掃除完了。
   // 読み込んだストレージ内容を通知マネージャへ反映
   notificationManager.loadSettings();
+  // ItemKeeper / 外部連携 設定を反映
+  itemKeeperIntegration.loadSettings();
   if (!monitorData.filamentSpools.length) {
     const preset = FILAMENT_PRESETS.find(
       p => p.presetId === "preset-unknown-somename-somecolor"

--- a/3dp_lib/3dp_dashboard_main.js
+++ b/3dp_lib/3dp_dashboard_main.js
@@ -29,6 +29,7 @@
 import { initializeDashboard } from "./3dp_dashboard_init.js";
 import { audioManager } from "./dashboard_audio_manager.js";
 import { notificationManager } from "./dashboard_notification_manager.js";
+import { itemKeeperIntegration } from "./dashboard_integration_itemkeeper.js";
 
 import { initStorageUI } from "./dashboard_storage_ui.js";
 import { bootPanelSystem } from "./dashboard_panel_boot.js";
@@ -46,6 +47,7 @@ window.addEventListener("unhandledrejection", evt => {
 // ——— デバッグ用グローバル参照 ———
 window.audioManager = audioManager;
 window.notificationManager = notificationManager;
+window.itemKeeperIntegration = itemKeeperIntegration;
 
 /**
  * ページ読み込み完了後のエントリポイント。

--- a/3dp_lib/dashboard_integration_itemkeeper.js
+++ b/3dp_lib/dashboard_integration_itemkeeper.js
@@ -1,0 +1,731 @@
+/**
+ * @fileoverview 外部連携 / ItemKeeper (ik2) 連携モジュール
+ *
+ * 3dpmon が保持する印刷履歴を、印刷開始・完了/失敗時に ItemKeeper の受け口へ
+ * Bearer 認証つき HTTP POST で送信する（製造実績の取り込み）。
+ * 汎用通知 Webhook（dashboard_notification_manager.js）とは別チャネル。
+ *
+ * 仕様: docs/develop/itemkeeper-integration-specification.md（Phase1 / 第一弾 MVP）
+ *  - 認証: Authorization: Bearer {clientId}.{secret}
+ *  - ペイロード: 全件スナップショット（機器ごとの配列）, schema "3dpmon.ik.history.v1"
+ *  - 冪等: 受信側がレコード単位(deviceKey + jobId)で重複排除
+ *  - encoding は Phase1 では "none" 固定（aes-256-gcm は受信側 Phase4+ 予約）
+ *  - 第一弾 MVP: 簡易インメモリ再送。IndexedDB 恒久アウトボックスは第二段で追加。
+ *
+ * また、本モジュールは接続設定モーダルの「🔌 外部連携」サブモーダル全体
+ * （汎用Webhook節 ＋ ItemKeeper節 ＋ 対象機器テーブル）を構築する。
+ * 編集はトランザクション方式（開いた時点の保存値から再構築、保存して戻る/破棄キャンセル）。
+ *
+ * @author pumpCurry
+ * @license BSD-3-Clause
+ */
+
+"use strict";
+
+/* グローバル（ブラウザ/Electron レンダラ・Node18+ ランタイム）: 認証ノンス・gzip 圧縮で使用 */
+/* global crypto, CompressionStream, Response */
+
+import { monitorData } from "./dashboard_data.js";
+import { saveUnifiedStorage } from "./dashboard_storage.js";
+import { getSpoolById, getMaterialDensity, weightFromLength } from "./dashboard_spool.js";
+import { attributedUsed, deriveSpoolRemaining } from "./dashboard_filament_ledger.js";
+import { notificationManager } from "./dashboard_notification_manager.js";
+
+/** ペイロードスキーマ識別子 */
+const IK_SCHEMA = "3dpmon.ik.history.v1";
+/** ItemKeeper 既定の受け口パス */
+const IK_DEFAULT_PATH = "/api/ingest/print-events";
+/** 設定の保存キー（monitorData.appSettings 直下） */
+const SETTINGS_KEY = "itemkeeper";
+/** インメモリ再送の最大試行回数（MVP。恒久アウトボックスは第二段） */
+const MAX_RETRY = 3;
+
+/** 既定設定 */
+const DEFAULTS = Object.freeze({
+  enabled: false,
+  endpoint: "",
+  clientId: "",
+  secret: "",
+  encoding: "none",      // Phase1 固定
+  onStart: true,
+  onFinish: true,
+  historyScope: "all"    // "all" | "recent:{n}"
+});
+
+/** 属性値エスケープ */
+function escAttr(s) {
+  return String(s ?? "")
+    .replace(/&/g, "&amp;").replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+/** テキストエスケープ */
+function escHtml(s) {
+  return String(s ?? "")
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+/**
+ * 外部連携 / ItemKeeper 連携マネージャ。
+ * シングルトン `itemKeeperIntegration` として export する。
+ */
+export class ItemKeeperIntegration {
+  constructor() {
+    /** @type {{enabled:boolean,endpoint:string,clientId:string,secret:string,encoding:string,onStart:boolean,onFinish:boolean,historyScope:string}} */
+    this.settings = { ...DEFAULTS };
+  }
+
+  // ───────────────────────────── 設定 load/save ─────────────────────────────
+
+  /**
+   * 永続化済みの ItemKeeper 設定を読み込む。
+   * @returns {void}
+   */
+  loadSettings() {
+    const saved = monitorData.appSettings[SETTINGS_KEY];
+    this.settings = { ...DEFAULTS, ...(saved && typeof saved === "object" ? saved : {}) };
+    this.settings.encoding = "none"; // Phase1 は none 固定
+  }
+
+  /**
+   * 現在の設定を永続化する（即時フラッシュ）。
+   * @returns {void}
+   */
+  persist() {
+    monitorData.appSettings[SETTINGS_KEY] = { ...this.settings };
+    saveUnifiedStorage(true);
+  }
+
+  // ───────────────────────────── ペイロード組立 ─────────────────────────────
+
+  /**
+   * 「接続先:ポート」や末尾欠落を完全 URL に正規化する。
+   * 例: "itemkeeper.com" → "https://itemkeeper.com/api/ingest/print-events"
+   * パスが指定済みならそれを尊重する。
+   *
+   * @param {string} input - 入力文字列
+   * @returns {string} 正規化済み URL（空入力なら ""）
+   */
+  normalizeEndpoint(input) {
+    let v = String(input ?? "").trim();
+    if (!v) return "";
+    if (!/^https?:\/\//i.test(v)) v = "https://" + v;
+    try {
+      const u = new URL(v);
+      if (!u.pathname || u.pathname === "/") u.pathname = IK_DEFAULT_PATH;
+      return u.toString();
+    } catch {
+      return v;
+    }
+  }
+
+  /**
+   * historyScope に従って履歴ジョブを選別する。
+   * @private
+   * @param {Array<object>} history - printStore.history
+   * @param {string} [scopeOverride] - "all" / "recent:{n}" の上書き
+   * @returns {Array<object>} 選別後のジョブ配列
+   */
+  _selectJobs(history, scopeOverride) {
+    const scope = scopeOverride || this.settings.historyScope || "all";
+    if (scope === "all") return history;
+    const m = /^recent:(\d+)$/.exec(scope);
+    if (m) {
+      const n = parseInt(m[1], 10);
+      return [...history].sort((a, b) => (Number(b?.id) || 0) - (Number(a?.id) || 0)).slice(0, n);
+    }
+    return history;
+  }
+
+  /**
+   * 1 件の履歴レコード（filamentInfo[]）から filaments[] を組み立てる。
+   * 真値は usedMm（mm）。usedGram は密度からの派生。spoolRemainMm は参考値。
+   *
+   * @param {object} job - printStore.history のレコード
+   * @returns {Array<object>} filaments[]
+   */
+  buildFilaments(job) {
+    const out = [];
+    const fi = Array.isArray(job?.filamentInfo) ? job.filamentInfo : [];
+    if (fi.length > 0) {
+      for (const f of fi) {
+        const spool = f?.spoolId ? getSpoolById(f.spoolId) : null;
+        const usedMm = (f?.usedMm != null) ? Number(f.usedMm) : Number(attributedUsed(job, f?.spoolId) || 0);
+        out.push(this._filamentEntry(f || {}, spool, usedMm, job));
+      }
+    } else {
+      // filamentInfo 欠落の旧ジョブ: 単一スプール扱いでフォールバック
+      const spoolId = job?.filamentId || null;
+      const spool = spoolId ? getSpoolById(spoolId) : null;
+      const usedMm = Number(job?.materialUsedMm || 0);
+      if (spoolId || usedMm > 0) {
+        out.push(this._filamentEntry(
+          { spoolId, material: job?.filamentType, filamentColor: job?.filamentColor },
+          spool, usedMm, job
+        ));
+      }
+    }
+    return out;
+  }
+
+  /**
+   * filaments[] の 1 要素を生成する（スプール台帳で補完）。
+   * @private
+   */
+  _filamentEntry(f, spool, usedMm, job) {
+    const material = spool?.material || spool?.materialName || f.material || job?.filamentType || "";
+    const colorHex = spool?.filamentColor || f.filamentColor || job?.filamentColor || "";
+    const diameterMm = Number(spool?.filamentDiameter || 1.75);
+    const density = Number(spool?.density || getMaterialDensity(material) || 1.24);
+    const usedGram = (usedMm > 0)
+      ? Math.round(weightFromLength(usedMm, density, diameterMm) * 100) / 100
+      : 0;
+    let spoolRemainMm = null;
+    if (f.expectedRemain != null) {
+      spoolRemainMm = Number(f.expectedRemain);
+    } else if (f.spoolId) {
+      try { spoolRemainMm = deriveSpoolRemaining(f.spoolId)?.remainingMm ?? null; } catch { /* noop */ }
+    }
+    return {
+      spoolId: f.spoolId || spool?.id || "",
+      serialNo: (f.serialNo != null) ? f.serialNo : (spool?.serialNo ?? null),
+      material,
+      colorName: f.colorName || spool?.colorName || "",
+      colorHex,
+      brand: spool?.brand || spool?.manufacturerName || "",
+      diameterMm,
+      density,
+      usedMm: Number(usedMm) || 0,
+      usedGram,
+      spoolRemainMm
+    };
+  }
+
+  /**
+   * 履歴レコードを §4.2 のジョブ形式へ変換する。
+   * @param {object} job - printStore.history のレコード
+   * @returns {object|null}
+   */
+  buildJob(job) {
+    if (!job || job.id == null) return null;
+    const startMs = job.startTime ? Date.parse(job.startTime)
+      : (job.startTimeSec ? Number(job.startTimeSec) * 1000 : NaN);
+    const finishMs = job.finishTime ? Date.parse(job.finishTime) : NaN;
+    const durationSec = (Number.isFinite(finishMs) && Number.isFinite(startMs) && finishMs > startMs)
+      ? Math.round((finishMs - startMs) / 1000) : null;
+    const state = job.finishTime ? "finished" : "printing";
+    const pf = job.printfinish;
+    const result = (state === "finished")
+      ? (pf === 1 ? "success" : (pf === 0 ? "failed" : null))
+      : null;
+    const filename = job.filename
+      || (job.rawFilename ? String(job.rawFilename).split(/[\\/]/).pop() : "");
+    return {
+      jobId: Number(job.id),
+      filename,
+      rawFilename: job.rawFilename || job.filename || "",
+      filemd5: job.filemd5 || "",
+      startTime: job.startTime || (Number.isFinite(startMs) ? new Date(startMs).toISOString() : null),
+      finishTime: job.finishTime || null,
+      durationSec,
+      state,
+      result,
+      printfinish: (pf === 1 || pf === 0) ? pf : null,
+      materialUsedMm: Number(job.materialUsedMm || 0),
+      filaments: this.buildFilaments(job)
+    };
+  }
+
+  /**
+   * 全機器スナップショット（§4.1 エンベロープ）を組み立てる。
+   *
+   * @param {string} triggerEvent - "print.started" | "print.finished" | "ingest.test" 等
+   * @param {string} [triggerHost] - トリガ元ホスト名（trigger.deviceKey/jobId に使用）
+   * @param {string} [scopeOverride] - historyScope の上書き（413 縮小再送用）
+   * @returns {{schema:string,sentAt:string,trigger:object,devices:Array<object>}}
+   */
+  buildSnapshot(triggerEvent, triggerHost, scopeOverride) {
+    const targets = (monitorData.appSettings.connectionTargets || [])
+      .filter(t => t && t.ikEnabled !== false); // 既定 ON、明示 false のみ除外
+    const devices = [];
+    let triggerDeviceKey = "";
+    let triggerJobId = null;
+
+    for (const t of targets) {
+      const host = t.hostname || "";
+      const machine = host ? monitorData.machines[host] : null;
+      const history = machine?.printStore?.history || [];
+      const jobs = this._selectJobs(history, scopeOverride).map(j => this.buildJob(j)).filter(Boolean);
+      const deviceKey = t.ikDeviceAlias || t.label || host || t.dest;
+      if (!deviceKey) continue;
+      devices.push({
+        deviceKey,
+        device: {
+          alias: t.ikDeviceAlias || t.label || host || "",
+          hostname: host,
+          ip: String(t.dest || "").split(":")[0] || "",
+          mac: t.macAddress || "",
+          model: machine?.storedData?.model?.rawValue || ""
+        },
+        jobs
+      });
+      if (host && host === triggerHost) {
+        triggerDeviceKey = deviceKey;
+        const cur = machine?.printStore?.current;
+        triggerJobId = (cur?.id != null) ? Number(cur.id)
+          : (jobs.length ? Math.max(...jobs.map(j => j.jobId)) : null);
+      }
+    }
+
+    const trigger = { event: triggerEvent || "" };
+    if (triggerDeviceKey) trigger.deviceKey = triggerDeviceKey;
+    if (triggerJobId != null) trigger.jobId = triggerJobId;
+
+    return { schema: IK_SCHEMA, sentAt: new Date().toISOString(), trigger, devices };
+  }
+
+  // ───────────────────────────── HTTP 送信 ─────────────────────────────
+
+  /** @private ランダム UUID（フォールバックあり） */
+  _uuid() {
+    try {
+      if (typeof crypto !== "undefined" && crypto.randomUUID) return crypto.randomUUID();
+    } catch { /* noop */ }
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, c => {
+      const r = (Math.random() * 16) | 0;
+      const v = c === "x" ? r : ((r & 0x3) | 0x8);
+      return v.toString(16);
+    });
+  }
+
+  /**
+   * §5 のリクエストヘッダを構築する（Bearer・X-IK-*）。
+   * @private
+   * @param {string} trigger - X-IK-Trigger 値
+   * @returns {Record<string,string>}
+   */
+  buildHeaders(trigger) {
+    const s = this.settings;
+    return {
+      "Authorization": `Bearer ${s.clientId}.${s.secret}`,
+      "Content-Type": "application/json",
+      "X-IK-Trigger": trigger,
+      "X-IK-Timestamp": String(Date.now()),
+      "X-IK-Nonce": this._uuid(),
+      "X-IK-Request-Id": this._uuid(),
+      "X-IK-Encoding": "none"
+    };
+  }
+
+  /**
+   * gzip 圧縮を試みる（CompressionStream 非対応環境は無圧縮にフォールバック）。
+   * @private
+   * @param {string} jsonStr
+   * @returns {Promise<{body:(ArrayBuffer|string), gzipped:boolean}>}
+   */
+  async _maybeGzip(jsonStr) {
+    try {
+      if (typeof CompressionStream === "function" && typeof Response === "function") {
+        const cs = new CompressionStream("gzip");
+        const stream = new Response(jsonStr).body.pipeThrough(cs);
+        const buf = await new Response(stream).arrayBuffer();
+        return { body: buf, gzipped: true };
+      }
+    } catch { /* fallback */ }
+    return { body: jsonStr, gzipped: false };
+  }
+
+  /**
+   * スナップショットを送信する（簡易再送つき）。fire-and-forget 用途。
+   *
+   * @param {{trigger:string, host?:string}} opts
+   * @returns {Promise<{ok:boolean,status?:number,error?:string,skipped?:boolean}>}
+   */
+  async sendSnapshot({ trigger, host } = {}) {
+    const s = this.settings;
+    if (!s.enabled) return { ok: false, skipped: true };
+    const endpoint = this.normalizeEndpoint(s.endpoint);
+    if (!endpoint || !s.clientId || !s.secret) return { ok: false, skipped: true };
+    const event = trigger || "";
+    const snap = this.buildSnapshot(event, host);
+    if (!snap.devices.length) return { ok: false, skipped: true };
+    return this._post(endpoint, event, snap, { host, retriesLeft: MAX_RETRY });
+  }
+
+  /**
+   * 実際の POST とレスポンス分岐・再送（§7）。
+   * @private
+   */
+  async _post(endpoint, trigger, payloadObj, opts = {}) {
+    const retriesLeft = opts.retriesLeft ?? 0;
+    const json = JSON.stringify(payloadObj);
+    const headers = this.buildHeaders(trigger);
+    let body = json;
+    const g = await this._maybeGzip(json);
+    if (g.gzipped) { body = g.body; headers["Content-Encoding"] = "gzip"; }
+
+    let res;
+    try {
+      res = await fetch(endpoint, { method: "POST", headers, body });
+    } catch (e) {
+      if (retriesLeft > 0) return this._retry(endpoint, trigger, payloadObj, opts, `network: ${e.message}`);
+      console.warn("[itemkeeper] network error:", e.message);
+      this._lastError = `ネットワークエラー: ${e.message}`;
+      return { ok: false, error: "network" };
+    }
+
+    if (res.ok) { this._lastError = null; return { ok: true, status: res.status }; }
+    const status = res.status;
+    if (status === 401 || status === 403) {
+      this._lastError = `ItemKeeper 認証エラー (${status})`;
+      console.warn("[itemkeeper]", this._lastError);
+      return { ok: false, status };
+    }
+    if (status === 400) {
+      this._lastError = "スキーマ不正 (400)";
+      console.warn("[itemkeeper]", this._lastError);
+      return { ok: false, status };
+    }
+    if (status === 413 && !opts._shrunk) {
+      // サイズ超過 → historyScope を縮小して 1 回だけ再送
+      const shrunk = this.buildSnapshot(trigger, opts.host, "recent:50");
+      return this._post(endpoint, trigger, shrunk, { ...opts, _shrunk: true, retriesLeft: 0 });
+    }
+    if ((status === 429 || status >= 500) && retriesLeft > 0) {
+      return this._retry(endpoint, trigger, payloadObj, opts, `HTTP ${status}`);
+    }
+    this._lastError = `HTTP ${status}`;
+    console.warn("[itemkeeper]", this._lastError);
+    return { ok: false, status };
+  }
+
+  /** @private 簡易バックオフ再送（インメモリ） */
+  _retry(endpoint, trigger, payloadObj, opts, reason) {
+    const retriesLeft = (opts.retriesLeft ?? 0) - 1;
+    const attempt = MAX_RETRY - retriesLeft;
+    console.warn(`[itemkeeper] retry #${attempt} (${reason})`);
+    const delay = 1500 * attempt; // 1.5s, 3s, 4.5s …
+    return new Promise(resolve => setTimeout(() => {
+      resolve(this._post(endpoint, trigger, payloadObj, { ...opts, retriesLeft }));
+    }, delay));
+  }
+
+  /**
+   * 連携テスト送信（X-IK-Trigger: ingest.test、本文 devices:[]）。
+   * 下書き（モーダルの現在値）でテストできるよう設定を引数で受け取る。
+   *
+   * @param {{endpoint:string,clientId:string,secret:string}} cfg
+   * @param {(ok:boolean, msg:string)=>void} [onResult]
+   * @returns {Promise<void>}
+   */
+  async testConnection(cfg, onResult) {
+    const endpoint = this.normalizeEndpoint(cfg?.endpoint);
+    if (!endpoint) { onResult?.(false, "接続先URLが未設定です"); return; }
+    if (!cfg.clientId || !cfg.secret) { onResult?.(false, "クライアントID/暗号キーが未設定です"); return; }
+    const payload = {
+      schema: IK_SCHEMA, sentAt: new Date().toISOString(),
+      trigger: { event: "ingest.test" }, devices: []
+    };
+    const headers = {
+      "Authorization": `Bearer ${cfg.clientId}.${cfg.secret}`,
+      "Content-Type": "application/json",
+      "X-IK-Trigger": "ingest.test",
+      "X-IK-Timestamp": String(Date.now()),
+      "X-IK-Nonce": this._uuid(),
+      "X-IK-Request-Id": this._uuid(),
+      "X-IK-Encoding": "none"
+    };
+    try {
+      const res = await fetch(endpoint, { method: "POST", headers, body: JSON.stringify(payload) });
+      if (res.ok) onResult?.(true, `OK (${res.status})`);
+      else if (res.status === 401 || res.status === 403) onResult?.(false, `認証エラー (${res.status})`);
+      else onResult?.(false, `HTTP ${res.status}`);
+    } catch (e) {
+      onResult?.(false, e.message);
+    }
+  }
+
+  /**
+   * 汎用Webhook の下書き URL 群へテスト送信する（保存前の値でテスト可能）。
+   * @param {string[]} urls
+   * @param {(url:string, ok:boolean, msg:(string|null))=>void} [onResult]
+   * @returns {Promise<void>}
+   */
+  async testWebhookUrls(urls, onResult) {
+    const list = (urls || []).filter(u => u);
+    if (!list.length) { onResult?.("", false, "URL が設定されていません"); return; }
+    const now = new Date();
+    const payload = {
+      text: "3dpmon Webhook テスト送信", event: "webhookTest", hostname: "3dpmon",
+      timestamp: now.toISOString(), timestamp_epoch: now.getTime(),
+      timestamp_local: now.toLocaleString(), timezone_offset_min: now.getTimezoneOffset(),
+      data: { message: "この通知はテスト送信です" }
+    };
+    const json = JSON.stringify(payload);
+    for (const url of list) {
+      try {
+        const res = await fetch(url, { method: "POST", headers: { "Content-Type": "application/json" }, body: json });
+        onResult?.(url, res.ok, res.ok ? null : `HTTP ${res.status}`);
+      } catch (e) {
+        onResult?.(url, false, e.message);
+      }
+    }
+  }
+
+  // ───────────────────────────── 印刷イベントフック ─────────────────────────────
+
+  /**
+   * 印刷イベント発火時に呼ばれ、条件を満たせばスナップショットを送る。
+   * dashboard_msg_handler.js のトリガ箇所から呼び出す。
+   *
+   * @param {string} host - イベント発生ホスト名
+   * @param {"started"|"finished"} kind - イベント種別
+   * @returns {void}
+   */
+  onPrintEvent(host, kind) {
+    const s = this.settings;
+    if (!s.enabled) return;
+    if (kind === "started" && !s.onStart) return;
+    if (kind === "finished" && !s.onFinish) return;
+    const t = (monitorData.appSettings.connectionTargets || [])
+      .find(x => x && (x.hostname === host || x.dest === host));
+    if (t && t.ikEnabled === false) return; // この機器は連携対象外
+    const trigger = kind === "started" ? "print.started" : "print.finished";
+    this.sendSnapshot({ trigger, host })
+      .catch(e => console.warn("[itemkeeper] sendSnapshot failed:", e?.message || e));
+  }
+
+  // ───────────────────────────── モーダル UI ─────────────────────────────
+
+  /**
+   * 外部連携モーダルの本体を構築する（汎用Webhook節＋ItemKeeper節＋対象機器テーブル）。
+   * トランザクション編集: 開いた時点の保存値からフォームを再構築し、
+   * 「保存して戻る」で確定、それ以外（キャンセル/×/枠外/Esc）は破棄。
+   *
+   * @param {HTMLElement} container - #external-modal-body 等の差し込み先
+   * @returns {void}
+   */
+  initModalUI(container) {
+    if (!container) return;
+    const s = this.settings;
+    const urls = (notificationManager.getWebhookUrls?.() || []).join(",");
+    const whIndep = !!notificationManager.getWebhookIndependent?.();
+    const snapEnabled = !!notificationManager.statusSnapshotEnabled;
+    const snapInterval = Number(notificationManager.statusSnapshotIntervalSec || 30);
+    const targets = monitorData.appSettings.connectionTargets || [];
+
+    const deviceRows = targets.map(t => {
+      const dest = escAttr(t.dest || "");
+      const name = escHtml(t.label || t.hostname || t.dest || "(未解決)");
+      const alias = escAttr(t.ikDeviceAlias || "");
+      const ikEnabled = t.ikEnabled !== false;
+      return `<tr>
+        <td style="padding:2px 6px;white-space:nowrap;">${name}</td>
+        <td style="padding:2px 6px;"><input type="text" data-ik-alias="${dest}" value="${alias}"
+            placeholder="${escAttr(t.hostname || "")}" style="width:10em;font-size:12px;padding:2px 4px;border:1px solid #ccc;border-radius:3px;"></td>
+        <td style="padding:2px 6px;text-align:center;"><input type="checkbox" data-ik-enabled="${dest}" ${ikEnabled ? "checked" : ""}></td>
+      </tr>`;
+    }).join("");
+
+    container.innerHTML = `
+      <div style="padding:14px 16px;font-size:13px;display:flex;flex-direction:column;gap:16px;">
+
+        <!-- ===== §A 汎用 Webhook Push ===== -->
+        <section style="border:1px solid #d8e0ea;border-radius:6px;padding:10px 12px;background:#fafcff;">
+          <div style="font-weight:bold;margin-bottom:6px;">📡 汎用 Webhook Push</div>
+          <div style="font-size:11px;color:#667;margin-bottom:8px;">
+            印刷・温度・フィラメント等のイベントを構造化JSONで外部URLへ送信します（Slack/Discord/IFTTT/n8n 等）。
+            仕様: docs/develop/webhook-specification.md
+          </div>
+          <label style="display:block;margin-bottom:6px;">Webhook URLs（カンマ区切り）
+            <textarea data-role="wh-urls" rows="2" style="width:100%;font-size:12px;box-sizing:border-box;">${escHtml(urls)}</textarea>
+          </label>
+          <label style="display:flex;align-items:center;gap:6px;margin-bottom:6px;">
+            <input type="checkbox" data-role="wh-independent" ${whIndep ? "checked" : ""}>
+            通知設定（画面/TTS）が OFF でも Webhook を送信する（独立 push）
+          </label>
+          <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:8px;">
+            <label style="display:flex;align-items:center;gap:4px;">
+              <input type="checkbox" data-role="wh-snap-enabled" ${snapEnabled ? "checked" : ""}>
+              ステータス定期送信
+            </label>
+            <label>間隔(秒) <input type="number" data-role="wh-snap-interval" min="5" max="300" step="5"
+                value="${snapInterval}" style="width:5em;font-size:12px;padding:2px 4px;"></label>
+          </div>
+          <div>
+            <button type="button" data-role="wh-test" style="font-size:12px;padding:3px 12px;">Webhook テスト送信</button>
+            <span data-role="wh-test-result" style="margin-left:8px;font-size:12px;"></span>
+          </div>
+        </section>
+
+        <!-- ===== §B ItemKeeper 連携 ===== -->
+        <section style="border:1px solid #d8e0ea;border-radius:6px;padding:10px 12px;background:#fffdfa;">
+          <div style="font-weight:bold;margin-bottom:6px;">📦 ItemKeeper 連携</div>
+          <div style="font-size:11px;color:#667;margin-bottom:8px;">
+            印刷開始・完了/失敗時に印刷履歴の全件スナップショットを ItemKeeper(ik2) へ Bearer 認証で送信します。
+            仕様: docs/develop/itemkeeper-integration-specification.md
+          </div>
+          <label style="display:flex;align-items:center;gap:6px;margin-bottom:8px;font-weight:bold;">
+            <input type="checkbox" data-role="ik-enabled" ${s.enabled ? "checked" : ""}>
+            この連携を有効化する
+          </label>
+          <label style="display:block;margin-bottom:6px;">接続先 URL
+            <input type="text" data-role="ik-endpoint" value="${escAttr(s.endpoint)}"
+              placeholder="itemkeeper.com（自動で https://…/api/ingest/print-events へ正規化）"
+              style="width:100%;font-size:12px;box-sizing:border-box;padding:3px 6px;border:1px solid #ccc;border-radius:3px;">
+          </label>
+          <div style="display:flex;gap:10px;flex-wrap:wrap;margin-bottom:6px;">
+            <label style="flex:1;min-width:12em;">クライアント ID
+              <input type="text" data-role="ik-clientid" value="${escAttr(s.clientId)}" autocomplete="off"
+                style="width:100%;font-size:12px;box-sizing:border-box;padding:3px 6px;border:1px solid #ccc;border-radius:3px;">
+            </label>
+            <label style="flex:1;min-width:12em;">暗号キー（鍵）
+              <input type="password" data-role="ik-secret" value="${escAttr(s.secret)}" autocomplete="off"
+                style="width:100%;font-size:12px;box-sizing:border-box;padding:3px 6px;border:1px solid #ccc;border-radius:3px;">
+            </label>
+          </div>
+          <div style="display:flex;gap:14px;flex-wrap:wrap;align-items:center;margin-bottom:6px;">
+            <label>暗号化
+              <select data-role="ik-encoding" style="font-size:12px;padding:2px 4px;">
+                <option value="none" selected>none（平文・Bearer認証）</option>
+                <option value="aes-256-gcm" disabled>aes-256-gcm（受信側 Phase4+・未対応）</option>
+              </select>
+            </label>
+            <label>履歴範囲
+              <select data-role="ik-scope" style="font-size:12px;padding:2px 4px;">
+                <option value="all" ${s.historyScope === "all" ? "selected" : ""}>全件</option>
+                <option value="recent:200" ${s.historyScope === "recent:200" ? "selected" : ""}>直近200件</option>
+                <option value="recent:500" ${s.historyScope === "recent:500" ? "selected" : ""}>直近500件</option>
+              </select>
+            </label>
+            <label style="display:flex;align-items:center;gap:4px;">
+              <input type="checkbox" data-role="ik-onstart" ${s.onStart ? "checked" : ""}>開始時に送信
+            </label>
+            <label style="display:flex;align-items:center;gap:4px;">
+              <input type="checkbox" data-role="ik-onfinish" ${s.onFinish ? "checked" : ""}>完了/失敗時に送信
+            </label>
+          </div>
+
+          <div style="margin:8px 0 4px;font-weight:bold;font-size:12px;">対象機器（機器エイリアス / 連携ON-OFF）</div>
+          <table style="width:100%;border-collapse:collapse;font-size:12px;">
+            <thead><tr style="color:#667;text-align:left;">
+              <th style="padding:2px 6px;">機器</th><th style="padding:2px 6px;">エイリアス（ItemKeeper側の安定名）</th><th style="padding:2px 6px;">連携</th>
+            </tr></thead>
+            <tbody data-role="ik-devices">${deviceRows || `<tr><td colspan="3" style="padding:6px;color:#999;">接続先がありません</td></tr>`}</tbody>
+          </table>
+
+          <div style="margin-top:8px;">
+            <button type="button" data-role="ik-test" style="font-size:12px;padding:3px 12px;">連携テスト送信</button>
+            <span data-role="ik-test-result" style="margin-left:8px;font-size:12px;"></span>
+          </div>
+        </section>
+
+        <!-- ===== フッター（保存/キャンセル）===== -->
+        <div style="display:flex;justify-content:flex-end;gap:8px;border-top:1px solid #e0e0e0;padding-top:10px;">
+          <button type="button" data-role="ext-cancel" style="font-size:13px;padding:5px 14px;">変更を破棄してキャンセル</button>
+          <button type="button" data-role="ext-save" class="primary" style="font-size:13px;padding:5px 16px;font-weight:bold;">保存して戻る</button>
+        </div>
+      </div>`;
+
+    this._bindModalHandlers(container);
+  }
+
+  /** @private モーダルのイベントを束ねる */
+  _bindModalHandlers(container) {
+    const q = sel => container.querySelector(sel);
+
+    // 汎用Webhook テスト送信（下書きの URL でテスト）
+    const whTest = q('[data-role="wh-test"]');
+    if (whTest) {
+      whTest.addEventListener("click", () => {
+        const result = q('[data-role="wh-test-result"]');
+        const urls = (q('[data-role="wh-urls"]')?.value || "").split(",").map(u => u.trim()).filter(Boolean);
+        if (result) { result.textContent = "送信中…"; result.style.color = "#667"; }
+        let okCount = 0, total = urls.length;
+        this.testWebhookUrls(urls, (url, ok, msg) => {
+          if (ok) okCount++;
+          if (result) {
+            result.textContent = ok ? `OK (${okCount}/${total})` : `失敗: ${msg || ""}`;
+            result.style.color = ok ? "#2a7" : "#c33";
+          }
+        });
+      });
+    }
+
+    // ItemKeeper テスト送信（下書きの接続情報でテスト）
+    const ikTest = q('[data-role="ik-test"]');
+    if (ikTest) {
+      ikTest.addEventListener("click", () => {
+        const result = q('[data-role="ik-test-result"]');
+        const cfg = {
+          endpoint: q('[data-role="ik-endpoint"]')?.value || "",
+          clientId: q('[data-role="ik-clientid"]')?.value || "",
+          secret: q('[data-role="ik-secret"]')?.value || ""
+        };
+        if (result) { result.textContent = "送信中…"; result.style.color = "#667"; }
+        this.testConnection(cfg, (ok, msg) => {
+          if (result) { result.textContent = (ok ? "✓ " : "✗ ") + msg; result.style.color = ok ? "#2a7" : "#c33"; }
+        });
+      });
+    }
+
+    // 保存して戻る
+    const saveBtn = q('[data-role="ext-save"]');
+    if (saveBtn) {
+      saveBtn.addEventListener("click", () => {
+        this._commitModal(container);
+        this._closeModal();
+      });
+    }
+    // 変更を破棄してキャンセル
+    const cancelBtn = q('[data-role="ext-cancel"]');
+    if (cancelBtn) cancelBtn.addEventListener("click", () => this._closeModal());
+  }
+
+  /** @private モーダルの DOM 値を確定し永続化する（保存して戻る） */
+  _commitModal(container) {
+    const q = sel => container.querySelector(sel);
+
+    // ── 汎用Webhook（notificationManager に反映）──
+    const urls = (q('[data-role="wh-urls"]')?.value || "").split(",").map(u => u.trim()).filter(Boolean);
+    notificationManager.setWebhookUrls(urls);
+    notificationManager.setWebhookIndependent(!!q('[data-role="wh-independent"]')?.checked);
+    const snapEnabled = !!q('[data-role="wh-snap-enabled"]')?.checked;
+    const snapInterval = parseInt(q('[data-role="wh-snap-interval"]')?.value, 10);
+    notificationManager.setStatusSnapshot(snapEnabled, Number.isFinite(snapInterval) ? snapInterval : undefined);
+
+    // ── ItemKeeper 設定 ──
+    this.settings.enabled = !!q('[data-role="ik-enabled"]')?.checked;
+    this.settings.endpoint = (q('[data-role="ik-endpoint"]')?.value || "").trim();
+    this.settings.clientId = (q('[data-role="ik-clientid"]')?.value || "").trim();
+    this.settings.secret = q('[data-role="ik-secret"]')?.value || "";
+    this.settings.encoding = "none";
+    this.settings.historyScope = q('[data-role="ik-scope"]')?.value || "all";
+    this.settings.onStart = !!q('[data-role="ik-onstart"]')?.checked;
+    this.settings.onFinish = !!q('[data-role="ik-onfinish"]')?.checked;
+
+    // ── 対象機器（connectionTargets に反映）──
+    const targets = monitorData.appSettings.connectionTargets || [];
+    container.querySelectorAll('[data-ik-alias]').forEach(inp => {
+      const dest = inp.getAttribute("data-ik-alias");
+      const t = targets.find(x => x && x.dest === dest);
+      if (t) t.ikDeviceAlias = inp.value.trim();
+    });
+    container.querySelectorAll('[data-ik-enabled]').forEach(chk => {
+      const dest = chk.getAttribute("data-ik-enabled");
+      const t = targets.find(x => x && x.dest === dest);
+      if (t) t.ikEnabled = chk.checked;
+    });
+
+    // 永続化（即時フラッシュ＝即反映）
+    this.persist();
+  }
+
+  /** @private 外部連携モーダルを閉じる */
+  _closeModal() {
+    const overlay = document.getElementById("external-modal-overlay");
+    if (overlay) overlay.classList.remove("open");
+  }
+}
+
+/** シングルトンインスタンス */
+export const itemKeeperIntegration = new ItemKeeperIntegration();

--- a/3dp_lib/dashboard_msg_handler.js
+++ b/3dp_lib/dashboard_msg_handler.js
@@ -47,6 +47,7 @@ import {
 } from "./dashboard_storage.js";
 import { pushLog } from "./dashboard_log_util.js";
 import { notificationManager } from "./dashboard_notification_manager.js";
+import { itemKeeperIntegration } from "./dashboard_integration_itemkeeper.js";
 import { handlePrintStateTransition } from "./dashboard_printstatus.js";
 import { parseCurPosition, getCurrentTimestamp } from "./dashboard_utils.js";
 import {
@@ -541,6 +542,8 @@ export function processData(data, hostname) {
     notificationManager.notify("printStarted", _buildNotifyPayload(host, machine, {
       includeSpool: true
     }));
+    // ItemKeeper 連携: 印刷開始時に全件スナップショットを送信（onStart 設定で制御）
+    itemKeeperIntegration.onPrintEvent(host, "started");
     _set("preparationTime", 0, true);
 
     // 現在ジョブを即座に保存（printFileName/fileName が同一メッセージに含まれていれば反映）
@@ -711,6 +714,8 @@ export function processData(data, hostname) {
       includeLayer: true, includeDuration: true
     });
     notificationManager.notify(evt, notifPayload);
+    // ItemKeeper 連携: 印刷完了/失敗時に全件スナップショットを送信（onFinish 設定で制御）
+    itemKeeperIntegration.onPrintEvent(host, "finished");
     persistHistoryTimers(currStartTime, host);
   }
   // (2.6.2) Idle or 再開でリセット

--- a/3dp_lib/dashboard_notification_manager.js
+++ b/3dp_lib/dashboard_notification_manager.js
@@ -155,6 +155,8 @@ export class NotificationManager {
     this.statusSnapshotEnabled = false;
     /** ステータススナップショット送信間隔 [秒] */
     this.statusSnapshotIntervalSec = 30;
+    /** 汎用Webhookを通知マスター(enabled)非依存で送信するか（外部連携・独立push） */
+    this.webhookIndependent = false;
 
     // 永続化済み設定の読み込みは initializeDashboard() から
     // 行うため、コンストラクタでは呼び出さない。
@@ -216,6 +218,9 @@ export class NotificationManager {
     if (typeof saved.statusSnapshotIntervalSec === "number" && saved.statusSnapshotIntervalSec >= 5) {
       this.statusSnapshotIntervalSec = saved.statusSnapshotIntervalSec;
     }
+    if (typeof saved.webhookIndependent === "boolean") {
+      this.webhookIndependent = saved.webhookIndependent;
+    }
 
     // level プロパティが欠けている場合は info を補填
     Object.values(this.map).forEach(cfg => {
@@ -256,7 +261,8 @@ export class NotificationManager {
       webhookUrls: this.webhookUrls,
       filamentLowThreshold: this.filamentLowThreshold,
       statusSnapshotEnabled: this.statusSnapshotEnabled,
-      statusSnapshotIntervalSec: this.statusSnapshotIntervalSec
+      statusSnapshotIntervalSec: this.statusSnapshotIntervalSec,
+      webhookIndependent: this.webhookIndependent
     };
     saveUnifiedStorage();
   }
@@ -282,6 +288,34 @@ export class NotificationManager {
    * @returns {string[]} URL 配列
    */
   getWebhookUrls() { return [...this.webhookUrls]; }
+  /**
+   * 汎用Webhookを通知マスター(enabled)に依存せず送信するかを設定する。
+   * true の場合、画面/TTS 通知が OFF でも印刷イベント等で Webhook を送る（外部連携・独立push）。
+   *
+   * @param {boolean} flag - 独立送信を有効にするか
+   * @returns {void}
+   */
+  setWebhookIndependent(flag) { this.webhookIndependent = !!flag; this._persistSettings(); }
+  /**
+   * 汎用Webhook 独立送信フラグを取得する。
+   *
+   * @returns {boolean} 独立送信が有効なら true
+   */
+  getWebhookIndependent() { return this.webhookIndependent; }
+  /**
+   * ステータス定期送信(statusSnapshot)の有効/間隔を設定する（外部連携モーダルから利用）。
+   *
+   * @param {boolean} enabled - 定期送信を有効にするか
+   * @param {number} [intervalSec] - 送信間隔[秒]（5以上のとき採用）
+   * @returns {void}
+   */
+  setStatusSnapshot(enabled, intervalSec) {
+    this.statusSnapshotEnabled = !!enabled;
+    if (typeof intervalSec === "number" && intervalSec >= 5) {
+      this.statusSnapshotIntervalSec = intervalSec;
+    }
+    this._persistSettings();
+  }
   /**
    * フィラメント残量警告の閾値を設定する。
    * 値は 0〜1 の範囲に丸められる。
@@ -430,9 +464,17 @@ export class NotificationManager {
    * @param {object} [payload] - マクロ展開用データ（hostname を含むこと）
   */
   notify(type, payload = {}) {
-    if (!this.enabled || isNotificationSuppressed(payload?.hostname)) return;
+    // ホスト抑制は全チャネル（画面/TTS/効果音/WebPush/Webhook）に適用する。
+    if (isNotificationSuppressed(payload?.hostname)) return;
     const def = this.map[type];
+    // イベントフィルタ: 通知マップで無効なイベントは Webhook も送らない（共有フィルタ）。
     if (!def?.enabled) return;
+
+    // 通知マスター(enabled)は 画面/TTS/効果音/WebPush の可否を決める。
+    // Webhook は webhookIndependent=true のとき通知OFFでも送信する（外部連携・独立push）。
+    const notifyActive  = this.enabled;
+    const webhookActive = this.webhookUrls.length > 0 && (notifyActive || this.webhookIndependent);
+    if (!notifyActive && !webhookActive) return; // 何もすることが無ければ離脱（後方互換）
 
     // マクロ展開
     const now = new Date().toLocaleString();
@@ -446,32 +488,34 @@ export class NotificationManager {
       .replace(/\{([^}]+)\}/g, (_, k) => ctx[k] != null ? String(ctx[k]) : "")
       .replace(/[\r\n]+/g, " ");
 
-    // 1) 固定アラート（showAlert 内でログ出力も行われる）
-    showAlert(text, def.level, def.level === "error", hostname);
+    // ── UI チャネル（通知マスターONのときのみ）──
+    if (notifyActive) {
+      // 1) 固定アラート（showAlert 内でログ出力も行われる）
+      showAlert(text, def.level, def.level === "error", hostname);
 
-    // 3) TTS（ホスト別設定を適用）
-    if (!this.muted && audioManager.isVoiceAllowed() && def.talk) {
-      this._speakText(text, hostname);
+      // 3) TTS（ホスト別設定を適用）
+      if (!this.muted && audioManager.isVoiceAllowed() && def.talk) {
+        this._speakText(text, hostname);
+      }
+
+      // 4) 効果音
+      if (!this.muted && audioManager.isMusicAllowed() && def.sound) {
+        audioManager.play(def.sound);
+      }
+
+      // 5) Web Push
+      // Notification の許可がある場合だけ Web Push 処理を呼ぶ
+      if (this.useWebPush
+          && "Notification" in window
+          && Notification.permission === "granted") {
+        this._sendWebPush(text);
+      }
     }
 
-
-    // 4) 効果音
-    if (!this.muted && audioManager.isMusicAllowed() && def.sound) {
-      audioManager.play(def.sound);
-    }
-
-    // 5) Web Push
-    // Notification の許可がある場合だけ Web Push 処理を呼ぶ
-    if (this.useWebPush
-        && "Notification" in window
-        && Notification.permission === "granted") {
-      this._sendWebPush(text);
-    }
-
-    if (this.webhookUrls.length > 0) {
+    // ── Webhook（webhookIndependent=true なら通知OFFでも送信）──
+    if (webhookActive) {
       this._sendWebHook(text, type, ctx);
     }
-
   }
 
   /**

--- a/3dp_lib/dashboard_panel_boot.js
+++ b/3dp_lib/dashboard_panel_boot.js
@@ -36,6 +36,7 @@ import { monitorData } from "./dashboard_data.js";
 const DEFAULT_CAMERA_PORT = 8080;
 import { saveUnifiedStorage } from "./dashboard_storage.js";
 import { notificationManager } from "./dashboard_notification_manager.js";
+import { itemKeeperIntegration } from "./dashboard_integration_itemkeeper.js";
 import { registerPrintManagerAccessor, registerRebaselineHostUsage } from "./dashboard_spool.js";
 import { registerRelayCallback, rebaselineHostUsage } from "./dashboard_aggregator.js";
 import { getFileList, buildFileInsight } from "./dashboard_printmanager.js";
@@ -538,6 +539,33 @@ function _initTopMenuBar() {
       if (e.target === storageOverlay) storageOverlay.classList.remove("open");
     });
   }
+
+  /* ── 外部連携サブモーダル（汎用Webhook / ItemKeeper）── */
+  const externalBtn     = document.getElementById("conn-modal-external-btn");
+  const externalOverlay = document.getElementById("external-modal-overlay");
+  const externalClose   = document.getElementById("external-modal-close");
+  const externalBody    = document.getElementById("external-modal-body");
+  /** @private 外部連携モーダルを閉じる（=変更を破棄してキャンセル。確定は「保存して戻る」のみ）*/
+  const closeExternal = () => { if (externalOverlay) externalOverlay.classList.remove("open"); };
+  if (externalBtn && externalOverlay) {
+    externalBtn.addEventListener("click", () => {
+      // 開くたびに保存値からフォームを再構築（トランザクション編集の下書き）
+      itemKeeperIntegration.initModalUI(externalBody);
+      externalOverlay.classList.add("open");
+    });
+  }
+  if (externalClose) externalClose.addEventListener("click", closeExternal);
+  if (externalOverlay) {
+    externalOverlay.addEventListener("click", e => {
+      if (e.target === externalOverlay) closeExternal();
+    });
+  }
+  // Esc で閉じる（破棄）
+  document.addEventListener("keydown", e => {
+    if (e.key === "Escape" && externalOverlay && externalOverlay.classList.contains("open")) {
+      closeExternal();
+    }
+  });
 
   /* ─── オーディオ トグルボタン（トップバー） ─── */
   const soundBtn = document.getElementById("top-sound-btn");

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <!-- ★ app-version: ビルド時に scripts/sync-version.js が package.json から自動更新する -->
-  <meta name="app-version" content="2.2.1020" />
-  <title>3dpmon - 3Dプリンタ監視ダッシュボード v2.2.1020</title>
+  <meta name="app-version" content="2.2.1021" />
+  <title>3dpmon - 3Dプリンタ監視ダッシュボード v2.2.1021</title>
   <!-- サイトアイコン -->
   <link rel="icon" href="favicon.ico">
 
@@ -91,6 +91,7 @@
           <span style="flex:1"></span>
           <button id="conn-modal-notif-btn" style="font-size:11px;padding:3px 10px;cursor:pointer;background:#f0f4ff;border:1px solid #c0d0e0;border-radius:3px;">🔔 通知設定</button>
           <button id="conn-modal-storage-btn" style="font-size:11px;padding:3px 10px;cursor:pointer;background:#f0f4ff;border:1px solid #c0d0e0;border-radius:3px;">💾 ストレージ</button>
+          <button id="conn-modal-external-btn" style="font-size:11px;padding:3px 10px;cursor:pointer;background:#e8f5f3;border:1px solid #99cdc6;border-radius:3px;">🔌 外部連携</button>
         </div>
       </div>
 
@@ -148,6 +149,21 @@
       </div>
       <div class="notif-modal-body" id="notif-modal-body">
         <!-- 動的生成される通知設定テーブル -->
+      </div>
+    </div>
+  </div>
+
+  <!-- ===============================================================
+       外部連携サブモーダル（汎用Webhook Push / ItemKeeper 連携）
+  =============================================================== -->
+  <div class="notif-modal-overlay" id="external-modal-overlay">
+    <div class="notif-modal" style="max-width:680px;">
+      <div class="notif-modal-header" style="background:#0f766e;">
+        <span>🔌 外部連携</span>
+        <button class="notif-modal-close" id="external-modal-close">×</button>
+      </div>
+      <div class="notif-modal-body" id="external-modal-body">
+        <!-- 動的生成: itemKeeperIntegration.initModalUI() -->
       </div>
     </div>
   </div>

--- a/docs/develop/itemkeeper-integration-specification.md
+++ b/docs/develop/itemkeeper-integration-specification.md
@@ -1,0 +1,288 @@
+# 3dpmon ItemKeeper 連携仕様書（印刷履歴プッシュ）— Phase 1 実装仕様
+
+3dpmon が保持する**印刷履歴**を、**印刷開始・完了（失敗）時**に **ItemKeeper (ik2) の受け口へ認証付き HTTP POST** する、
+**ItemKeeper 専用連携**の実装仕様（3dpmon 側 = 送信側の実装対象）。
+
+汎用通知 Webhook（[webhook-specification.md](webhook-specification.md)）とは**別チャネル**として新規実装する。
+通知 Webhook が「外部サービスへの通知文配信（無認証・再送なし・単発イベント）」であるのに対し、本連携は
+**製造実績の取り込み**が目的で、次を備える:
+
+- **認証**: ItemKeeper が払い出した **ID（client_id）+ 鍵（secret）** を用い、**特定 URI へ特定の方法で送ったときのみ**受理・解析される。
+- **全件スナップショット**: 各トリガで、保持している印刷履歴を **機器ごとにまとめた配列**で送る（取りこぼしゼロ）。
+- **冪等・再送**: 同じ履歴を何度送っても二重計上されない。失敗は再送する。
+
+- 対象: 3dpmon v2.2.x 以降 / ItemKeeper ik2（`https://itemkeeper.com`）
+- 役割: 3dpmon = **プッシュ送信側（本書の実装対象）** / ItemKeeper = **受け口（別途実装）**
+- ItemKeeper 側設計の正本: ItemKeeper リポジトリ `docs/design/3dpmon_print_ingest_webhook.md`
+
+---
+
+## 0. 汎用 Webhook との違い
+
+| 観点 | 汎用通知 Webhook | ItemKeeper 連携（本書） |
+|------|------------------|--------------------------|
+| 目的 | 通知文配信 | 製造実績・フィラメント消費の取り込み |
+| 認証 | なし | **ID（client_id）+ 鍵（secret）/ Bearer 必須** |
+| 送信単位 | 単発イベント1件 | **全件スナップショット（機器ごとの履歴配列）** |
+| 信頼性 | ファイア&フォーゲット | **アウトボックス + 指数バックオフ再送** |
+| 重複 | 対策なし | **冪等（機器 + jobId で重複排除）** |
+| ファイル同一性 | filename のみ | **filename + filemd5** |
+| 機器 | hostname（表示名） | **機器ごとに配列化（alias/mac/hostname/model）** |
+
+> 既存 `_sendWebHook()`（`dashboard_notification_manager.js`）は通知用のまま残し、本連携は新モジュール
+> （例 `dashboard_integration_itemkeeper.js`）として分離実装することを推奨する。
+
+---
+
+## 1. 全体像
+
+```
+[ItemKeeper] でクライアントを発行 → client_id（ID） + secret（鍵）を 3dpmon に設定
+       │
+3dpmon: 印刷 開始/完了 を検知
+       │ 保持している印刷履歴を「機器ごとの配列」にまとめる（全件スナップショット）
+       │ Authorization: Bearer client_id.secret を付与（特定 URI・特定方法）
+       │ アウトボックスに積み、gzip で POST（失敗は再送）
+       ▼
+[ItemKeeper] /api/ingest/print-events
+       1) 認証（Bearer）・リプレイ防止・冪等
+       2) client_id → org 確定 / 機器を同定
+       3) 各ジョブを解析（新規のみ「製造結果取り込み」へ）
+```
+
+- **client_id は 3dpmon インスタンス（= 1 組織）に1つ**。1 回の POST に**複数機器**の履歴を含められる。
+- 機器は **配列の各要素**として送る（受信側が「どの機器の履歴か」を判定できる）。
+
+---
+
+## 2. 設定方法
+
+ItemKeeper 連携の**接続情報はインスタンス単位**（1 つ）で持ち、**機器エイリアスは機器ごと**に持つ。
+
+### 2.1 インスタンス設定（接続設定モーダルに「ItemKeeper連携」セクションを新設）
+
+| 項目 | キー | 説明 |
+|------|------|------|
+| 連携を有効化 | `enabled` | ON で印刷開始・完了時に送信 |
+| 接続先 URL | `endpoint` | 例 `https://itemkeeper.com/api/ingest/print-events`。「接続先:ポート」入力は内部で完全 URL に正規化 |
+| クライアント ID | `clientId` | ItemKeeper が払い出す「ID」 |
+| 暗号キー | `secret` | ItemKeeper が払い出す「鍵」（共有シークレット。Bearer 認証鍵） |
+| 暗号化 | `encoding` | **Phase1 は `none` 固定**（履歴 JSON を平文・Bearer 認証）。`aes-256-gcm` は**受信側 Phase4+ 予定・現状未受理**のため UI は選択不可（グレーアウト）。**いずれの場合も Bearer 認証は外さない** |
+| 開始時に送信 | `onStart` | 既定 ON |
+| 完了/失敗時に送信 | `onFinish` | 既定 ON |
+| 履歴の送信範囲 | `historyScope` | `all`（全件・既定）/ `recent:{n}`（直近 n 件）。大規模時の調整用 |
+
+```js
+// monitorData.appSettings.itemkeeper = {
+  enabled: true,
+  endpoint: "https://itemkeeper.com/api/ingest/print-events",
+  clientId: "ikc_live_xxxxxxxxxxxx",
+  secret: "********",
+  encoding: "none",         // Phase1は "none" 固定（"aes-256-gcm" は受信側Phase4+・現状未受理）
+  onStart: true,
+  onFinish: true,
+  historyScope: "all"       // "all" | "recent:200"
+}
+```
+
+### 2.2 機器エイリアス（接続先ごと = `connectionTargets[]`）
+
+| 項目 | キー | 説明 |
+|------|------|------|
+| 機器エイリアス | `ikDeviceAlias` | **ItemKeeper 側で機器を一意化する安定名**（例「1号機」）。DHCP で hostname が変わっても不変。未設定時は `label`→`hostname` で代替 |
+| この機器を連携対象にする | `ikEnabled` | 既定 ON。OFF の機器は配列から除外 |
+
+- 永続化は既存 `saveUnifiedStorage()` で自動（`appSettings` 全体が対象）。
+- ItemKeeper 側はこの `ikDeviceAlias` を「1号機/2号機」等の登録機器に突き合わせる（機器別の稼働可視化に使う）。
+
+### 2.3 テスト送信
+「連携テスト送信」ボタンで疎通＋認証を確認（`X-IK-Trigger: ingest.test`、本文は空 `devices:[]`）。
+ItemKeeper は 2xx を返す。401/403 は認証失敗として UI に明示する。
+
+---
+
+## 3. 送信タイミング
+
+| トリガ | X-IK-Trigger | 送信内容 |
+|--------|--------------|----------|
+| 印刷開始検出（新 PrintID） | `print.started` | **全件スナップショット**（開始直後の進行中ジョブを含む） |
+| 印刷正常完了（`printDone`） | `print.finished` | **全件スナップショット**（確定したジョブを含む） |
+| 印刷失敗/中断（`printFailed`） | `print.finished` | 同上（失敗ジョブは `result:"failed"`/`"canceled"`） |
+
+- いずれのトリガでも本文は同一構造（§4）。**毎回スナップショット全件**を送るため、トリガを取りこぼしても次回で必ず追いつく。
+- `X-IK-Trigger` と本文の `trigger` は「何が起きたか」の補助情報。受信側の処理は**スナップショットの差分（新規ジョブ）駆動**であり、トリガ依存ではない。
+- 任意: `historyScope` を `recent:n` にすると直近 n 件のみ送る（受信側は冪等なので欠落しても次回補完）。
+
+---
+
+## 4. ペイロード（履歴 JSON）
+
+### 4.1 構造（機器ごとの配列）
+本文は「**機器IDオブジェクトごとに履歴配列を持つ**」構造。バージョン管理のためエンベロープで包む。
+
+```jsonc
+{
+  "schema": "3dpmon.ik.history.v1",
+  "sentAt": "2026-06-08T15:47:31.000Z",
+  "trigger": { "event": "print.finished", "deviceKey": "1号機", "jobId": 1738921200 }, // 補助
+  "devices": [                          // ★機器ごとの配列
+    {
+      "deviceKey": "1号機",             // 配列の機器ID（ikDeviceAlias 優先・安定キー）
+      "device": {
+        "alias": "1号機",
+        "hostname": "k1max-abcd.local",
+        "ip": "192.168.1.5",
+        "mac": "fc:ee:28:11:22:33",     // Electron 時・取得できれば
+        "model": "K1 Max"
+      },
+      "jobs": [ /* §4.2 履歴レコード（全件 or 直近n件） */ ]
+    }
+    /* , { 別の機器 … } */
+  ]
+}
+```
+
+### 4.2 履歴レコード（jobs[] の1件）
+```jsonc
+{
+  "jobId":          1738921200,          // 安定ジョブID（=開始時刻epoch秒）。冪等キーの一部・大小で時系列保証
+  "filename":       "dragon_plate.gcode",
+  "rawFilename":    "/card/gcodes/dragon_plate.gcode",
+  "filemd5":        "3a7f4e8b...",       // プリンタ報告値（§6.3 注意）。内容同一判定に使う
+  "startTime":      "2026-06-08T15:00:00.000Z",
+  "finishTime":     "2026-06-08T15:47:30.000Z", // 進行中は null/省略
+  "durationSec":    2685,
+  "state":          "finished",          // "printing" | "finished"
+  "result":         "success",           // finished 時: success | failed | canceled（printing 時は null）
+  "printfinish":    1,                   // 1=成功 0=失敗 null=未確定（3dpmon内部値）
+  "materialUsedMm": 14256,               // 確定総消費(mm)。進行中は途中値/省略可
+  "filaments": [                         // 分割交換対応の配列
+    {
+      "spoolId":   "spool_1654789_a3f2",
+      "serialNo":  42,
+      "material":  "PLA",
+      "colorName": "Leaf Green",
+      "colorHex":  "#2ECC71",
+      "brand":     "CC3D",
+      "diameterMm":1.75,
+      "density":   1.24,
+      "usedMm":    14256,                // ★このスプールの消費(mm)＝真値
+      "usedGram":  52.7,                 // 参考（density×mm の派生値）
+      "spoolRemainMm": 187400            // 参考（リール残のヒント）
+    }
+  ]
+}
+```
+
+> **mm が真値・g は派生**: G-code/プリンタは mm（押し出し長）基準で、素材が違っても温度が合えば出てしまうため、
+> g は密度からの逆算値でしかない。ItemKeeper は mm を正として扱う。
+> 古い履歴で `filaments[].usedMm` が無い場合は、ジョブ全体の `materialUsedMm`（単一スプール扱い）にフォールバックしてよい。
+
+> **`filename` は basename（拡張子込みのファイル名のみ）で送る**: ItemKeeper の出力マッピングは `filename`（basename）を主キーに解決する。フルパスは `rawFilename`（情報用）に入れること。`filename` にパスを含めるとマッピング不一致になる。
+
+### 4.3 暗号化（encoding=aes-256-gcm 時）【Phase4+ 予約・受信側未対応】
+> **Phase1 では受信側が AES を未対応（`none` のみ受理）。本節は将来（Phase4+）用の予約仕様。** 当面 3dpmon は `encoding=none` で送信する。
+
+`devices` 配列を含む JSON を AES-256-GCM で暗号化し、本文を次のエンベロープにする:
+```jsonc
+{ "enc":"aes-256-gcm", "v":1, "iv":"<b64,12B>", "ct":"<b64>", "tag":"<b64,16B>" }
+// 鍵 = HKDF-SHA256(secret)
+```
+
+---
+
+## 5. HTTP リクエスト
+
+```
+POST {endpoint}
+Authorization:   Bearer {clientId}.{secret}
+Content-Type:    application/json
+Content-Encoding: gzip                  // 履歴が大きいので gzip 圧縮を推奨
+X-IK-Trigger:    print.started | print.finished | ingest.test
+X-IK-Timestamp:  {epoch_ms}             // リプレイ防止（受信側 ±5分外は拒否）
+X-IK-Nonce:      {uuid}                  // リプレイ防止（この POST の一意性）
+X-IK-Request-Id: {uuid}                  // ログ追跡用（冪等キーではない）
+X-IK-Encoding:   none                    // Phase1は none 固定（aes-256-gcm は受信側Phase4+・現状未受理）
+# 【Phase4+ 予約】encoding=aes-256-gcm かつ署名併用時のみ:
+X-IK-Signature:  sha256={hex}            // HMAC-SHA256(secret, `${X-IK-Timestamp}.${X-IK-Nonce}.${rawBody}`)
+
+{body}                                   // §4（gzip 圧縮可）
+```
+
+- メソッド `POST`。**Authorization は Bearer 必須**。
+- **冪等は本文の各レコード単位**（`client_id` + `deviceKey` + `jobId`）。POST 単位の冪等キーは持たない（スナップショットは毎回内容が変わるため）。`X-IK-Nonce` は POST の再送（同一バイト列）リプレイ防止用。
+- gzip 圧縮を推奨（全件履歴は数百 KB になりうる）。
+- **Phase1 の受理は `encoding=none` のみ**。受信側は `X-IK-Encoding` が none 以外なら **400（`unsupported encoding`）** で明示拒否する（§7 の 400 と同じく再送せず UI 警告）。`X-IK-Signature` も Phase1 は未使用（Bearer が認証を担保）。
+- 【Phase4+ 予約】`X-IK-Signature` は将来 aes 併用時の任意上乗せ（`crypto.subtle` 必須・§6.2 注意）。
+
+---
+
+## 6. 実装メモ・注意
+
+### 6.1 アウトボックス（再送）
+- 製造実績は落とせない。POST 前に IndexedDB のキューへ積み、2xx 受領で削除、失敗は指数バックオフで再送。
+- スナップショット方式なので、再送が遅れても次回 POST に最新全件が含まれる。冪等なので重複送信は無害。
+
+### 6.2 暗号化しないでも認証は外さない / secure-context
+- `encoding=none` は履歴 JSON を平文で送るだけ。`Authorization: Bearer` は常に付与。
+- `crypto.subtle`（署名・AES）は**セキュアコンテキスト限定**。`http://localhost`・`https://`・Electron は可だが
+  **`http://192.168.x.x` 直アクセスでは使えない**。→ 既定は **Bearer のみ（crypto 不要）**。署名/暗号化は使える環境での上乗せ。
+
+### 6.3 filemd5 はプリンタ報告値（重要）
+- `filemd5` は印刷履歴に**プリンタが報告する値**で、3dpmon は算出しない（md5 ライブラリ無し・SubtleCrypto は MD5 非対応）。
+- かつ **md5 は印刷完了後の履歴にしか現れない**（印刷前には不明）。
+- → ItemKeeper 側のマッピングは **filename を主キー**に、**md5 は内容同一の確認**に使う設計が前提。
+  ローカルで事前計算した md5 を登録する運用は、**プリンタ報告 md5 と一致するか要検証**（本書 §8 / ItemKeeper 側で扱う）。
+
+### 6.4 混在コンテンツ / CORS
+- `https://` で開いた 3dpmon から `http://` LAN 宛 POST はブラウザがブロック。`https://itemkeeper.com` 宛は問題なし。
+- クロスオリジン POST はプリフライト（OPTIONS）が走る。ItemKeeper 側で許可する（セキュリティは Bearer が担保）。Electron 経由なら実質非問題。
+
+### 6.5 秘密情報
+- `secret` は localStorage/IndexedDB に平文保存。ItemKeeper 側で**低権限・即時失効可能**なクレデンシャルとして発行される前提。
+
+### 6.6 3dpmon が必ず載せるべきフィールド
+解析は ItemKeeper 側が行うが、それには **`deviceKey`/`device`、`job.filename`+`job.filemd5`、`filaments[].{material,colorHex,spoolId,usedMm}`** が要。**欠かさず載せる**こと。
+
+---
+
+## 7. レスポンス契約と再送判断
+
+ItemKeeper はバッチ結果を JSON で返す。
+
+```jsonc
+// 200 OK
+{ "status": "ok",
+  "accepted": 3,      // 新規に受理したジョブ数
+  "duplicate": 41,    // 既受信でスキップした数
+  "pending_review": 3,// 取り込み待ち（人手確定待ち）に積んだ数
+  "devices_unregistered": ["2号機"]  // 未登録機器（要・管理画面で登録）
+}
+```
+
+| HTTP | 3dpmon の挙動 |
+|------|----------------|
+| 200/202 | 成功。アウトボックスから削除 |
+| 400 | スキーマ不正。再送せずログ＋UI 警告 |
+| 401/403 | 認証失敗・失効。再送せず **UI に「ItemKeeper 認証エラー」明示** |
+| 413 | サイズ超過。`historyScope` を縮小して再送 |
+| 429 / 5xx / ネットワーク | 指数バックオフで再送 |
+
+---
+
+## 8. ItemKeeper 側の扱い（対向の参考・3dpmon 実装には不要）
+
+- `clientId → org` 固定。受信は org スコープ隔離。`deviceKey` を登録機器（1号機/2号機 等）に突き合わせ、機器別稼働を可視化。
+- `filename`(+`filemd5`) → **「どのアイテムが何個できるか」の配列**に解決（同時複数アイテム対応）。md5 は内容同一の確認・ドリフト検出に使用。
+- 受信は「**製造結果取り込み**」に着地し、**人が品目ごとに良品/不良を確認して確定**（検品兼用）→ 良品=入庫 / 不良=不良ロット入庫（廃棄待ち/再生待ち）/ フィラメント=mm で出庫。
+- 将来: フィラメント交換時に「次に何色をセットし何を作るか（不足順/重要順）」を提示する planning に、本連携の機器×フィラメント×出力マッピング データを使う。
+
+---
+
+## 変更履歴
+
+| 日付 | 内容 |
+|------|------|
+| 2026-06-08 | 初版ドラフト: ItemKeeper 専用連携。Bearer 認証・冪等・再送・filemd5・filaments[]。単発イベント方式。 |
+| 2026-06-08 | v2（Phase1確定版）: **全件スナップショット＋機器ごとの配列**方式に変更。client_id はインスタンス単位（1 org）。機器エイリアスで機器同定。冪等はレコード単位（deviceKey+jobId）。gzip。filemd5 はプリンタ報告値（事前計算の一致は要検証）。レスポンス=バッチ集計。 |
+| 2026-06-08 | v2.1（受信対向 最終確認反映）: Phase1 の受理は **`encoding=none` のみ**と明記（`aes-256-gcm`/`X-IK-Signature` は受信側 Phase4+ 予約・現状未受理・UI 選択不可）。受信側は非 none encoding を 400（`unsupported encoding`）で拒否。`filename`=basename（マッピングキー）/`rawFilename`=フルパスの規則を明文化。 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "3dpmon",
-  "version": "2.2.1020",
+  "version": "2.2.1021",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "3dpmon",
-      "version": "2.2.1020",
+      "version": "2.2.1021",
       "license": "BSD-3-Clause",
       "dependencies": {
         "gridstack": "^10.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3dpmon",
-  "version": "2.2.1020",
+  "version": "2.2.1021",
   "description": "3Dプリンタ監視ダッシュボード - Electron版",
   "main": "electron/main.js",
   "scripts": {

--- a/tests/unit/dashboard_integration_itemkeeper.test.js
+++ b/tests/unit/dashboard_integration_itemkeeper.test.js
@@ -1,0 +1,283 @@
+/**
+ * @fileoverview dashboard_integration_itemkeeper.js の単体テスト
+ *
+ * ペイロード組立（filaments[] per-spool usedMm / state・result / historyScope）、
+ * エンベロープ schema、Bearer・X-IK-* ヘッダ、テスト送信のレスポンス分岐、
+ * 送信ゲート（enabled / per-host ikEnabled / onStart・onFinish）を検証する。
+ *
+ * 依存モジュールは全て vi.doMock でモックする（dashboard_notification_manager は
+ * モジュール読込時に document へ触れるため node 環境では必ずモックすること）。
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+/** モック monitorData */
+const mockMonitorData = {
+  machines: {},
+  appSettings: { connectionTargets: [], itemkeeper: {} }
+};
+/** モックスプール辞書 */
+const mockSpools = {
+  s1: {
+    id: "s1", serialNo: 1, material: "PLA", materialName: "PLA",
+    colorName: "Leaf Green", filamentColor: "#2ECC71", brand: "CC3D",
+    filamentDiameter: 1.75, density: 1.24, remainingLengthMm: 187400
+  },
+  s2: {
+    id: "s2", serialNo: 2, material: "PETG", colorName: "Blue",
+    filamentColor: "#0000FF", brand: "X", filamentDiameter: 1.75,
+    density: 1.27, remainingLengthMm: 100000
+  }
+};
+
+vi.doMock("../../3dp_lib/dashboard_data.js", () => ({
+  monitorData: mockMonitorData,
+  PLACEHOLDER_HOSTNAME: "_$_NO_MACHINE_$_"
+}));
+vi.doMock("../../3dp_lib/dashboard_storage.js", () => ({ saveUnifiedStorage: vi.fn() }));
+vi.doMock("../../3dp_lib/dashboard_spool.js", () => ({
+  getSpoolById: (id) => mockSpools[id] || null,
+  getMaterialDensity: () => 1.24,
+  weightFromLength: (mm, density, dia) => {
+    const r = (dia || 1.75) / 2;
+    return Math.PI * r * r * (mm / 1000) * (density || 1.24);
+  }
+}));
+vi.doMock("../../3dp_lib/dashboard_filament_ledger.js", () => ({
+  attributedUsed: (job, spoolId) => {
+    const fi = (job?.filamentInfo || []).find(f => f.spoolId === spoolId);
+    return fi ? fi.usedMm : (job?.materialUsedMm || 0);
+  },
+  deriveSpoolRemaining: (id) => ({ remainingMm: mockSpools[id]?.remainingLengthMm ?? 0 })
+}));
+vi.doMock("../../3dp_lib/dashboard_notification_manager.js", () => ({
+  notificationManager: {
+    getWebhookUrls: () => [], getWebhookIndependent: () => false,
+    statusSnapshotEnabled: false, statusSnapshotIntervalSec: 30,
+    setWebhookUrls: vi.fn(), setWebhookIndependent: vi.fn(), setStatusSnapshot: vi.fn()
+  }
+}));
+
+const { ItemKeeperIntegration } = await import("../../3dp_lib/dashboard_integration_itemkeeper.js");
+
+/** 設定済みインスタンスを生成 */
+function newIK(settings = {}) {
+  const ik = new ItemKeeperIntegration();
+  ik.settings = { ...ik.settings, ...settings };
+  return ik;
+}
+
+/** 履歴ジョブ生成ヘルパー（parse 後スキーマ） */
+function job(o) {
+  return {
+    id: o.id,
+    filename: o.filename ?? "a.gcode",
+    rawFilename: o.rawFilename ?? "/card/gcodes/a.gcode",
+    filemd5: o.filemd5 ?? "abc123",
+    startTime: o.startTime ?? "2026-06-08T15:00:00.000Z",
+    finishTime: o.finishTime ?? null,
+    printfinish: o.printfinish ?? null,
+    materialUsedMm: o.materialUsedMm ?? 0,
+    filamentId: o.filamentId,
+    filamentType: o.filamentType,
+    filamentColor: o.filamentColor,
+    filamentInfo: o.filamentInfo ?? []
+  };
+}
+
+beforeEach(() => {
+  mockMonitorData.machines = {};
+  mockMonitorData.appSettings = { connectionTargets: [], itemkeeper: {} };
+});
+
+describe("normalizeEndpoint", () => {
+  const ik = newIK();
+  it("空入力は空文字", () => expect(ik.normalizeEndpoint("")).toBe(""));
+  it("ホストのみ → https + 既定パス", () =>
+    expect(ik.normalizeEndpoint("itemkeeper.com")).toBe("https://itemkeeper.com/api/ingest/print-events"));
+  it("ホスト:ポート → https + 既定パス", () =>
+    expect(ik.normalizeEndpoint("itemkeeper.com:8443")).toBe("https://itemkeeper.com:8443/api/ingest/print-events"));
+  it("パス指定済みURLは尊重", () =>
+    expect(ik.normalizeEndpoint("https://x.example/custom")).toBe("https://x.example/custom"));
+});
+
+describe("buildJob", () => {
+  const ik = newIK();
+  it("完了・成功ジョブ", () => {
+    const j = ik.buildJob(job({
+      id: 1700000000, finishTime: "2026-06-08T15:47:30.000Z",
+      printfinish: 1, materialUsedMm: 14256,
+      filamentInfo: [{ spoolId: "s1", usedMm: 14256 }]
+    }));
+    expect(j.jobId).toBe(1700000000);
+    expect(j.state).toBe("finished");
+    expect(j.result).toBe("success");
+    expect(j.printfinish).toBe(1);
+    expect(j.materialUsedMm).toBe(14256);
+    expect(j.filename).toBe("a.gcode");
+    expect(j.filaments).toHaveLength(1);
+    expect(j.filaments[0].usedMm).toBe(14256);
+  });
+  it("進行中ジョブは state=printing / result=null", () => {
+    const j = ik.buildJob(job({ id: 1700000100, finishTime: null, printfinish: null }));
+    expect(j.state).toBe("printing");
+    expect(j.result).toBeNull();
+    expect(j.printfinish).toBeNull();
+  });
+  it("失敗ジョブは result=failed", () => {
+    const j = ik.buildJob(job({ id: 1700000200, finishTime: "2026-06-08T16:00:00.000Z", printfinish: 0 }));
+    expect(j.result).toBe("failed");
+  });
+  it("filename 未指定なら rawFilename の basename", () => {
+    const j = ik.buildJob({ id: 1, rawFilename: "/card/gcodes/dragon.gcode" });
+    expect(j.filename).toBe("dragon.gcode");
+  });
+});
+
+describe("buildFilaments", () => {
+  const ik = newIK();
+  it("複数スプール: per-spool usedMm を正しく分配", () => {
+    const fil = ik.buildFilaments(job({
+      id: 5, materialUsedMm: 1000,
+      filamentInfo: [{ spoolId: "s1", usedMm: 300 }, { spoolId: "s2", usedMm: 700 }]
+    }));
+    expect(fil).toHaveLength(2);
+    expect(fil[0].spoolId).toBe("s1");
+    expect(fil[0].usedMm).toBe(300);
+    expect(fil[0].material).toBe("PLA");
+    expect(fil[0].colorHex).toBe("#2ECC71");
+    expect(fil[0].brand).toBe("CC3D");
+    expect(fil[1].spoolId).toBe("s2");
+    expect(fil[1].usedMm).toBe(700);
+    expect(fil[0].usedGram).toBeGreaterThan(0);
+  });
+  it("filamentInfo 欠落の旧ジョブは単一スプールにフォールバック", () => {
+    const fil = ik.buildFilaments(job({ id: 6, filamentId: "s1", materialUsedMm: 500, filamentInfo: [] }));
+    expect(fil).toHaveLength(1);
+    expect(fil[0].spoolId).toBe("s1");
+    expect(fil[0].usedMm).toBe(500);
+  });
+  it("§6.6 必須フィールドが揃う", () => {
+    const fil = ik.buildFilaments(job({ id: 7, filamentInfo: [{ spoolId: "s1", usedMm: 100 }] }));
+    const f = fil[0];
+    expect(f).toHaveProperty("material");
+    expect(f).toHaveProperty("colorHex");
+    expect(f).toHaveProperty("spoolId");
+    expect(f).toHaveProperty("usedMm");
+  });
+});
+
+describe("buildSnapshot", () => {
+  beforeEach(() => {
+    mockMonitorData.appSettings.connectionTargets = [
+      { dest: "192.168.1.5:9999", hostname: "k1", label: "1号機", ikDeviceAlias: "1号機", macAddress: "fc:ee:28:11:22:33" },
+      { dest: "192.168.1.6:9999", hostname: "k2", label: "2号機", ikEnabled: false }
+    ];
+    mockMonitorData.machines.k1 = {
+      storedData: { model: { rawValue: "K1 Max" } },
+      printStore: {
+        history: [
+          job({ id: 1700000000, finishTime: "2026-06-08T15:47:30.000Z", printfinish: 1, materialUsedMm: 1000, filamentInfo: [{ spoolId: "s1", usedMm: 1000 }] }),
+          job({ id: 1700000500, finishTime: "2026-06-08T16:47:30.000Z", printfinish: 1, materialUsedMm: 2000, filamentInfo: [{ spoolId: "s1", usedMm: 2000 }] })
+        ]
+      }
+    };
+    mockMonitorData.machines.k2 = { storedData: {}, printStore: { history: [job({ id: 1700000900, materialUsedMm: 5 })] } };
+  });
+
+  it("エンベロープ schema と機器配列", () => {
+    const ik = newIK();
+    const snap = ik.buildSnapshot("print.finished", "k1");
+    expect(snap.schema).toBe("3dpmon.ik.history.v1");
+    expect(snap.trigger.event).toBe("print.finished");
+    expect(snap.trigger.deviceKey).toBe("1号機");
+    expect(Array.isArray(snap.devices)).toBe(true);
+  });
+  it("ikEnabled=false の機器を除外する", () => {
+    const ik = newIK();
+    const snap = ik.buildSnapshot("print.finished", "k1");
+    expect(snap.devices).toHaveLength(1);
+    expect(snap.devices[0].deviceKey).toBe("1号機");
+  });
+  it("device メタ（alias/hostname/ip/mac/model）", () => {
+    const ik = newIK();
+    const d = ik.buildSnapshot("print.finished", "k1").devices[0];
+    expect(d.device.hostname).toBe("k1");
+    expect(d.device.ip).toBe("192.168.1.5");
+    expect(d.device.mac).toBe("fc:ee:28:11:22:33");
+    expect(d.device.model).toBe("K1 Max");
+    expect(d.jobs).toHaveLength(2);
+  });
+  it("historyScope=recent:1 で直近1件のみ", () => {
+    const ik = newIK({ historyScope: "recent:1" });
+    const d = ik.buildSnapshot("print.finished", "k1").devices[0];
+    expect(d.jobs).toHaveLength(1);
+    expect(d.jobs[0].jobId).toBe(1700000500); // id が大きい方
+  });
+});
+
+describe("buildHeaders", () => {
+  it("Bearer と X-IK-* を付与", () => {
+    const ik = newIK({ clientId: "cid", secret: "sec" });
+    const h = ik.buildHeaders("print.finished");
+    expect(h.Authorization).toBe("Bearer cid.sec");
+    expect(h["X-IK-Encoding"]).toBe("none");
+    expect(h["X-IK-Trigger"]).toBe("print.finished");
+    expect(h["X-IK-Nonce"]).toBeTruthy();
+    expect(h["X-IK-Request-Id"]).toBeTruthy();
+    expect(h["X-IK-Timestamp"]).toMatch(/^\d+$/);
+  });
+});
+
+describe("testConnection（fetch モック）", () => {
+  it("2xx で成功", async () => {
+    global.fetch = vi.fn(async () => ({ ok: true, status: 200 }));
+    const ik = newIK();
+    const cb = vi.fn();
+    await ik.testConnection({ endpoint: "itemkeeper.com", clientId: "c", secret: "s" }, cb);
+    expect(cb).toHaveBeenCalledWith(true, expect.stringContaining("200"));
+    const [, opts] = global.fetch.mock.calls[0];
+    expect(opts.headers.Authorization).toBe("Bearer c.s");
+    expect(opts.headers["X-IK-Trigger"]).toBe("ingest.test");
+  });
+  it("401 は認証エラー", async () => {
+    global.fetch = vi.fn(async () => ({ ok: false, status: 401 }));
+    const ik = newIK();
+    const cb = vi.fn();
+    await ik.testConnection({ endpoint: "itemkeeper.com", clientId: "c", secret: "s" }, cb);
+    expect(cb).toHaveBeenCalledWith(false, expect.stringContaining("認証エラー"));
+  });
+  it("URL 未設定はエラー", async () => {
+    const ik = newIK();
+    const cb = vi.fn();
+    await ik.testConnection({ endpoint: "", clientId: "c", secret: "s" }, cb);
+    expect(cb).toHaveBeenCalledWith(false, expect.stringContaining("URL"));
+  });
+});
+
+describe("送信ゲート", () => {
+  it("enabled=false なら sendSnapshot は skipped", async () => {
+    const ik = newIK({ enabled: false });
+    const r = await ik.sendSnapshot({ trigger: "print.started", host: "k1" });
+    expect(r.skipped).toBe(true);
+  });
+  it("onStart=false なら開始イベントで送らない", () => {
+    const ik = newIK({ enabled: true, endpoint: "x.com", clientId: "c", secret: "s", onStart: false });
+    const spy = vi.spyOn(ik, "sendSnapshot").mockResolvedValue({ ok: true });
+    ik.onPrintEvent("k1", "started");
+    expect(spy).not.toHaveBeenCalled();
+  });
+  it("per-host ikEnabled=false なら送らない", () => {
+    mockMonitorData.appSettings.connectionTargets = [{ dest: "d", hostname: "k1", ikEnabled: false }];
+    const ik = newIK({ enabled: true, endpoint: "x.com", clientId: "c", secret: "s", onFinish: true });
+    const spy = vi.spyOn(ik, "sendSnapshot").mockResolvedValue({ ok: true });
+    ik.onPrintEvent("k1", "finished");
+    expect(spy).not.toHaveBeenCalled();
+  });
+  it("条件を満たせば finished で sendSnapshot 呼び出し", () => {
+    mockMonitorData.appSettings.connectionTargets = [{ dest: "d", hostname: "k1" }];
+    const ik = newIK({ enabled: true, endpoint: "x.com", clientId: "c", secret: "s", onFinish: true });
+    const spy = vi.spyOn(ik, "sendSnapshot").mockResolvedValue({ ok: true });
+    ik.onPrintEvent("k1", "finished");
+    expect(spy).toHaveBeenCalledWith({ trigger: "print.finished", host: "k1" });
+  });
+});

--- a/tests/unit/dashboard_integration_itemkeeper_modal.test.js
+++ b/tests/unit/dashboard_integration_itemkeeper_modal.test.js
@@ -1,0 +1,134 @@
+/**
+ * @fileoverview 外部連携モーダル UI（initModalUI / _commitModal）の単体テスト
+ *
+ * モーダルの動的生成（汎用Webhook節 / ItemKeeper節 / 対象機器テーブル / 保存・キャンセル）と、
+ * トランザクション編集（「保存して戻る」で draft を確定し永続化）を検証する。
+ * DOM を使うため jsdom 環境で実行する。
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockMonitorData = {
+  machines: {},
+  appSettings: {
+    connectionTargets: [
+      { dest: "192.168.1.5:9999", hostname: "k1", label: "1号機", ikDeviceAlias: "", ikEnabled: true },
+      { dest: "192.168.1.6:9999", hostname: "k2", label: "2号機", ikEnabled: false }
+    ],
+    itemkeeper: {}
+  }
+};
+const nmMock = {
+  getWebhookUrls: () => ["http://a.test/hook"],
+  getWebhookIndependent: () => true,
+  statusSnapshotEnabled: false,
+  statusSnapshotIntervalSec: 30,
+  setWebhookUrls: vi.fn(),
+  setWebhookIndependent: vi.fn(),
+  setStatusSnapshot: vi.fn()
+};
+
+vi.doMock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mockMonitorData, PLACEHOLDER_HOSTNAME: "_$_NO_MACHINE_$_" }));
+vi.doMock("../../3dp_lib/dashboard_storage.js", () => ({ saveUnifiedStorage: vi.fn() }));
+vi.doMock("../../3dp_lib/dashboard_spool.js", () => ({
+  getSpoolById: () => null, getMaterialDensity: () => 1.24, weightFromLength: () => 0
+}));
+vi.doMock("../../3dp_lib/dashboard_filament_ledger.js", () => ({
+  attributedUsed: () => 0, deriveSpoolRemaining: () => ({ remainingMm: 0 })
+}));
+vi.doMock("../../3dp_lib/dashboard_notification_manager.js", () => ({ notificationManager: nmMock }));
+
+const { ItemKeeperIntegration } = await import("../../3dp_lib/dashboard_integration_itemkeeper.js");
+
+/** モーダル本体 + overlay を用意して initModalUI を呼ぶ */
+function openModal(ik) {
+  document.body.innerHTML = '<div id="external-modal-overlay" class="open"></div>';
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  ik.initModalUI(container);
+  return container;
+}
+
+beforeEach(() => {
+  mockMonitorData.appSettings.connectionTargets = [
+    { dest: "192.168.1.5:9999", hostname: "k1", label: "1号機", ikDeviceAlias: "", ikEnabled: true },
+    { dest: "192.168.1.6:9999", hostname: "k2", label: "2号機", ikEnabled: false }
+  ];
+  vi.clearAllMocks();
+});
+
+describe("initModalUI（描画）", () => {
+  it("汎用Webhook節・ItemKeeper節・保存/キャンセルを描画", () => {
+    const ik = new ItemKeeperIntegration();
+    const c = openModal(ik);
+    expect(c.querySelector('[data-role="wh-urls"]')).toBeTruthy();
+    expect(c.querySelector('[data-role="wh-independent"]')).toBeTruthy();
+    expect(c.querySelector('[data-role="ik-enabled"]')).toBeTruthy();
+    expect(c.querySelector('[data-role="ik-endpoint"]')).toBeTruthy();
+    expect(c.querySelector('[data-role="ik-secret"]')?.getAttribute("type")).toBe("password");
+    expect(c.querySelector('[data-role="ext-save"]')).toBeTruthy();
+    expect(c.querySelector('[data-role="ext-cancel"]')).toBeTruthy();
+  });
+
+  it("現在の保存値をフォームへ反映（webhook独立フラグ等）", () => {
+    const ik = new ItemKeeperIntegration();
+    ik.settings.enabled = true;
+    ik.settings.endpoint = "itemkeeper.com";
+    const c = openModal(ik);
+    expect(c.querySelector('[data-role="ik-enabled"]').checked).toBe(true);
+    expect(c.querySelector('[data-role="ik-endpoint"]').value).toBe("itemkeeper.com");
+    expect(c.querySelector('[data-role="wh-independent"]').checked).toBe(true); // nmMock=true
+    expect(c.querySelector('[data-role="wh-urls"]').value).toContain("a.test");
+  });
+
+  it("対象機器テーブルを connectionTargets から生成（alias入力・連携チェック）", () => {
+    const ik = new ItemKeeperIntegration();
+    const c = openModal(ik);
+    expect(c.querySelectorAll("[data-ik-alias]")).toHaveLength(2);
+    const k2chk = c.querySelector('[data-ik-enabled="192.168.1.6:9999"]');
+    expect(k2chk.checked).toBe(false); // ikEnabled:false
+  });
+});
+
+describe("_commitModal（保存して戻る）", () => {
+  it("ItemKeeper設定 / webhook / 対象機器エイリアスを確定し永続化", () => {
+    const ik = new ItemKeeperIntegration();
+    const c = openModal(ik);
+
+    c.querySelector('[data-role="ik-enabled"]').checked = true;
+    c.querySelector('[data-role="ik-endpoint"]').value = "itemkeeper.com";
+    c.querySelector('[data-role="ik-clientid"]').value = "cid";
+    c.querySelector('[data-role="ik-secret"]').value = "sec";
+    c.querySelector('[data-role="ik-scope"]').value = "recent:200";
+    c.querySelector('[data-role="wh-urls"]').value = "http://x.test/1, http://x.test/2";
+    c.querySelector('[data-ik-alias="192.168.1.5:9999"]').value = "1号機";
+
+    // 「保存して戻る」をクリック
+    c.querySelector('[data-role="ext-save"]').click();
+
+    expect(ik.settings.enabled).toBe(true);
+    expect(ik.settings.endpoint).toBe("itemkeeper.com");
+    expect(ik.settings.clientId).toBe("cid");
+    expect(ik.settings.secret).toBe("sec");
+    expect(ik.settings.historyScope).toBe("recent:200");
+    // appSettings へ永続化されている
+    expect(mockMonitorData.appSettings.itemkeeper.clientId).toBe("cid");
+    // webhook は notificationManager 経由
+    expect(nmMock.setWebhookUrls).toHaveBeenCalledWith(["http://x.test/1", "http://x.test/2"]);
+    expect(nmMock.setWebhookIndependent).toHaveBeenCalled();
+    // 機器エイリアスが connectionTargets に反映
+    const t = mockMonitorData.appSettings.connectionTargets.find(x => x.dest === "192.168.1.5:9999");
+    expect(t.ikDeviceAlias).toBe("1号機");
+    // overlay が閉じている
+    expect(document.getElementById("external-modal-overlay").classList.contains("open")).toBe(false);
+  });
+
+  it("キャンセルは設定を変更しない", () => {
+    const ik = new ItemKeeperIntegration();
+    const c = openModal(ik);
+    c.querySelector('[data-role="ik-endpoint"]').value = "changed.example";
+    c.querySelector('[data-role="ext-cancel"]').click();
+    expect(ik.settings.endpoint).toBe(""); // 既定のまま
+    expect(document.getElementById("external-modal-overlay").classList.contains("open")).toBe(false);
+  });
+});

--- a/tests/unit/dashboard_notification_webhook_independent.test.js
+++ b/tests/unit/dashboard_notification_webhook_independent.test.js
@@ -1,0 +1,101 @@
+/**
+ * @fileoverview notify() の汎用Webhook 独立化ゲートの回帰テスト
+ *
+ * v2.2.1021: 「webhookIndependent=true なら通知マスター(enabled)が OFF でも Webhook を送る」
+ * という外部連携の独立 push を追加した。既定(false)では従来挙動と完全互換であることを担保する。
+ *
+ * notification_manager.js はモジュール読込時に document へ触れるため jsdom 環境で実行する。
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockMonitorData = { machines: {}, appSettings: {} };
+let suppressed = false;
+
+vi.doMock("../../3dp_lib/dashboard_data.js", () => ({
+  monitorData: mockMonitorData,
+  isNotificationSuppressed: () => suppressed,
+  PLACEHOLDER_HOSTNAME: "_$_NO_MACHINE_$_"
+}));
+vi.doMock("../../3dp_lib/dashboard_storage.js", () => ({ saveUnifiedStorage: vi.fn() }));
+vi.doMock("../../3dp_lib/dashboard_audio_manager.js", () => ({
+  audioManager: { isVoiceAllowed: () => true, isMusicAllowed: () => false, play: vi.fn() }
+}));
+// showAlert は dashboard_log_util を動的 import して window.dispatchEvent するため、
+// テスト環境破棄後の未処理例外（window is not defined）を避けるためモックする。
+vi.doMock("../../3dp_lib/dashboard_log_util.js", () => ({
+  pushNotificationLog: vi.fn(),
+  pushLog: vi.fn()
+}));
+
+const { NotificationManager } = await import("../../3dp_lib/dashboard_notification_manager.js");
+
+/** テスト用イベントマップを持つインスタンスを生成 */
+function makeMgr() {
+  const m = new NotificationManager();
+  m.map = { ev: { enabled: true, talk: "hi {hostname}", label: "hi", level: "info" } };
+  m.webhookUrls = ["http://example.test/hook"];
+  return m;
+}
+
+/** notify() を呼び、UI(_speakText)/Webhook(_sendWebHook) の発火を観測する */
+function run(m) {
+  const wh = vi.spyOn(m, "_sendWebHook").mockImplementation(() => {});
+  const tts = vi.spyOn(m, "_speakText").mockImplementation(() => {});
+  m.notify("ev", { hostname: "h" });
+  return { wh, tts };
+}
+
+beforeEach(() => {
+  suppressed = false;
+  mockMonitorData.machines = {};
+});
+
+describe("notify() 汎用Webhook 独立化ゲート", () => {
+  it("enabled=true & independent=false: UI と Webhook 両方（後方互換）", () => {
+    const m = makeMgr();
+    m.enabled = true; m.webhookIndependent = false;
+    const { wh, tts } = run(m);
+    expect(tts).toHaveBeenCalledTimes(1);
+    expect(wh).toHaveBeenCalledTimes(1);
+  });
+
+  it("enabled=false & independent=false: 無送信（後方互換）", () => {
+    const m = makeMgr();
+    m.enabled = false; m.webhookIndependent = false;
+    const { wh, tts } = run(m);
+    expect(tts).not.toHaveBeenCalled();
+    expect(wh).not.toHaveBeenCalled();
+  });
+
+  it("enabled=false & independent=true: Webhook のみ（UI 無発火）", () => {
+    const m = makeMgr();
+    m.enabled = false; m.webhookIndependent = true;
+    const { wh, tts } = run(m);
+    expect(tts).not.toHaveBeenCalled();
+    expect(wh).toHaveBeenCalledTimes(1);
+  });
+
+  it("def.enabled=false のイベントは独立でも無送信（イベントフィルタ維持）", () => {
+    const m = makeMgr();
+    m.enabled = false; m.webhookIndependent = true;
+    m.map.ev.enabled = false;
+    const { wh } = run(m);
+    expect(wh).not.toHaveBeenCalled();
+  });
+
+  it("ホスト抑制中は独立でも無送信", () => {
+    suppressed = true;
+    const m = makeMgr();
+    m.enabled = false; m.webhookIndependent = true;
+    const { wh } = run(m);
+    expect(wh).not.toHaveBeenCalled();
+  });
+
+  it("webhookUrls が空なら独立でも Webhook 無送信", () => {
+    const m = makeMgr();
+    m.enabled = false; m.webhookIndependent = true; m.webhookUrls = [];
+    const { wh } = run(m);
+    expect(wh).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要
接続設定モーダルに「🔌 外部連携」ボタン + トランザクション編集サブモーダルを新設し、ItemKeeper(ik2)連携(第一弾MVP)と汎用Webhookの独立化を実装。

## ItemKeeper連携 (docs/develop/itemkeeper-integration-specification.md / Phase1)
- 印刷開始/完了・失敗で印刷履歴の**全件スナップショット**を `Bearer認証 + gzip` で POST
- `filaments[]` は ADR-0004/0005 台帳(filamentInfo / attributedUsed / deriveSpoolRemaining)から **per-spool usedMm** を組立。jobId=printStore.history.id(epoch秒)
- 連携テスト送信 / per-host 機器エイリアス・連携ON-OFF / historyScope / レスポンス分岐(400・401/403・413・429/5xx) + 簡易インメモリ再送
- IndexedDB恒久アウトボックス・AES暗号化は**第二段へ繰延**

## 汎用Webhook Push
- 既存通知Webエンジンを外部連携に表示 + 通知マスターOFFでも送れる独立フラグ `webhookIndependent`(既定OFF=**完全後方互換**、notify()ゲート改修)

## 編集UX
- 保存して戻る=即永続+即反映 / 変更を破棄してキャンセル・×・枠外・Esc=破棄

## テスト・検証
- 新規単体テスト3本(34件) / **全435テスト緑** / lint 0 error
- 実機Electronで外部連携モーダルの開閉・描画(対象機器2台表示・暗号化aesグレーアウト・キャンセル破棄)を CDP で検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)