### PR TITLE
main(v2.2.1031)→feature 定期同期

### DIFF
--- a/3dp_lib/dashboard_client_sync.js
+++ b/3dp_lib/dashboard_client_sync.js
@@ -378,6 +378,21 @@ function _refreshFilamentPreviews() {
 }
 
 /**
+ * 親からミラーされた ItemKeeper 設定を子の monitorData + itemKeeperIntegration へ反映する。
+ * 子は親の設定を読み取りミラーするのみ（ローカル確定保存はしない）。開いている
+ * 外部連携モーダルがあれば（未編集時のみ）再描画して最新設定を反映する。
+ *
+ * @private
+ * @param {Object} ik - ItemKeeper 設定オブジェクト
+ */
+function _applyItemkeeperSettings(ik) {
+  if (!ik || typeof ik !== "object") return;
+  monitorData.appSettings.itemkeeper = ik;
+  try { window.itemKeeperIntegration?.loadSettings?.(); } catch { /* noop */ }
+  try { window.itemKeeperIntegration?.refreshOpenModal?.(); } catch { /* noop */ }
+}
+
+/**
  * フルスナップショットを monitorData に適用する。
  *
  * @private
@@ -390,6 +405,11 @@ function _applySnapshot(state) {
   // 接続先情報を設定
   if (state.appSettings?.connectionTargets) {
     monitorData.appSettings.connectionTargets = state.appSettings.connectionTargets;
+  }
+
+  // ★ ItemKeeper 連携設定を親からミラー（親が唯一の設定元・送信元）。
+  if (state.appSettings?.itemkeeper) {
+    _applyItemkeeperSettings(state.appSettings.itemkeeper);
   }
 
   // ★ フィラメントデータ: 親が唯一の権威 — 受信内容で全置換する。
@@ -495,6 +515,10 @@ function _applyDelta(msg) {
   //   差分でも全置換で整合する（IDマージ+stickyフラグは乖離の根本原因だった）。
   if (msg.shared) {
     _applySharedFilamentState(msg.shared);
+    // ★ ItemKeeper 設定の差分ミラー（親で変更 or satellite 逆反映が確定したとき届く）。
+    if (msg.shared.appSettingsItemkeeper) {
+      _applyItemkeeperSettings(msg.shared.appSettingsItemkeeper);
+    }
   }
 
   // ★ 印刷履歴・現在ジョブの差分適用 + 履歴パネル再描画
@@ -549,6 +573,42 @@ export function sendRelayCommand(method, params, hostname) {
     params
   }));
   return true;
+}
+
+/**
+ * ItemKeeper 等の外部連携設定の変更を親へ逆反映する（satellite モード専用）。
+ *
+ * 子（satellite）はローカルに設定を確定保存せず、本 RPC で親へ委譲する。
+ * 親が唯一の設定元として確定保存し、次回 relay-delta(appSettingsItemkeeper)で
+ * 全子クライアント（自分自身を含む）へミラー還流する。
+ * readonly モードはサーバ側ガードで弾かれる（閲覧専用）。
+ *
+ * @param {Object} itemkeeper - ItemKeeper 設定オブジェクト（this.settings 相当）
+ * @returns {boolean} 送信成功なら true
+ */
+export function sendRelaySettings(itemkeeper) {
+  if (_relayMode !== "satellite") {
+    console.warn("[client-sync] readonly モードでは設定変更不可");
+    _alertRelayBlocked("readonly");
+    return false;
+  }
+  if (!_relayWs || _relayWs.readyState !== 1) {
+    console.warn("[client-sync] リレー未接続");
+    _alertRelayBlocked("disconnected");
+    return false;
+  }
+  _relayWs.send(JSON.stringify({
+    type: "relay-settings",
+    payload: { itemkeeper }
+  }));
+  return true;
+}
+
+/* ★ 外部連携モーダル(itemkeeper)がリレーモード分岐に使うため window へ公開。
+   静的 import の循環（client_sync ↔ itemkeeper）を避けるための疎結合。 */
+if (typeof window !== "undefined") {
+  window.getRelayMode = getRelayMode;
+  window.sendRelaySettings = sendRelaySettings;
 }
 
 /** リレー操作ブロック時のトースト連続表示を抑制するための最終表示時刻 */

