### PR TITLE
v2.2.1023: フィラメント記録消失(残量0開始→印刷中交換)修正 (ADR-0005 B8)

### DIFF
--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -706,12 +706,15 @@ export function setCurrentSpoolId(id, hostname) {
     const _consumed = Math.max(0, _startLen - (Number(prevSpool.remainingLengthMm) || 0));
     // 切れ確定なら旧スプールを 0 へ駆動（物理的に空）。それ以外は consumed-so-far。
     _Uold = _runoutConfirmed ? _startLen : _consumed;
-    finalizeFilamentUsage(_Uold, prevSpool.currentPrintID, host);
+    // ★ ADR-0005: per-reel 確定は exact（_Uold が権威。見積りフォールバック禁止）。
+    //   残量0で開始したスプール(_startLen=0→_Uold=0)で架空消費が記録される根本バグの修正。
+    finalizeFilamentUsage(_Uold, prevSpool.currentPrintID, host, true, { exact: true });
   } else if (host && prevSpool && !newSpool && prevSpool.currentJobStartLength != null) {
     // 純粋な取り外し（mid-print だが新スプール無し）: 従来どおり中途確定（残量保全）。
     const _used = Math.max(0,
       (Number(prevSpool.currentJobStartLength) || 0) - (Number(prevSpool.remainingLengthMm) || 0));
-    finalizeFilamentUsage(_used, prevSpool.currentPrintID, host);
+    // ★ per-reel 確定は exact（_used が権威。0 のとき見積りで埋めない）。
+    finalizeFilamentUsage(_used, prevSpool.currentPrintID, host, true, { exact: true });
   }
 
   // per-host マップを更新（hostSpoolMap が唯一の権威）
@@ -801,7 +804,11 @@ export function setCurrentSpoolId(id, hostname) {
         newSpool.currentJobStartLength = _newRemain;
         _rebaselineHostUsage?.(host, { accumulated: 0, prevUsed: _usedAtSwap });
         // 進行中ジョブ J に旧リールの per-reel 消費(U_old)を信頼ソースへ反映（derive 分割帰属）。
-        if (_J) _upsertSplitReel(host, _J, prevSpool, _Uold);
+        // ★ ADR-0005 防御: 旧リールの消費が 0（残量0で開始＝空リール）のときは per-reel に
+        //   載せない。0 を載せると当該ジョブが「複数スプール」扱いになり、実際に印刷した
+        //   新スプールが materialUsedMm フォールバックを受けられず未帰属(=満タンのまま)になる。
+        //   0 リールを除けばジョブは単一スプール扱いとなり、新スプールが正しく帰属される。
+        if (_J && _Uold > 0) _upsertSplitReel(host, _J, prevSpool, _Uold);
       }
       // 旧スプールは印刷フラグ解除済み → 信頼ソースから残量を冪等補正
       //   （whole: until=Lc で J 除外 → J前の値へ復元 / split: until=J で U_old 反映）。
