### PR TITLE
v2.2.1028: 印刷中ジョブの履歴表示（▶維持・成否誤計上修正）＋ Moonraker履歴/ファイル🔄

### DIFF
--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -1539,6 +1539,23 @@ function _sendMoonrakerCommand(method, params, host) {
     showAlert(`[${host}] Moonraker に接続されていません`, "error", false, host);
     return Promise.reject(new Error("Moonraker session not connected"));
   }
+
+  // ★ K1 の 履歴/ファイル一覧 再取得(🔄) を Moonraker の fetchHistory/fetchFiles へ橋渡し。
+  //   旧実装は get{reqHistory:1}/{reqGcodeFile:1} を「未対応」で no-op にしており、
+  //   Moonraker 機で 🔄 を押しても履歴/ファイルが更新されなかった。
+  if (method === "get" && params && (params.reqHistory || params.reqGcodeFile)) {
+    const tasks = [];
+    if (params.reqHistory && typeof session.refreshHistory === "function") {
+      pushLog("送信(Moonraker): 印刷履歴を再取得", "send", false, host);
+      tasks.push(Promise.resolve(session.refreshHistory()).catch(() => {}));
+    }
+    if (params.reqGcodeFile && typeof session.refreshFiles === "function") {
+      pushLog("送信(Moonraker): ファイル一覧を再取得", "send", false, host);
+      tasks.push(Promise.resolve(session.refreshFiles()).catch(() => {}));
+    }
+    return Promise.all(tasks).then(() => null);
+  }
+
   const steps = translateK1CommandToMoonraker(method, params);
   if (!steps || steps.length === 0) {
     pushLog(`Moonraker機では未対応の操作のため無視しました: ${method} ${JSON.stringify(params)}`, "warn", false, host);

--- a/3dp_lib/dashboard_moonraker.js
+++ b/3dp_lib/dashboard_moonraker.js
@@ -1073,5 +1073,9 @@ export function createMoonrakerSession(opts) {
      * @returns {Promise<*>} result
      */
     request: (method, params = {}) => rpc(method, params),
+    /** 印刷履歴を再取得して onAux 通知する（K1 の reqHistory 相当の🔄用）。 */
+    refreshHistory: () => fetchHistory(),
+    /** gcode ファイル一覧を再取得して onAux 通知する（K1 の reqGcodeFile 相当の🔄用）。 */
+    refreshFiles: () => fetchFiles(),
   };
 }