--- a/3dp_lib/dashboard_integration_itemkeeper.js
+++ b/3dp_lib/dashboard_integration_itemkeeper.js
@@ -80,6 +80,27 @@ function escHtml(s) {
 }
 
 /**
+ * 現在のリレーモードを安全に取得する（window 越しに疎結合、循環 import 回避）。
+ * @returns {string|null} "parent"|"readonly"|"satellite"|"standalone"|null
+ */
+function _relayMode() {
+  try {
+    return (typeof window !== "undefined" && window.getRelayMode) ? window.getRelayMode() : null;
+  } catch { return null; }
+}
+
+/**
+ * リレー子（readonly/satellite）かどうか。子は ItemKeeper をローカル確定保存も送信もせず、
+ * 親の設定をミラーする（送信元は親のみ）。standalone/parent は自分が権威で送信する。
+ * @returns {boolean}
+ */
+function _isRelayChild() {
+  try {
+    return typeof window !== "undefined" && window._3dpmonRelayChild === true;
+  } catch { return false; }
+}
+
+/**
  * 外部連携 / ItemKeeper 連携マネージャ。
  * シングルトン `itemKeeperIntegration` として export する。
  */
@@ -114,6 +135,48 @@ export class ItemKeeperIntegration {
     monitorData.appSettings[SETTINGS_KEY] = { ...this.settings };
     saveUnifiedStorage(true);
     this._restartIntervalTimer();
+  }
+
+  /**
+   * satellite から逆反映された設定を親側で確定保存する（親が唯一の設定元）。
+   * 親レンダラーが relay-settings RPC を受けて呼ぶ。確定後は relay-delta
+   * (appSettingsItemkeeper) で全子（送信元 satellite を含む）へミラー還流する。
+   *
+   * @param {Object} ik - ItemKeeper 設定オブジェクト（子の this.settings 相当）
+   * @returns {void}
+   */
+  applyRemoteSettings(ik) {
+    if (!ik || typeof ik !== "object") return;
+    this.settings = { ...DEFAULTS, ...ik };
+    this.settings.encoding = "none"; // Phase1 は none 固定
+    this.persist();
+  }
+
+  /**
+   * 親設定がミラー更新されたとき、開いている外部連携モーダルの ItemKeeper 入力欄を
+   * （未編集時のみ）最新値へ追従させる。full re-render はせず（リレー接続節やハンドラを
+   * 壊さないため）入力値だけを差し替える。編集中(_dirty)はユーザー入力を尊重して触らない。
+   * 子（readonly/satellite）が relay-snapshot/delta を適用したときに呼ばれる。
+   *
+   * @returns {void}
+   */
+  refreshOpenModal() {
+    try {
+      const overlay = document.getElementById("external-modal-overlay");
+      if (!overlay || !overlay.classList.contains("open")) return;
+      if (this._dirty) return; // 編集中は壊さない
+      const body = document.getElementById("external-modal-body");
+      if (!body) return;
+      const s = this.settings;
+      const chk = (role, v) => { const el = body.querySelector(`[data-role="${role}"]`); if (el) el.checked = !!v; };
+      const val = (role, v) => { const el = body.querySelector(`[data-role="${role}"]`); if (el) el.value = v ?? ""; };
+      chk("ik-enabled", s.enabled);
+      val("ik-endpoint", s.endpoint); val("ik-clientid", s.clientId); val("ik-secret", s.secret);
+      val("ik-scope", s.historyScope || "all"); val("ik-intervalmin", String(Number(s.intervalMin) || 5));
+      chk("ik-onstart", s.onStart); chk("ik-onfinish", s.onFinish); chk("ik-onpause", s.onPause); chk("ik-oninterval", s.onInterval);
+      chk("ik-attach-camera", s.attachCamera); chk("ik-attach-state", s.attachState); chk("ik-attach-files", s.attachFiles);
+      chk("ik-attach-thumbs", s.attachFileThumbs); chk("ik-attach-filhistory", s.attachFilamentHistory);
+    } catch { /* noop */ }
   }
 
   // ───────────────────────────── ペイロード組立 ─────────────────────────────