@@ -1409,6 +1416,13 @@ export function reserveFilament(lengthMm, jobId = "", hostname) {
  * @param {string} [jobId=""] - 印刷ジョブID
  * @param {string} hostname - ホスト名
  * @param {boolean} [isSuccess=true] - 印刷成功フラグ（false=失敗/キャンセル）
+ * @param {Object} [opts]
+ * @param {boolean} [opts.exact=false] - true の場合、lengthMm を権威値として扱い
+ *   currentJobExpectedLength への「見積りフォールバック」を行わない（ADR-0005）。
+ *   印刷途中の per-reel 確定（split 交換／取り外し）で 0/実消費を渡す呼び出しに使う。
+ *   これを付けないと used<=0 のとき見積り長を架空消費として代入し、空スプールに
+ *   架空消費を記録＋進行中ジョブを早期に完了マークしてしまう（残量0で印刷開始した
+ *   スプールを途中交換したときの記録消失バグの根本原因）。
  * @returns {void}
  * @description
  * 使用完了時点のスプール情報を履歴にスナップショットとして保存する。
@@ -1416,7 +1430,7 @@ export function reserveFilament(lengthMm, jobId = "", hostname) {
  * name/color/material などのメタ情報を同時に記録する。
  * 履歴更新後は {@link updateHistoryList} を介して永続化し UI へ即時反映する。
  */
-export function finalizeFilamentUsage(lengthMm, jobId = "", hostname, isSuccess = true) {
+export function finalizeFilamentUsage(lengthMm, jobId = "", hostname, isSuccess = true, { exact = false } = {}) {
   const host = hostname;
   if (!host) return;
   const s = getCurrentSpool(host);
@@ -1449,12 +1463,15 @@ export function finalizeFilamentUsage(lengthMm, jobId = "", hostname, isSuccess 
   const expectedLength = Number(s.currentJobExpectedLength ?? NaN);
   let resolvedUsed = used;
   if (
+    !exact &&
     (isNaN(resolvedUsed) || resolvedUsed <= 0) &&
     !isNaN(expectedLength) &&
     expectedLength > 0
   ) {
     // 使用量が0または不明なのに予定使用量がある場合は、
-    // 予定使用量をフォールバックとして採用し、ログを残す
+    // 予定使用量をフォールバックとして採用し、ログを残す。
+    // ★ ADR-0005: per-reel 確定(exact=true)では行わない。途中交換で 0/実消費を
+    //   渡すのに見積り長を架空消費として代入すると記録が破壊されるため。
     console.warn(
       "finalizeFilamentUsage: used length was empty. fallback to expected length.",
       { used: resolvedUsed, expectedLength, jobId: normalizedJobId }

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <!-- ★ app-version: ビルド時に scripts/sync-version.js が package.json から自動更新する -->
-  <meta name="app-version" content="2.2.1022" />
-  <title>3dpmon - 3Dプリンタ監視ダッシュボード v2.2.1022</title>
+  <meta name="app-version" content="2.2.1023" />
+  <title>3dpmon - 3Dプリンタ監視ダッシュボード v2.2.1023</title>
   <!-- サイトアイコン -->
   <link rel="icon" href="favicon.ico">
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v2.2.1023 (2026-06-11)
+
+### フィラメント記録消失バグの修正（残量0で開始したスプールの印刷中交換 / ADR-0005 B8）
+
+#### 修正（致命的データ整合バグ）
+- **残量0/要交換のスプールで印刷開始 → 印刷中にフィラメント交換すると、完了後に実際に印刷した新スプールの記録が捨てられ、新スプールが満タン(100%)のまま残り印刷記録が残らない問題を修正**。
+  - 根本原因: 残量0で印刷開始すると `beginExternalPrint` が `currentJobStartLength=0` / `currentJobExpectedLength=見積り長` をセットする。一時停止中(split)交換で `setCurrentSpoolId` が `finalizeFilamentUsage(_Uold=0)` を呼ぶと、finalize の「used<=0 → 見積り長フォールバック」が誤発火し、空スプールにジョブ全体の見積り長(架空消費)を記録・進行中ジョブを早期に完了マーク・`printCount` を水増しする。結果ジョブが旧スプールだけの完了に化け、実際に印刷した新スプールが未帰属となり満タンに reconcile される。
+  - 修正(根本): `finalizeFilamentUsage` に `{ exact }` オプションを追加し、per-reel 確定(split 交換／取り外し)では見積りフォールバックを抑止（`lengthMm` を権威値として扱う）。
+  - 修正(防御): 消費0の旧リールは split `filamentInfo` に載せない（`_Uold>0` 条件）。これによりジョブが単一スプール扱いとなり、新スプールが `materialUsedMm` で正しく帰属される（`NEW=100%` 固定化も解消）。
+
+#### テスト
+- 回帰テスト `tests/unit/dashboard_filament_runout_start_swap.test.js` を追加（4件: 架空消費なし／新スプール正帰属／実測≒0でも非100%／genuine split 回帰防止）。全テスト緑、eslint 0 error。
+
+---
+
 ## v2.2.1022 (2026-06-11)
 
 ### 状態パネル「エラー状況」の per-host 表示修正 ＋ 単一ホストバグの再発防止インフラ

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "3dpmon",
-  "version": "2.2.1022",
+  "version": "2.2.1023",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "3dpmon",
-      "version": "2.2.1022",
+      "version": "2.2.1023",
       "license": "BSD-3-Clause",
       "dependencies": {
         "gridstack": "^10.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3dpmon",
-  "version": "2.2.1022",
+  "version": "2.2.1023",
   "description": "3Dプリンタ監視ダッシュボード - Electron版",
   "main": "electron/main.js",
   "scripts": {

--- a/tests/unit/dashboard_filament_runout_start_swap.test.js
+++ b/tests/unit/dashboard_filament_runout_start_swap.test.js
@@ -1,0 +1,153 @@
+/**
+ * @fileoverview ADR-0005 回帰: 残量0/要交換のスプールで印刷開始 → 印刷中のフィラメント交換
+ *
+ * 前提条件(従来テストで未カバー): OLD スプールが印刷開始時点で残量0
+ *   = currentJobStartLength=0、かつ beginExternalPrint が設定する currentJobExpectedLength>0。
+ *
+ * バグ: setCurrentSpoolId(split) 内の per-reel finalize が _Uold=0 を渡すと、
+ *   finalizeFilamentUsage の「used<=0 → 見積り長フォールバック」が発火し、
+ *   空スプールにジョブ全体の見積り長(=架空消費)を記録、進行中ジョブを早期完了マーク、
+ *   printCount を水増し。結果、実際に印刷した新スプールが未帰属(=満タン100%)になり記録消失。
+ *
+ * 修正: per-reel finalize は { exact:true } で見積りフォールバックを抑止（根本）＋
+ *   消費0の旧リールは split filamentInfo に載せない（防御 → 新スプールが正しく帰属）。
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockMonitorData = {
+  machines: {}, filamentSpools: [], usageHistory: [], mountHistory: [],
+  hostSpoolMap: {}, filamentEventContext: {}, spoolSerialCounter: 0,
+};
+
+vi.mock('../../3dp_lib/dashboard_data.js', () => ({
+  monitorData: mockMonitorData,
+  setStoredDataForHost: vi.fn(),
+  PLACEHOLDER_HOSTNAME: '_$_NO_MACHINE_$_',
+}));
+vi.mock('../../3dp_lib/dashboard_storage.js', () => ({ saveUnifiedStorage: vi.fn(), trimUsageHistory: vi.fn() }));
+vi.mock('../../3dp_lib/dashboard_filament_inventory.js', () => ({ consumeInventory: vi.fn() }));
+vi.mock('../../3dp_lib/dashboard_ui.js', () => ({ updateStoredDataToDOM: vi.fn() }));
+vi.mock('../../3dp_lib/dashboard_printmanager.js', () => ({
+  updateHistoryList: vi.fn(), loadHistory: vi.fn(() => []), saveHistory: vi.fn(),
+}));
+vi.mock('../../3dp_lib/dashboard_connection.js', () => ({ getDisplayBaseUrl: vi.fn(() => 'http://t') }));
+
+const ledger = await import('../../3dp_lib/dashboard_filament_ledger.js');
+const { setCurrentSpoolId, registerRebaselineHostUsage, finalizeFilamentUsage } =
+  await import('../../3dp_lib/dashboard_spool.js');
+
+let rebaselineSpy;
+function reset() {
+  mockMonitorData.machines = {};
+  mockMonitorData.filamentSpools = [];
+  mockMonitorData.usageHistory = [];
+  mockMonitorData.mountHistory = [];
+  mockMonitorData.hostSpoolMap = {};
+  mockMonitorData.filamentEventContext = {};
+  mockMonitorData.spoolSerialCounter = 0;
+  vi.clearAllMocks();
+  rebaselineSpy = vi.fn();
+  registerRebaselineHostUsage(rebaselineSpy);
+}
+function job(id, usedMm, extra = {}) {
+  return { id, materialUsedMm: usedMm, printfinish: extra.printfinish ?? (usedMm > 0 ? 1 : 0), ...extra };
+}
+function addSpool(sp) { mockMonitorData.filamentSpools.push(sp); return sp; }
+function histJob(host, id) { return mockMonitorData.machines[host].printStore.history.find(h => String(h.id) === String(id)); }
+
+/** 残量0で印刷開始した OLD（startLen=0, expected=50000）＋一時停止中の切れ文脈をセットアップ */
+function setupEmptyStartPaused({ usedAtSwap = 2000 } = {}) {
+  mockMonitorData.machines['h'] = {
+    printStore: { current: { id: '300' }, history: [job(100, 5000), job(200, 6000)] },
+    storedData: { usedMaterialLength: { rawValue: usedAtSwap }, state: { rawValue: 5 } },
+    runtimeData: { state: 5 },
+    historyData: [],
+  };
+  const OLD = addSpool({
+    id: 'OLD', totalLengthMm: 330000, remainingLengthMm: 0,
+    currentPrintID: '300', currentJobStartLength: 0, currentJobExpectedLength: 50000,
+    isActive: true, hostname: 'h', printCount: 0, usedLengthLog: [],
+  });
+  const NEW = addSpool({ id: 'NEW', totalLengthMm: 330000, remainingLengthMm: 330000 });
+  mockMonitorData.hostSpoolMap = { h: 'OLD' };
+  ledger.appendMountEvent({ host: 'h', spoolId: 'OLD', anchorRemainingMm: 0, sinceJobId: 200, ts: 1 });
+  ledger.recordFilamentEvent({ host: 'h', ts: 50, stateAtEvent: 5, oldSpoolId: 'OLD', oldRemainingMm: 0, oldRemainingPct: 0, runout: true });
+  return { OLD, NEW };
+}
+
+describe('残量0で印刷開始 → 印刷中(paused)交換: 架空消費を作らない（根本修正）', () => {
+  beforeEach(reset);
+
+  it('交換直後: 空OLDに架空消費を記録せず、進行中ジョブを早期完了マークしない', () => {
+    const { OLD } = setupEmptyStartPaused();
+    setCurrentSpoolId('NEW', 'h');
+
+    const h300 = histJob('h', 300);
+    // 架空消費(見積り50000)が OLD/履歴に書かれていないこと
+    expect(OLD.usedLengthLog.find(l => String(l.jobId) === '300')?.used ?? 0).not.toBe(50000);
+    expect(OLD.printCount, '空スプールで printCount を水増ししない').toBe(0);
+    expect(OLD.remainingLengthMm, 'OLD は 0 のまま').toBe(0);
+    // 進行中ジョブ300を materialUsedMm=50000/printfinish=1 で早期完了マークしない
+    expect(h300?.materialUsedMm ?? 0, '進行中ジョブに架空 materialUsedMm を書かない').not.toBe(50000);
+  });
+
+  it('完了: NEW が残りを印刷 → NEW が正しく帰属（満タン100%に戻らない）', () => {
+    const { NEW } = setupEmptyStartPaused({ usedAtSwap: 2000 });
+    setCurrentSpoolId('NEW', 'h');
+
+    // NEW が交換後に残り 48000 を印刷して完了（実測 48000）
+    finalizeFilamentUsage(48000, '300', 'h', true);
+
+    const remNew = ledger.deriveSpoolRemaining('NEW').remainingMm;
+    expect(remNew, 'NEW は実際に印刷した分だけ減る（満タン330000=記録消失ではない）').toBeLessThan(330000);
+    expect(remNew).toBe(282000);                                  // 330000 - 48000
+    expect(ledger.deriveSpoolRemaining('OLD').remainingMm).toBe(0); // 空OLDは0維持
+    expect(histJob('h', 300).materialUsedMm).toBe(48000);          // 実値（架空50000ではない）
+  });
+
+  it('完了: NEW実測が取得できなくても（accumulated≒0）NEWは単一スプール帰属で満タンに戻らない', () => {
+    const { NEW } = setupEmptyStartPaused({ usedAtSwap: 0 });
+    setCurrentSpoolId('NEW', 'h');
+
+    // ライブ追跡が 0 で完了 → その後プリンタ確定値(reqHistory 相当)が入る
+    finalizeFilamentUsage(0, '300', 'h', true);
+    // プリンタ報告の総消費が後から入る（単一スプールジョブ）
+    const h300 = histJob('h', 300) || (mockMonitorData.machines.h.printStore.history.push(job(300, 50000)), histJob('h', 300));
+    h300.materialUsedMm = 50000;
+
+    const remNew = ledger.deriveSpoolRemaining('NEW').remainingMm;
+    expect(remNew, 'NEW は単一スプール materialUsedMm 帰属で減る（100%固定にならない）').toBeLessThan(330000);
+  });
+});
+
+describe('対照: 残量ありの genuine split は従来どおり（回帰防止）', () => {
+  beforeEach(reset);
+
+  it('OLD残量あり(startLen=300000)の paused 交換は per-reel 分割を維持し OLD→0', () => {
+    mockMonitorData.machines['h'] = {
+      printStore: { current: { id: '300' }, history: [job(100, 5000), job(200, 6000)] },
+      storedData: { usedMaterialLength: { rawValue: 15000 }, state: { rawValue: 5 } },
+      runtimeData: { state: 5 },
+      historyData: [],
+    };
+    const OLD = addSpool({
+      id: 'OLD', totalLengthMm: 330000, remainingLengthMm: 285000,
+      currentPrintID: '300', currentJobStartLength: 300000, currentJobExpectedLength: 50000,
+      isActive: true, hostname: 'h', printCount: 0, usedLengthLog: [],
+    });
+    addSpool({ id: 'NEW', totalLengthMm: 330000, remainingLengthMm: 330000 });
+    mockMonitorData.hostSpoolMap = { h: 'OLD' };
+    ledger.appendMountEvent({ host: 'h', spoolId: 'OLD', anchorRemainingMm: 300000, sinceJobId: 200, ts: 1 });
+    ledger.recordFilamentEvent({ host: 'h', ts: 50, stateAtEvent: 5, oldSpoolId: 'OLD', oldRemainingMm: 285000, oldRemainingPct: 86, runout: true });
+
+    setCurrentSpoolId('NEW', 'h');
+
+    // genuine split: 旧リールの per-reel(300000) は維持、OLD は切れ確定で 0
+    expect(OLD.remainingLengthMm).toBe(0);
+    expect(histJob('h', 300).filamentInfo.find(fi => fi.spoolId === 'OLD').usedMm).toBe(300000);
+
+    finalizeFilamentUsage(25000, '300', 'h');
+    expect(ledger.deriveSpoolRemaining('NEW').remainingMm).toBe(305000); // 330000-25000
+    expect(ledger.deriveSpoolRemaining('OLD').remainingMm).toBe(0);
+  });
+});


### PR DESCRIPTION
## 概要
残量0/要交換のスプールで印刷開始 → **印刷中にフィラメント交換すると、完了後に実際に印刷した新スプールの記録が捨てられ、新スプールが満タン(100%)のまま残り印刷記録が残らない**致命的データ整合バグを修正します。

## 根本原因
- 残量0で印刷開始すると `beginExternalPrint` が `currentJobStartLength=0` / `currentJobExpectedLength=見積り長` をセット。
- 一時停止中(split)交換で `setCurrentSpoolId` が `finalizeFilamentUsage(_Uold=0)` を呼ぶと、finalize の「used<=0 → 見積り長フォールバック」が誤発火し、空スプールにジョブ全体の見積り長(架空消費)を記録・進行中ジョブを早期に完了マーク・`printCount` を水増し。結果ジョブが旧スプールだけの完了に化け、実際に印刷した新スプールが未帰属となり満タンに reconcile。
- **トリガは precondition そのもの**: `currentJobStartLength=0`(=印刷前に0)のときだけ `_Uold=0`→フォールバック発火。既存 ADR-0005 帰属テストは全件 startLen>0 で未カバーだった。

## 修正（根本＋防御）
- **根本**: `finalizeFilamentUsage` に `{ exact }` を追加し、per-reel 確定(split/取り外し)では見積りフォールバックを抑止。
- **防御**: 消費0の旧リールを split `filamentInfo` に載せない(`_Uold>0`)→ ジョブが単一スプール扱いとなり新スプールが `materialUsedMm` で正しく帰属（`NEW=100%` 固定化も解消）。

## テスト
- 回帰テスト `tests/unit/dashboard_filament_runout_start_swap.test.js`（4件）追加。
- **全447テスト緑**（既存443＋4）、eslint 0 error。

🤖 Generated with [Claude Code](https://claude.com/claude-code)