--- a/3dp_lib/dashboard_moonraker.js
+++ b/3dp_lib/dashboard_moonraker.js
@@ -259,6 +259,10 @@ export function translateMoonrakerStatus(status, ctx, nowMs) {
 
   // --- 経過時間(秒) ---------------------------------------------------------
   const printDuration = Number(ps.print_duration || 0);
+  // total_duration は加熱・一時停止を含む「開始からの総経過」。開始時刻の逆算には
+  // こちらを使う（print_duration は加熱/停止を除くため、逆算すると実開始より後ろへ
+  // 数十秒〜数分ズレ、履歴の実 start_time と食い違って ▶→「…」になる）。
+  const totalDuration = Number(ps.total_duration || ps.print_duration || 0);
 
   // --- ジョブID(printStartTime, epoch秒) -----------------------------------
   // 印刷/一時停止中はジョブが進行中。ファイル名が変わるか未確定なら確定し直す。
@@ -267,8 +271,9 @@ export function translateMoonrakerStatus(status, ctx, nowMs) {
   if (!ctx.job) ctx.job = { startEpoch: null, filename: null };
   if (printState === "printing" || printState === "paused") {
     if (!ctx.job.startEpoch || ctx.job.filename !== filename) {
-      // now - 経過 で開始時刻を逆算(安定したジョブIDとして利用)
-      ctx.job.startEpoch = Math.max(1, nowSec - Math.round(printDuration));
+      // ★ now - total_duration で開始時刻を逆算（履歴未取得時のブートストラップ）。
+      //   接続時は fetchHistory が実 start_time を先に確定するためここは通常使われない。
+      ctx.job.startEpoch = Math.max(1, nowSec - Math.round(totalDuration));
       ctx.job.filename   = filename;
     }
   }
@@ -931,11 +936,16 @@ export function createMoonrakerSession(opts) {
         // 初期スナップショット
         mergeMoonrakerStatus(accStatus, result.status);
         maybeFetchMeta();
-        emit();
-        // 状態購読が確立(=ホスト確定・パネル生成済み)した後に履歴/ファイル/カメラを取得
-        fetchHistory();
-        fetchFiles();
-        fetchWebcams();
+        // ★ 印刷中ジョブID(=開始時刻)の再採番防止:
+        //   先に履歴を取得して進行中ジョブの「実 start_time」を ctx.job.startEpoch へ確定
+        //   してから初回 emit する。これをやらないと、初回 emit が逆算ID(now-duration)で
+        //   現在ジョブ行を作り、直後の履歴取得で実IDへ貼り替わって ▶→「…」になる
+        //   （印刷中に 3dpmon を再起動した時の不具合）。
+        fetchHistory().finally(() => {
+          emit();
+          fetchFiles();
+          fetchWebcams();
+        });
       } else if (tag === "meta" && result) {
         // gcode メタ(残時間/レイヤー算出用)を ctx へ格納
         ctx.meta = {

--- a/3dp_lib/dashboard_msg_handler.js
+++ b/3dp_lib/dashboard_msg_handler.js
@@ -1045,7 +1045,12 @@ export function processData(data, hostname) {
 
   // runtimeData.state は ingestData 後に更新することで
   // aggregator 側が前回状態を正しく参照できるようにする
-  machine.runtimeData.state = String(st);
+  // ★ state 欠落メッセージ(data.state 無し)では st=NaN。runtimeData.state を "NaN" で
+  //   上書きすると印刷中でも ▶ にならない/前回状態参照が壊れるため、NaN のときは
+  //   直近の有効値を維持する（K1 は状態を含まない部分更新メッセージを送ることがある）。
+  if (!Number.isNaN(st)) {
+    machine.runtimeData.state = String(st);
+  }
 }
 
 /**

--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -969,7 +969,14 @@ export function renderPrintCurrent(containerEl, hostname) {
 
   /* 印刷中であれば storedData からリアルタイム使用量を取得 */
   const machine = monitorData.machines[hostname];
-  const printState = Number(machine?.runtimeData?.state ?? -1);
+  // ★ 状態は storedData.state(機器報告の生値・再起動後も保持)を最優先。
+  //   runtimeData.state は data.state 欠落メッセージで "NaN" に化け、印刷中でも
+  //   ▶(進行中)にならない不具合があったため、信頼できる storedData.state を一次ソースにする。
+  const printState = Number(
+    machine?.storedData?.state?.rawValue
+    ?? machine?.runtimeData?.state
+    ?? -1
+  );
   if (
     (printState === PRINT_STATE_CODE.printStarted ||
      printState === PRINT_STATE_CODE.printPaused) &&
@@ -1463,7 +1470,14 @@ export function renderHistoryTable(rawArray, baseUrl, hostname) {
   /* 現在印刷中のジョブ判定用 */
   const curPrintId = getCurrentPrintID(hostname);
   const machine    = monitorData.machines[hostname];
-  const printState = Number(machine?.runtimeData?.state ?? -1);
+  // ★ 状態は storedData.state(機器報告の生値・再起動後も保持)を最優先。
+  //   runtimeData.state は data.state 欠落メッセージで "NaN" に化け、印刷中でも
+  //   ▶(進行中)にならない不具合があったため、信頼できる storedData.state を一次ソースにする。
+  const printState = Number(
+    machine?.storedData?.state?.rawValue
+    ?? machine?.runtimeData?.state
+    ?? -1
+  );
   const isActive   = (st) =>
     st === PRINT_STATE_CODE.printStarted || st === PRINT_STATE_CODE.printPaused;
 

--- a/tests/unit/dashboard_moonraker.test.js
+++ b/tests/unit/dashboard_moonraker.test.js
@@ -193,8 +193,10 @@ describe('translateMoonrakerStatus(印刷中)', () => {
     expect(out.printLeftTime).toBeGreaterThan(1300);
     expect(out.printLeftTime).toBeLessThan(1500);
   });
-  it('printStartTime = now - 経過(安定ジョブID)', () => {
-    expect(out.printStartTime).toBe(Math.floor(NOW_MS / 1000) - 1470);
+  it('printStartTime = now - total_duration(加熱含む総経過＝実開始時刻に一致)', () => {
+    // ★ print_duration(加熱除外)でなく total_duration(1533.88→1534)で逆算する。
+    //   加熱ぶん後ろにズレて履歴の実 start_time と食い違い ▶→「…」になる不具合の対策。
+    expect(out.printStartTime).toBe(Math.floor(NOW_MS / 1000) - 1534);
   });
   it('ファン速度を ON/OFF と % に', () => {
     expect(out.fan).toBe(1);
@@ -240,7 +242,8 @@ describe('ジョブID(printStartTime)安定性', () => {
   it('ファイル名が変わると新しいジョブIDを確定する', () => {
     const ctx = mkCtx();
     const a = translateMoonrakerStatus(FIXTURE_PRINTING, ctx, NOW_MS);
-    const other = { ...FIXTURE_PRINTING, print_stats: { ...FIXTURE_PRINTING.print_stats, filename: 'Cube-PLA.gcode', print_duration: 10 } };
+    // 新ファイルが開始直後（total_duration も print_duration も ~10秒）
+    const other = { ...FIXTURE_PRINTING, print_stats: { ...FIXTURE_PRINTING.print_stats, filename: 'Cube-PLA.gcode', print_duration: 10, total_duration: 10 } };
     const b = translateMoonrakerStatus(other, ctx, NOW_MS + 60_000);
     expect(b.printStartTime).not.toBe(a.printStartTime);
     expect(b.printStartTime).toBe(Math.floor((NOW_MS + 60_000) / 1000) - 10);

--- a/tests/unit/dashboard_printmanager_render_perf.test.js
+++ b/tests/unit/dashboard_printmanager_render_perf.test.js
@@ -84,8 +84,9 @@ vi.mock("../../3dp_lib/dashboard_aggregator.js", () => ({ getCurrentPrintID: vi.
 
 const { renderHistoryTable, renderFileList } =
   await import("../../3dp_lib/dashboard_printmanager.js");
-const { scopedById } = await import("../../3dp_lib/dashboard_data.js");
+const { scopedById, monitorData } = await import("../../3dp_lib/dashboard_data.js");
 const spoolMod = await import("../../3dp_lib/dashboard_spool.js");
+const aggMod = await import("../../3dp_lib/dashboard_aggregator.js");
 
 /** スコープ付きテーブル（thead+tbody+親）を生成して scopedById に登録する */
 function makeTable(tableId) {
@@ -181,6 +182,30 @@ describe("renderHistoryTable — 描画律速対策（lazy画像＋イベント�
     renderHistoryTable(makeHistoryRows(3), "http://127.0.0.1", HOST);
     const drill = table.parentElement.querySelector(".job-drilldown");
     expect(drill).toBeTruthy();
+  });
+
+  it("(D) 印刷中(storedData.state=printStarted)の現在ジョブは ▶(result-active)になる（runtimeData.state が NaN でも）", () => {
+    const CURID = 1781739950;
+    // ★ K1 は state 欠落メッセージで runtimeData.state が "NaN" に化けるが、
+    //   storedData.state(機器報告の生値)で判定して印刷中ジョブを ▶ にする回帰防止。
+    monitorData.machines[HOST] = {
+      storedData: { state: { rawValue: 1 /* printStarted */ } },
+      runtimeData: { state: "NaN" },
+    };
+    aggMod.getCurrentPrintID.mockReturnValue(CURID);
+
+    renderHistoryTable(
+      [{ id: CURID, filename: "/x/cur.gcode", starttime: CURID, usagetime: 0, printfinish: 0 }],
+      "http://127.0.0.1", HOST
+    );
+
+    const row = table.querySelector("tbody tr.history-row");
+    const finishSpan = row?.querySelector(".col-finish span");
+    expect(finishSpan?.className, "現在の印刷ジョブは ▶(result-active)").toBe("result-active");
+    expect(finishSpan?.textContent).toBe("▶");
+    expect(row?.classList.contains("history-row-printing"), "印刷中行ハイライト").toBe(true);
+    aggMod.getCurrentPrintID.mockReturnValue(0);
+    delete monitorData.machines[HOST];
   });
 });
 


### PR DESCRIPTION
## 概要（v2.2.1027 リリース後の修正、PR #386 を含む）
印刷中にアプリを再起動した際の履歴表示まわりを根本修正。

### 1) 印刷中ジョブを成否へ誤確定・誤計上しない（PR #386）
未完了ジョブが履歴で K1=失敗(✗)/IR3v2=成功(✔) に化け、stats にも計上されていた。
完了シグナル（usagetime>0 || endtime>0）が無い＝未完了は `printfinish=null`（未確定「…」）にし、
完了報告後にのみ ✔/✗。`updateHistoryList`/`jobsToRaw`/`resolveHistoryFinishStatus` を統一。

### 2) 印刷中の現在ジョブは ▶（進行中）で表示
K1 は state 欠落の部分更新で `runtimeData.state` が "NaN" に化け ▶ にならなかった。
状態判定を信頼できる `storedData.state` 優先に＋`runtimeData.state` を NaN で上書きしない。

### 3) Moonraker のジョブID（開始時刻）を実 start_time で安定化（再採番しない）
`now - print_duration`（加熱・停止除外）で逆算していたため実 start_time と数十秒ズレ、
履歴再取得(🔄)で id が貼り替わり ▶→「…」に戻っていた。接続時に履歴を先取りして
実 start_time を確定してから初回描画（再採番しない）＋ブートストラップ逆算は
`now - total_duration` へ。→ id 不変、🔄しても ▶ 維持、完了時も重複なし。

### 4) Moonraker の履歴/ファイル一覧 🔄 を実機能化
`reqHistory`/`reqGcodeFile` を fetchHistory/fetchFiles へ橋渡し（従来 no-op）。

## テスト
全 701 緑。printfinish 確定・▶判定・printStartTime(total_duration)・履歴正規化の回帰テスト追加/更新。実機(K1/IR3v2)で ▶ 維持・🔄維持を確認済み。

## 既知の残課題（後追い）
- 進行中エントリが前ジョブの finishTime をコピーする偽値（完了表示に影響、▶中はマスクされる）。
- 接続追加の ping/hostname/重複ブロック（item3, 未着手）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)