@@ -808,6 +871,9 @@ export class ItemKeeperIntegration {
    * @returns {Promise<{ok:boolean,status?:number,error?:string,skipped?:boolean}>}
    */
   async sendSnapshot({ trigger, host } = {}) {
+    // ★ リレー子(readonly/satellite)は ItemKeeper へ送信しない（送信元は親のみ＝重複報告防止）。
+    //   子は親設定をミラーするだけ。standalone/parent のみがここから送る。
+    if (_isRelayChild()) return { ok: false, skipped: "relay-child" };
     const s = this.settings;
     if (!s.enabled) return { ok: false, skipped: true };
     const endpoint = this.normalizeEndpoint(s.endpoint);
@@ -987,6 +1053,8 @@ export class ItemKeeperIntegration {
    */
   _restartIntervalTimer() {
     if (this._intervalTimer) { clearInterval(this._intervalTimer); this._intervalTimer = null; }
+    // ★ リレー子は定期送信もしない（送信元は親のみ）。
+    if (_isRelayChild()) return;
     const s = this.settings;
     if (!s.enabled || !s.onInterval) return;
     const min = (Number(s.intervalMin) > 0) ? Number(s.intervalMin) : 5;
@@ -1257,6 +1325,27 @@ export class ItemKeeperIntegration {
     // 変更を破棄してキャンセル（明示操作なので確認なしで即破棄）
     const cancelBtn = q('[data-role="ext-cancel"]');
     if (cancelBtn) cancelBtn.addEventListener("click", () => { this._dirty = false; this._closeModal(); });
+
+    // ★ リレーモードに応じた ItemKeeper 節の編集可否:
+    //   readonly(閲覧専用ミラー) = ItemKeeper 入力を無効化し注意書きを出す（親で設定）。
+    //   satellite(操作) = 編集可。保存は _commitModal が親へ逆反映する。
+    //   parent/standalone = 従来どおり編集可・ローカル保存。
+    if (_relayMode() === "readonly") {
+      const ikBody = q('[data-role="ik-body"]');
+      if (ikBody) {
+        ikBody.querySelectorAll('input, select, textarea, button[data-role="ik-test"]')
+          .forEach(el => { el.disabled = true; });
+        container.querySelectorAll('[data-ik-alias], [data-ik-enabled], [data-ik-camera]')
+          .forEach(el => { el.disabled = true; });
+        if (!ikBody.querySelector('[data-role="ik-readonly-note"]')) {
+          const note = document.createElement("div");
+          note.setAttribute("data-role", "ik-readonly-note");
+          note.style.cssText = "margin:0 0 8px;padding:6px 8px;border-radius:4px;background:#fff5e6;border:1px solid #f0c674;font-size:11px;color:#a06a00;";
+          note.textContent = "閲覧専用（ミラー）：ItemKeeper 連携の設定は親機（デスクトップ）で変更してください。ここでは編集・送信できません。";
+          ikBody.insertBefore(note, ikBody.firstChild);
+        }
+      }
+    }
   }
 
   /** @private モーダルの DOM 値を確定し永続化する（保存して戻る） */
@@ -1308,8 +1397,22 @@ export class ItemKeeperIntegration {
       if (t) t.ikCamera = chk.checked;
     });
 
-    // 永続化（即時フラッシュ＝即反映）
-    this.persist();
+    // ★ リレーモードで ItemKeeper 設定の保存先を分岐:
+    //   - satellite : 親へ relay-settings RPC で逆反映（親が確定保存→delta で全子ミラー）。
+    //                 子はローカル確定しない（webhook/機器のローカル変更だけ flush）。
+    //   - readonly  : ItemKeeper は親ミラー（編集不可）＝確定しない。webhook/機器のみ flush。
+    //   - parent/standalone: 従来どおりローカル確定保存（即時フラッシュ＝即反映）。
+    const mode = _relayMode();
+    if (mode === "satellite") {
+      if (typeof window !== "undefined" && window.sendRelaySettings) {
+        window.sendRelaySettings({ ...this.settings });
+      }
+      saveUnifiedStorage(true);
+    } else if (mode === "readonly") {
+      saveUnifiedStorage(true);
+    } else {
+      this.persist();
+    }
   }
 
   /**

--- a/3dp_lib/dashboard_relay_bridge.js
+++ b/3dp_lib/dashboard_relay_bridge.js
@@ -43,6 +43,9 @@ let _prevSharedHash = "";
 /** 前回ブロードキャストした mountHistory（ADR-0004 台帳）のハッシュ（変更検出） */
 let _prevMountHash = "";
 
+/** 前回ブロードキャストした ItemKeeper 設定のハッシュ（変更検出） */
+let _prevIkHash = "";
+
 /** 前回ブロードキャスト時の各ホストの印刷履歴(printStore)ハッシュ */
 const _prevPrintHash = new Map();
 
@@ -88,6 +91,16 @@ export function initRelayBridge() {
   window.electronAPI.onRelayFilament?.(async (data) => {
     console.debug(`[relay-bridge] 子からフィラメント操作受信:`, data.action);
     await handleRelayFilamentAction(data.action, data.data || {});
+  });
+
+  // ★ satellite からの ItemKeeper 設定変更を親で受領 → 親が唯一の設定元として確定保存。
+  //   確定後は次回 relay-delta(appSettingsItemkeeper)で全子へ還流しミラーが揃う。
+  window.electronAPI.onRelaySettings?.((data) => {
+    const ik = data?.payload?.itemkeeper;
+    if (ik && typeof ik === "object") {
+      console.debug("[relay-bridge] satellite から ItemKeeper 設定受信");
+      window.itemKeeperIntegration?.applyRemoteSettings?.(ik);
+    }
   });
 
   // 新規子クライアントからのスナップショット要求
@@ -426,6 +439,16 @@ function _buildDelta() {
     hasChanges = true;
   }
 
+  // ★ ItemKeeper 設定の変更検出（親で変更 or satellite からの逆反映時のみ送る）。
+  //   子はこれを受けて自身の itemKeeperIntegration を親設定で再読込（ミラー）する。
+  const ikHash = _quickHash(monitorData.appSettings.itemkeeper || {});
+  if (ikHash !== _prevIkHash) {
+    _prevIkHash = ikHash;
+    sharedDelta = sharedDelta || {};
+    sharedDelta.appSettingsItemkeeper = monitorData.appSettings.itemkeeper || {};
+    hasChanges = true;
+  }
+
   if (!hasChanges) return null;
 
   const delta = { machines: machinesDelta, shared: sharedDelta };
@@ -477,7 +500,10 @@ function _buildFullSnapshot() {
     hostSpoolMap: monitorData.hostSpoolMap,
     mountHistory: monitorData.mountHistory || [],
     appSettings: {
-      connectionTargets: monitorData.appSettings.connectionTargets || []
+      connectionTargets: monitorData.appSettings.connectionTargets || [],
+      // ★ ItemKeeper 連携設定を子へミラー（親が唯一の設定元・送信元）。
+      //   子(readonly=閲覧専用ミラー / satellite=編集可だが変更は relay-settings で親へ逆反映)。
+      itemkeeper: monitorData.appSettings.itemkeeper || {}
     }
   };
 }

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <!-- ★ app-version: ビルド時に scripts/sync-version.js が package.json から自動更新する -->
-  <meta name="app-version" content="2.2.1030" />
-  <title>3dpmon - 3Dプリンタ監視ダッシュボード v2.2.1030</title>
+  <meta name="app-version" content="2.2.1031" />
+  <title>3dpmon - 3Dプリンタ監視ダッシュボード v2.2.1031</title>
   <!-- サイトアイコン -->
   <link rel="icon" href="favicon.ico">
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v2.2.1031 (2026-06-20)
+
+### ItemKeeper 連携設定をリレー親子で同期（サテライト/閲覧専用のミラー＋逆反映、送信は親のみ）
+
+#### 修正（不具合）
+- **デスクトップ本体とブラウザ画面で ItemKeeper 設定が共有されず「保存しても消える」ように見える問題を解消。** 原因は両者が別オリジン（`file://` と `http://localhost:5313`）で IndexedDB が分離していたため。保存自体は全環境で正常だが、片方で設定してももう片方には反映されなかった。
+  - **リレー親 → 子へ設定をミラー配信**: relay-snapshot / relay-delta に `appSettings.itemkeeper` を追加。子（readonly/satellite）は受信して自身の表示を親に揃える。
+  - **閲覧専用（readonly）= 読み取りミラー**: ItemKeeper 設定欄を無効化し「親機で設定してください」の注意書きを表示。
+  - **操作（satellite）= 編集可・親へ逆反映**: 子で保存すると新 RPC `relay-settings` で親へ委譲。親が唯一の設定元として確定保存し、次回 delta で全子へ還流（往復同期）。
+  - **送信元は親（とスタンドアロン）のみ**: リレー子は ItemKeeper への送信・定期送信を行わない（`window._3dpmonRelayChild` ガード）＝重複報告を防止。
+  - スタンドアロンは従来どおり独立設定を維持。
+
+#### テスト
+- 全724テスト緑（新規8: 送信ガード/定期タイマー抑止/applyRemoteSettings/readonly無効化・注意書き/satellite RPC ルーティング/parent ローカル保存）。touched 3dp_lib は eslint 0 error。**実機検証済**（親→readonly子ミラー・satellite 自動昇格→RPC→親確定→子へ還流の往復、CDP 実測）。
+
+---
+
 ## v2.2.1030 (2026-06-20)
 
 ### ItemKeeper 連携: フィラメント更新履歴の添付オプション（spools[] レジストリ＋装着/切れ交換イベント）

--- a/docs/develop/itemkeeper-integration-specification.md
+++ b/docs/develop/itemkeeper-integration-specification.md
@@ -367,6 +367,14 @@ X-IK-Signature:  sha256={hex}            // HMAC-SHA256(secret, `${X-IK-Timestam
 ### 6.6 3dpmon が必ず載せるべきフィールド
 解析は ItemKeeper 側が行うが、それには **`deviceKey`/`device`、`job.filename`+`job.filemd5`、`filaments[].{material,colorHex,spoolId,usedMm}`** が要。**欠かさず載せる**こと。
 
+### 6.7 リレー親子での設定同期（v2.2.1031〜）
+ItemKeeper 設定（`appSettings.itemkeeper`）は **親（デスクトップ `file://`）が唯一の権威**として保持・送信する。ブラウザ画面はオリジンが異なり IndexedDB が分離するため、以下で親子の表示と送信元を一致させる。
+- **親 → 子ミラー**: relay-snapshot / relay-delta に `appSettings.itemkeeper` を含める。子は受信して `monitorData.appSettings.itemkeeper` を置換し `itemKeeperIntegration.loadSettings()` で自身を再構築する。
+- **readonly（閲覧専用）**: 設定欄は無効化＝読み取りミラー。
+- **satellite（操作）**: 編集可。保存は新 RPC `relay-settings`（`{type:"relay-settings", payload:{itemkeeper}}`）で親へ委譲。親が `applyRemoteSettings()` で確定保存し、次回 delta で全子へ還流する（往復同期）。readonly からの `relay-settings` はサーバ側ガードで拒否。
+- **送信元**: ItemKeeper への POST・定期送信は **親とスタンドアロンのみ**。リレー子（readonly/satellite）は `window._3dpmonRelayChild` ガードで送信しない＝重複報告を防ぐ。
+- **standalone（`?relay=standalone`）**: リレー子ではなく独立クライアント。自身の設定を独自に保持・送信する（同期対象外）。
+
 ---
 
 ## 7. レスポンス契約と再送判断

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -137,6 +137,14 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onRelayFilament: (callback) => ipcRenderer.on("relay-filament", (_, data) => callback(data)),
 
   /**
+   * リレー経由の外部連携設定変更（satellite→親）を受信するリスナーを登録する。
+   * 親レンダラーが ItemKeeper 設定を確定保存し、次回 delta で全子へ還流する。
+   *
+   * @param {Function} callback - (data: {payload}) => void
+   */
+  onRelaySettings: (callback) => ipcRenderer.on("relay-settings", (_, data) => callback(data)),
+
+  /**
    * リレー経由のスナップショット要求を受信するリスナーを登録する。
    *
    * @param {Function} callback - (data: {clientId}) => void

--- a/electron/relay_server.js
+++ b/electron/relay_server.js
@@ -239,6 +239,14 @@ function _handleClientMessage(client, msg) {
       }
       break;
 
+    case "relay-settings":
+      // ★ ItemKeeper 等の外部連携設定変更の中継: satellite → 親レンダラー。
+      //   readonly はここに到達しない（上の readonly ガードで弾かれる＝閲覧専用ミラー）。
+      if (_sendToRenderer && msg.payload) {
+        _sendToRenderer("relay-settings", { payload: msg.payload });
+      }
+      break;
+
     case "relay-ping":
       _safeSend(client.ws, { type: "relay-pong", timestamp: Date.now() });
       break;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "3dpmon",
-  "version": "2.2.1030",
+  "version": "2.2.1031",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "3dpmon",
-      "version": "2.2.1030",
+      "version": "2.2.1031",
       "license": "BSD-3-Clause",
       "dependencies": {
         "gridstack": "^10.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3dpmon",
-  "version": "2.2.1030",
+  "version": "2.2.1031",
   "description": "3Dプリンタ監視ダッシュボード - Electron版",
   "main": "electron/main.js",
   "scripts": {

--- a/tests/unit/dashboard_integration_itemkeeper.test.js
+++ b/tests/unit/dashboard_integration_itemkeeper.test.js
@@ -8,7 +8,7 @@
  * 依存モジュールは全て vi.doMock でモックする（dashboard_notification_manager は
  * モジュール読込時に document へ触れるため node 環境では必ずモックすること）。
  */
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 /** モック monitorData */
 const mockMonitorData = {
@@ -583,5 +583,46 @@ describe("フィラメント更新履歴添付 (attachFilamentHistory)", () => {
     const fil = newIK().buildFilaments(job({ id: 5, filamentInfo: [{ spoolId: "s1", usedMm: 100, spoolName: "緑PLA" }] }));
     expect(fil[0].serialDisplay).toBe("#001"); // mockSpools s1 serialNo=1
     expect(fil[0].name).toBe("緑PLA");
+  });
+});
+
+describe("リレー子ガード／親逆反映 (relay mirror)", () => {
+  afterEach(() => { delete globalThis.window; });
+
+  it("リレー子(window._3dpmonRelayChild=true)では sendSnapshot が送信せずスキップ", async () => {
+    globalThis.window = { _3dpmonRelayChild: true };
+    const ik = newIK({ enabled: true, endpoint: "x.com", clientId: "c", secret: "s", onStart: true });
+    const r = await ik.sendSnapshot({ trigger: "print.started", host: "k1" });
+    expect(r.skipped).toBe("relay-child");
+  });
+
+  it("parent/standalone(window未設定)では sendSnapshot のガードを通過する", async () => {
+    // window 無し（node）＝ _isRelayChild()=false。enabled だが endpoint 不足で別理由 skip になることを確認
+    const ik = newIK({ enabled: true, endpoint: "", clientId: "", secret: "" });
+    const r = await ik.sendSnapshot({ trigger: "print.started", host: "k1" });
+    expect(r.skipped).toBe(true);   // relay-child ではなく endpoint 不足の skip
+    expect(r.skipped).not.toBe("relay-child");
+  });
+
+  it("リレー子では定期送信タイマーを起動しない", () => {
+    globalThis.window = { _3dpmonRelayChild: true };
+    const ik = newIK({ enabled: true, onInterval: true, intervalMin: 1 });
+    ik._restartIntervalTimer();
+    expect(ik._intervalTimer).toBeNull();
+  });
+
+  it("applyRemoteSettings は satellite の設定を親で確定保存する", () => {
+    const ik = newIK();
+    ik.applyRemoteSettings({
+      enabled: true, endpoint: "ik.example.com", clientId: "c", secret: "s",
+      attachState: true, attachFiles: true, attachFilamentHistory: true
+    });
+    expect(ik.settings.enabled).toBe(true);
+    expect(ik.settings.attachState).toBe(true);
+    expect(ik.settings.attachFilamentHistory).toBe(true);
+    expect(ik.settings.encoding).toBe("none");
+    // persist で monitorData へ書き込まれる（次回 relay-delta で子へミラー還流する元）
+    expect(mockMonitorData.appSettings.itemkeeper.attachState).toBe(true);
+    expect(mockMonitorData.appSettings.itemkeeper.attachFilamentHistory).toBe(true);
   });
 });

--- a/tests/unit/dashboard_integration_itemkeeper_modal.test.js
+++ b/tests/unit/dashboard_integration_itemkeeper_modal.test.js
@@ -6,7 +6,7 @@
  * DOM を使うため jsdom 環境で実行する。
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 const mockMonitorData = {
   machines: {},
@@ -282,5 +282,62 @@ describe("破棄確認 (requestCloseExternal・共通confirm)", () => {
     keepBtn.click();
     await p;
     expect(document.getElementById("external-modal-overlay").classList.contains("open")).toBe(true);
+  });
+});
+
+describe("リレーモード別の編集可否 (readonly/satellite)", () => {
+  afterEach(() => {
+    delete window.getRelayMode; delete window.sendRelaySettings; delete window._3dpmonRelayChild;
+    mockMonitorData.appSettings.itemkeeper = {};
+  });
+
+  it("readonly: ItemKeeper入力が無効化され注意書きが出る", () => {
+    window.getRelayMode = () => "readonly";
+    window._3dpmonRelayChild = true;
+    const ik = new ItemKeeperIntegration();
+    ik.settings.enabled = true;
+    const c = openModal(ik);
+    expect(c.querySelector('[data-role="ik-readonly-note"]')).toBeTruthy();
+    expect(c.querySelector('[data-role="ik-attach-state"]').disabled).toBe(true);
+    expect(c.querySelector('[data-role="ik-endpoint"]').disabled).toBe(true);
+    expect(c.querySelector('[data-role="ik-enabled"]').disabled).toBe(true);
+  });
+
+  it("satellite: ItemKeeper入力は編集可・注意書きは出ない", () => {
+    window.getRelayMode = () => "satellite";
+    window._3dpmonRelayChild = true;
+    const ik = new ItemKeeperIntegration();
+    ik.settings.enabled = true;
+    const c = openModal(ik);
+    expect(c.querySelector('[data-role="ik-attach-state"]').disabled).toBe(false);
+    expect(c.querySelector('[data-role="ik-readonly-note"]')).toBeFalsy();
+  });
+
+  it("satellite: 保存は親へ relay-settings RPC で逆反映しローカル確定しない", () => {
+    window.getRelayMode = () => "satellite";
+    window._3dpmonRelayChild = true;
+    window.sendRelaySettings = vi.fn();
+    mockMonitorData.appSettings.itemkeeper = {};
+    const ik = new ItemKeeperIntegration();
+    ik.settings.enabled = true;
+    const c = openModal(ik);
+    c.querySelector('[data-role="ik-attach-state"]').checked = true;
+    c.querySelector('[data-role="ik-attach-filhistory"]').checked = true;
+    ik._commitModal(c);
+    expect(window.sendRelaySettings).toHaveBeenCalledTimes(1);
+    const sent = window.sendRelaySettings.mock.calls[0][0];
+    expect(sent.attachState).toBe(true);
+    expect(sent.attachFilamentHistory).toBe(true);
+    // 子はローカル確定しない（親が確定→delta でミラー還流）
+    expect(mockMonitorData.appSettings.itemkeeper.attachState).toBeUndefined();
+  });
+
+  it("parent(モード未設定): 従来どおりローカル確定保存する", () => {
+    const ik = new ItemKeeperIntegration();
+    ik.settings.enabled = true;
+    const c = openModal(ik);
+    c.querySelector('[data-role="ik-attach-state"]').checked = true;
+    ik._commitModal(c);
+    expect(mockMonitorData.appSettings.itemkeeper.attachState).toBe(true);
   });
 });


### PR DESCRIPTION
main を feature/v2.2.1011-relay-ui-filament へ定期同期（毎リリースごと）。v2.2.1031（ItemKeeper設定のリレー親子同期）を取り込む。サーバ側マージで feature ツリーを main(44ec284) に揃える。

🤖 Generated with [Claude Code](https://claude.com/claude-code)