### PR TITLE
sync: main → feature (v2.2.1032 storage namespace split)

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -35,8 +35,10 @@
 import {
   initStorage,
   restoreUnifiedStorage,
-  saveUnifiedStorage
+  saveUnifiedStorage,
+  setStorageNamespace
 } from "./dashboard_storage.js";
+import { setPanelLayoutNamespace } from "./dashboard_panel_factory.js";
 import {
   PLACEHOLDER_HOSTNAME,
   monitorData,
@@ -64,6 +66,27 @@ import { initAboutDialogListener } from "./dashboard_about.js";
  */
 export async function initializeDashboard() {
   // (1) ★ currentHostname / PLACEHOLDER 設定は廃止済み。per-host 処理のみ使用。
+
+  // (1.5) ★ ストレージ初期化より前にリレーモードを判定し、名前空間を設定する。
+  //   理由: 同一ブラウザ内の readonly/satellite と ?relay=standalone はクエリ違い
+  //   だけで origin が同じ(http://host:port)ため、IndexedDB/localStorage を共有する。
+  //   旧実装はこれを「ブラウザ画面はオリジンが異なり IDB が分離する」と誤認しており、
+  //   readonly が relay-snapshot で受けた親由来データを autoSave で共有DBに書き戻し、
+  //   後で開く standalone の永続データを破壊する不具合があった(v2.2.1031 spec §6.7
+  //   の前提崩れ)。リレー子では DB を "3dpmon-relay" 等へ切り替えて物理分離する。
+  //   detectRelayMode は dashboard_client_sync.js から動的 import で取得する
+  //   (テスト環境(node)で client_sync の重い依存を読み込まない方針を維持)。
+  let _earlyRelayMode = "standalone";
+  try {
+    const { detectRelayMode } = await import("./dashboard_client_sync.js");
+    _earlyRelayMode = detectRelayMode();
+  } catch (e) {
+    console.debug("[init] detectRelayMode スキップ:", e.message);
+  }
+  const _storageNs = (_earlyRelayMode === "readonly" || _earlyRelayMode === "satellite")
+    ? "relay" : "";
+  setStorageNamespace(_storageNs);
+  setPanelLayoutNamespace(_storageNs);
 
   // (2) ストレージ復元／マイグレーション
   await initStorage();            // IndexedDB 初期化（localStorage からの自動マイグレーション含む）

--- a/3dp_lib/dashboard_panel_factory.js
+++ b/3dp_lib/dashboard_panel_factory.js
@@ -48,12 +48,29 @@ import { registerFieldElements, unregisterFieldElements } from "./dashboard_ui.j
 /* ─── localStorage キー ─── */
 
 /**
- * レイアウト保存用の localStorage キー
- * @constant {string}
+ * レイアウト保存用の localStorage キー (既定値)。
+ *
+ * リレー子(readonly/satellite)では setPanelLayoutNamespace() で
+ * "3dpmon_panel_layout_v5_relay" 等に切り替わり、同一ブラウザ内の
+ * standalone とパネルレイアウトを物理分離する。
+ *
+ * @type {string}
  */
-const LAYOUT_STORAGE_KEY = "3dpmon_panel_layout_v5";
+let LAYOUT_STORAGE_KEY = "3dpmon_panel_layout_v5";
 // ★ v2.2.0: レイアウト v2→v3→v5 マイグレーションコードは削除。
 //   v2.1.017 LTS が最終移行ポイント。
+
+/**
+ * パネルレイアウトの localStorage キーに名前空間サフィックスを付与する。
+ * **必ず restoreLayout/saveLayout より前に呼ぶこと**。
+ *
+ * @param {string} ns - 名前空間("" | "relay" 等)
+ * @returns {void}
+ */
+export function setPanelLayoutNamespace(ns) {
+  const base = "3dpmon_panel_layout_v5";
+  LAYOUT_STORAGE_KEY = (typeof ns === "string" && ns.length > 0) ? `${base}_${ns}` : base;
+}
 
 /* ─── パネル種別定義 ─── */
 

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -49,7 +49,8 @@ import {
   queueMachineWrite,
   flushIdb,
   exportAllIdb,
-  importAllIdb
+  importAllIdb,
+  setIdbDbName
 } from "./dashboard_storage_idb.js";
 
 let _enableStorageLog = false;
@@ -561,10 +562,49 @@ function pushLog(msg, isErr = false) {
  */
 // ★ STORAGE_KEY ("3dp-monitor_1.400") は v2.2.0 で削除。v2.1.017 LTS が最終移行ポイント。
 
-/** per-host localStorage 分割キー: グローバルデータ用 */
-const LS_KEY_GLOBAL = "3dpmon-global";
-/** per-host localStorage 分割キー: ホスト別データの接頭辞 */
-const LS_KEY_HOST_PREFIX = "3dpmon-host-";
+/**
+ * per-host localStorage 分割キー: グローバルデータ用 (既定値)。
+ *
+ * リレー子(readonly/satellite)では setStorageNamespace() により
+ * "3dpmon-relay-global" 等へ切り替わる。
+ *
+ * @type {string}
+ */
+let LS_KEY_GLOBAL = "3dpmon-global";
+
+/**
+ * per-host localStorage 分割キー: ホスト別データの接頭辞 (既定値)。
+ * setStorageNamespace() で "3dpmon-relay-host-" 等へ切り替わる。
+ *
+ * @type {string}
+ */
+let LS_KEY_HOST_PREFIX = "3dpmon-host-";
+
+/**
+ * ストレージの名前空間を設定する。**必ず {@link initStorage} の前に呼ぶこと**。
+ *
+ * 【背景】
+ * v2.2.1031 spec §6.7 は「親(file://) と ブラウザ(http://) はオリジン差で
+ * IndexedDB が分離される」前提だったが、同一ブラウザ内の readonly と
+ * ?relay=standalone はクエリ違いで origin が同じため IDB/LS を共有してしまう。
+ * その結果、readonly が relay-snapshot で受けた親由来データを autoSave で
+ * 共有ストレージに書き戻し、後から開く standalone の永続データを破壊する。
+ *
+ * 【挙動】
+ * - 既定 (空文字 / "") : DB="3dpmon", LS="3dpmon-global"/"3dpmon-host-"
+ *   → 親(file://) と standalone(http://) で従来通り。
+ * - "relay" : DB="3dpmon-relay", LS="3dpmon-relay-global"/"3dpmon-relay-host-"
+ *   → readonly/satellite 専用。同一ブラウザ内の standalone と物理分離される。
+ *
+ * @param {string} ns - 名前空間("" | "relay" 等)
+ * @returns {void}
+ */
+export function setStorageNamespace(ns) {
+  const prefix = (typeof ns === "string" && ns.length > 0) ? `3dpmon-${ns}` : "3dpmon";
+  LS_KEY_GLOBAL = `${prefix}-global`;
+  LS_KEY_HOST_PREFIX = `${prefix}-host-`;
+  setIdbDbName(prefix);
+}
 
 /** localStorage 用に保存可能なグローバルフィールド名一覧 */
 const LS_GLOBAL_FIELDS = [

--- a/3dp_lib/dashboard_storage_idb.js
+++ b/3dp_lib/dashboard_storage_idb.js
@@ -37,10 +37,51 @@
 // 定数
 // ==============================
 
-const DB_NAME    = "3dpmon";
+/**
+ * 既定の IndexedDB 名。
+ *
+ * 親(Electron file://) と standalone(?relay=standalone) は同一オリジン上では
+ * このDBを使う(file:// と http:// はブラウザの origin 規則で自動分離されるため、
+ * 同名でも互いの DB は物理的に別)。一方、同一ブラウザ内の readonly/satellite は
+ * クエリ違いでオリジンが同じため、setIdbDbName() で別名("3dpmon-relay")へ
+ * 切り替えてリレー子の永続データを standalone と物理分離する。
+ *
+ * 旧仕様では DB 名固定 ("3dpmon") のため、ブラウザで readonly を一度開くと
+ * 親由来の relay-snapshot で上書きされた monitorData が autoSave で同じDBに
+ * 書き戻され、後で ?relay=standalone を開くと standalone の永続データが
+ * 物理的に破壊される問題があった(v2.2.1031 spec §6.7 の前提が崩れていた)。
+ *
+ * @constant {string}
+ */
+const DEFAULT_DB_NAME = "3dpmon";
+
+/** 現在の IndexedDB 名 (setIdbDbName で初期化前に切替可能) */
+let _dbName = DEFAULT_DB_NAME;
+
 const DB_VERSION = 1;
 const STORE_SHARED   = "shared";
 const STORE_MACHINES = "machines";
+
+/**
+ * IndexedDB の DB 名を設定する。**必ず {@link initIdb} の前に呼ぶこと**。
+ *
+ * リレー子(readonly/satellite)では "3dpmon-relay" 等を渡して standalone と
+ * 物理分離する。空文字/undefined を渡すと既定値("3dpmon")へ戻る。
+ *
+ * @param {string} name - DB 名(例: "3dpmon" / "3dpmon-relay")
+ * @returns {void}
+ */
+export function setIdbDbName(name) {
+  _dbName = (typeof name === "string" && name.length > 0) ? name : DEFAULT_DB_NAME;
+}
+
+/**
+ * 現在設定されている IndexedDB 名を返す。
+ * @returns {string}
+ */
+export function getIdbDbName() {
+  return _dbName;
+}
 
 // ★ LS_KEY ("3dp-monitor_1.400") は v2.2.0 で削除。マイグレーション不要。
 
@@ -303,7 +344,7 @@ export async function importAllIdb(data) {
  */
 function _openDatabase() {
   return new Promise((resolve, reject) => {
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    const req = indexedDB.open(_dbName, DB_VERSION);
 
     req.onupgradeneeded = (event) => {
       const db = event.target.result;

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <!-- ★ app-version: ビルド時に scripts/sync-version.js が package.json から自動更新する -->
-  <meta name="app-version" content="2.2.1031" />
-  <title>3dpmon - 3Dプリンタ監視ダッシュボード v2.2.1031</title>
+  <meta name="app-version" content="2.2.1032" />
+  <title>3dpmon - 3Dプリンタ監視ダッシュボード v2.2.1032</title>
   <!-- サイトアイコン -->
   <link rel="icon" href="favicon.ico">
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v2.2.1032 (2026-06-28)
+
+### ブラウザ standalone と リレー子(readonly/satellite)の永続データを物理分離（IndexedDB / localStorage を別名前空間化）
+
+#### 修正（不具合）
+- **`http://<host>:5313/?relay=standalone` で保存した設定が、同じブラウザで `http://<host>:5313/`（readonly 既定）を開くたびに親由来データで上書きされ、消滅する不具合を根本修正。**
+  - 原因: v2.2.1031 spec §6.7 は「親(`file://`)とブラウザ(`http://`)はオリジンが異なるため IndexedDB が分離される」前提だったが、**同一ブラウザ内の `?relay=standalone` と既定の readonly はクエリ違いだけで origin が同じ**（`http://host:5313`）。よって IDB / localStorage を共有し、readonly が relay-snapshot で受けた親由来 `monitorData` を autoSave で同じDBへ書き戻して standalone の永続データを破壊していた。
+  - 修正: リレー子（readonly/satellite）モードで起動した時のみ、ストレージ初期化前に名前空間を `"relay"` へ切り替える。
+    - IndexedDB DB 名: `"3dpmon"`（親/standalone）→ `"3dpmon-relay"`（リレー子）
+    - localStorage 全体キー: `"3dpmon-global"` / `"3dpmon-host-*"` → `"3dpmon-relay-global"` / `"3dpmon-relay-host-*"`
+    - パネルレイアウト: `"3dpmon_panel_layout_v5"` → `"3dpmon_panel_layout_v5_relay"`
+  - 結果: 同一ブラウザの standalone とリレー子は **物理的に別DB／別LSキー** に書き出されるため、もう互いに上書きしない。spec §6.7 の「standalone は独立設定を維持」が実体化される。
+  - 親(Electron `file://`) と standalone(`http://`) は従来通り origin 差で自動分離される（DB 名は両方 `"3dpmon"` のままで後方互換）。
+
+#### テスト
+- 全728テスト緑（新規4: 既定/relay切替時のDB名・LSキー検証、相互非干渉、復元時の分離）。touched 3dp_lib は eslint 0 error。spec §6.7 を改訂。
+
+---
+
 ## v2.2.1031 (2026-06-20)
 
 ### ItemKeeper 連携設定をリレー親子で同期（サテライト/閲覧専用のミラー＋逆反映、送信は親のみ）

--- a/docs/develop/itemkeeper-integration-specification.md
+++ b/docs/develop/itemkeeper-integration-specification.md
@@ -367,13 +367,27 @@ X-IK-Signature:  sha256={hex}            // HMAC-SHA256(secret, `${X-IK-Timestam
 ### 6.6 3dpmon が必ず載せるべきフィールド
 解析は ItemKeeper 側が行うが、それには **`deviceKey`/`device`、`job.filename`+`job.filemd5`、`filaments[].{material,colorHex,spoolId,usedMm}`** が要。**欠かさず載せる**こと。
 
-### 6.7 リレー親子での設定同期（v2.2.1031〜）
-ItemKeeper 設定（`appSettings.itemkeeper`）は **親（デスクトップ `file://`）が唯一の権威**として保持・送信する。ブラウザ画面はオリジンが異なり IndexedDB が分離するため、以下で親子の表示と送信元を一致させる。
+### 6.7 リレー親子での設定同期（v2.2.1031〜、v2.2.1032 で永続層を物理分離）
+ItemKeeper 設定（`appSettings.itemkeeper`）は **親（デスクトップ `file://`）が唯一の権威**として保持・送信する。以下で親子の表示と送信元を一致させる。
 - **親 → 子ミラー**: relay-snapshot / relay-delta に `appSettings.itemkeeper` を含める。子は受信して `monitorData.appSettings.itemkeeper` を置換し `itemKeeperIntegration.loadSettings()` で自身を再構築する。
 - **readonly（閲覧専用）**: 設定欄は無効化＝読み取りミラー。
 - **satellite（操作）**: 編集可。保存は新 RPC `relay-settings`（`{type:"relay-settings", payload:{itemkeeper}}`）で親へ委譲。親が `applyRemoteSettings()` で確定保存し、次回 delta で全子へ還流する（往復同期）。readonly からの `relay-settings` はサーバ側ガードで拒否。
 - **送信元**: ItemKeeper への POST・定期送信は **親とスタンドアロンのみ**。リレー子（readonly/satellite）は `window._3dpmonRelayChild` ガードで送信しない＝重複報告を防ぐ。
 - **standalone（`?relay=standalone`）**: リレー子ではなく独立クライアント。自身の設定を独自に保持・送信する（同期対象外）。
+
+#### 6.7.1 ストレージ分離（v2.2.1032〜）
+親(`file://`) と ブラウザ(`http://host:5313`) のオリジン差で IndexedDB は自動分離されるが、**同一ブラウザ内の `?relay=standalone` と既定の readonly はクエリ違いだけで origin が同じため IDB / localStorage を共有してしまう**（v2.2.1031 までの暗黙の前提崩れ）。readonly が relay-snapshot で受けた親由来 `monitorData` を autoSave で同一DBへ書き戻すと、後から開く standalone の永続データが破壊される。
+
+これを防ぐため、リレー子（readonly/satellite）モードで起動した時のみ、ストレージ初期化前に名前空間を `"relay"` へ切り替える（`setStorageNamespace("relay")` + `setPanelLayoutNamespace("relay")`）。具体的には:
+
+| 対象 | 親 / standalone | リレー子(readonly/satellite) |
+|---|---|---|
+| IndexedDB DB 名 | `"3dpmon"` | `"3dpmon-relay"` |
+| localStorage 全体キー | `"3dpmon-global"` | `"3dpmon-relay-global"` |
+| localStorage host 接頭辞 | `"3dpmon-host-"` | `"3dpmon-relay-host-"` |
+| パネルレイアウト LS キー | `"3dpmon_panel_layout_v5"` | `"3dpmon_panel_layout_v5_relay"` |
+
+これにより同一ブラウザ内の standalone とリレー子は **物理的に別DB／別LSキー** に書き出されるため、互いに永続データを上書きしない。親(Electron `file://`) と standalone(`http://`) は従来通り origin 差で自動分離される（両方 `"3dpmon"` のままで後方互換）。
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "3dpmon",
-  "version": "2.2.1031",
+  "version": "2.2.1032",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "3dpmon",
-      "version": "2.2.1031",
+      "version": "2.2.1032",
       "license": "BSD-3-Clause",
       "dependencies": {
         "gridstack": "^10.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3dpmon",
-  "version": "2.2.1031",
+  "version": "2.2.1032",
   "description": "3Dプリンタ監視ダッシュボード - Electron版",
   "main": "electron/main.js",
   "scripts": {

--- a/tests/unit/dashboard_storage_namespace.test.js
+++ b/tests/unit/dashboard_storage_namespace.test.js
@@ -1,0 +1,200 @@
+/**
+ * @file dashboard_storage_namespace.test.js
+ * @description setStorageNamespace() がリレー子と standalone の永続データを
+ *              localStorage / IndexedDB の両層で物理分離することを検証する。
+ *
+ * 背景: v2.2.1031 spec §6.7 の前提("ブラウザはオリジンが異なるため IDB が分離する")
+ * は同一ブラウザ内の ?relay=standalone と readonly では成立しない(クエリ違いで
+ * origin は同じ)。setStorageNamespace("relay") でリレー子側を別 DB / 別 LS キーへ
+ * 切り替え、standalone の永続データを上書きから守る。
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/* ── localStorage スタブ ── */
+class LocalStorageStub {
+  constructor() { this._m = new Map(); }
+  getItem(k) { return this._m.has(k) ? this._m.get(k) : null; }
+  setItem(k, v) { this._m.set(String(k), String(v)); }
+  removeItem(k) { this._m.delete(k); }
+  clear() { this._m.clear(); }
+  key(i) { return Array.from(this._m.keys())[i] ?? null; }
+  get length() { return this._m.size; }
+}
+globalThis.localStorage = new LocalStorageStub();
+
+/* ── monitorData モック ── */
+const monitorData = {
+  appSettings: { connectionTargets: [], itemkeeper: {} },
+  machines: {},
+  filamentSpools: [],
+  usageHistory: [],
+  filamentPresets: [],
+  userPresets: [],
+  hiddenPresets: [],
+  favoritePresets: [],
+  filamentInventory: [],
+  mountHistory: [],
+  filamentEventContext: {},
+  hostSpoolMap: {},
+  hostCameraToggle: {},
+  spoolSerialCounter: 0,
+};
+
+function resetMonitorData() {
+  monitorData.appSettings = { connectionTargets: [], itemkeeper: {} };
+  monitorData.machines = {};
+  monitorData.filamentSpools = [];
+  monitorData.usageHistory = [];
+  monitorData.filamentPresets = [];
+  monitorData.userPresets = [];
+  monitorData.hiddenPresets = [];
+  monitorData.favoritePresets = [];
+  monitorData.filamentInventory = [];
+  monitorData.mountHistory = [];
+  monitorData.filamentEventContext = {};
+  monitorData.hostSpoolMap = {};
+  monitorData.hostCameraToggle = {};
+  monitorData.spoolSerialCounter = 0;
+}
+
+vi.mock('../../3dp_lib/dashboard_data.js', () => ({
+  monitorData,
+  PLACEHOLDER_HOSTNAME: '_$_NO_MACHINE_$_',
+  ensureMachineData: (host) => {
+    if (!monitorData.machines[host]) {
+      monitorData.machines[host] = { storedData: {}, printStore: { history: [], current: null, videos: {} }, runtimeData: {} };
+    }
+  },
+}));
+vi.mock('../../3dp_lib/dashboard_filament_presets.js', () => ({ FILAMENT_PRESETS: [] }));
+vi.mock('../../3dp_lib/dashboard_log_util.js', () => ({ logManager: { add: vi.fn() } }));
+vi.mock('../../3dp_lib/dashboard_utils.js', () => ({ getCurrentTimestamp: () => 0 }));
+vi.mock('../../3dp_lib/dashboard_filament_ledger.js', () => ({ initLedgerAnchors: () => ({ seeded: 0 }) }));
+
+/* IDB は実装の setIdbDbName 呼び出しを spy できる本物のモジュールを使う(LS 経路は無効化) */
+const _idbDbNameCalls = [];
+vi.mock('../../3dp_lib/dashboard_storage_idb.js', () => ({
+  initIdb: vi.fn(), isIdbAvailable: () => false, getIdbCache: () => null,
+  queueSharedWrite: vi.fn(), queueMachineWrite: vi.fn(), flushIdb: vi.fn(),
+  exportAllIdb: vi.fn(), importAllIdb: vi.fn(),
+  setIdbDbName: vi.fn((name) => { _idbDbNameCalls.push(name); }),
+  getIdbDbName: () => _idbDbNameCalls[_idbDbNameCalls.length - 1] || '3dpmon',
+}));
+
+const { saveUnifiedStorage, restoreUnifiedStorage, setStorageNamespace } =
+  await import('../../3dp_lib/dashboard_storage.js');
+
+beforeEach(() => {
+  globalThis.localStorage.clear();
+  _idbDbNameCalls.length = 0;
+  resetMonitorData();
+});
+
+// =============================================================
+// 既定 (standalone / 親) — 3dpmon-global / 3dpmon-host-* に保存
+// =============================================================
+describe('setStorageNamespace 既定(standalone/親)', () => {
+  it('既定では LS キーは "3dpmon-global" / "3dpmon-host-*"、DB 名は "3dpmon"', () => {
+    setStorageNamespace('');
+
+    monitorData.appSettings.itemkeeper = { endpoint: 'https://standalone.example/' };
+    monitorData.machines['HostA'] = {
+      storedData: { x: { rawValue: 1 } },
+      printStore: { history: [], current: null, videos: {} },
+      runtimeData: {},
+    };
+    saveUnifiedStorage(true);
+
+    expect(globalThis.localStorage.getItem('3dpmon-global')).toBeTruthy();
+    expect(globalThis.localStorage.getItem('3dpmon-host-HostA')).toBeTruthy();
+    // relay 系のキーは存在しない
+    expect(globalThis.localStorage.getItem('3dpmon-relay-global')).toBeNull();
+    expect(globalThis.localStorage.getItem('3dpmon-relay-host-HostA')).toBeNull();
+    // IDB 名も既定
+    expect(_idbDbNameCalls).toContain('3dpmon');
+  });
+});
+
+// =============================================================
+// "relay" 名前空間 — 3dpmon-relay-global / 3dpmon-relay-host-* に保存
+// =============================================================
+describe('setStorageNamespace("relay") リレー子', () => {
+  it('LS キーは "3dpmon-relay-global" / "3dpmon-relay-host-*"、DB 名は "3dpmon-relay"', () => {
+    setStorageNamespace('relay');
+
+    monitorData.appSettings.itemkeeper = { endpoint: 'https://parent.example/' };
+    monitorData.machines['HostA'] = {
+      storedData: { y: { rawValue: 2 } },
+      printStore: { history: [], current: null, videos: {} },
+      runtimeData: {},
+    };
+    saveUnifiedStorage(true);
+
+    expect(globalThis.localStorage.getItem('3dpmon-relay-global')).toBeTruthy();
+    expect(globalThis.localStorage.getItem('3dpmon-relay-host-HostA')).toBeTruthy();
+    // 既定キーは触られない
+    expect(globalThis.localStorage.getItem('3dpmon-global')).toBeNull();
+    expect(globalThis.localStorage.getItem('3dpmon-host-HostA')).toBeNull();
+    // IDB 名も relay
+    expect(_idbDbNameCalls).toContain('3dpmon-relay');
+  });
+});
+
+// =============================================================
+// ★ 本丸: standalone が書いたデータをリレー子が上書きしないこと
+// =============================================================
+describe('standalone と relay の物理分離(上書き耐性)', () => {
+  it('standalone で保存 → relay モードへ切替 → relay で別データを保存しても、standalone のデータは残る', () => {
+    // (1) standalone として保存
+    setStorageNamespace('');
+    monitorData.appSettings.itemkeeper = { endpoint: 'https://standalone.example/', clientId: 'sa' };
+    monitorData.appSettings.connectionTargets = [{ dest: '192.168.1.1:9999', hostname: 'StandaloneHost' }];
+    saveUnifiedStorage(true);
+
+    const standaloneGlobalRaw = globalThis.localStorage.getItem('3dpmon-global');
+    expect(standaloneGlobalRaw).toBeTruthy();
+    const standaloneSnapshot = JSON.parse(standaloneGlobalRaw);
+    expect(standaloneSnapshot.appSettings.itemkeeper.endpoint).toBe('https://standalone.example/');
+    expect(standaloneSnapshot.appSettings.connectionTargets[0].dest).toBe('192.168.1.1:9999');
+
+    // (2) relay モードに切替 → 別の(親由来の)データを保存
+    setStorageNamespace('relay');
+    resetMonitorData();
+    monitorData.appSettings.itemkeeper = { endpoint: 'https://parent.example/', clientId: 'parent' };
+    monitorData.appSettings.connectionTargets = [{ dest: '10.0.0.1:9999', hostname: 'ParentHost' }];
+    saveUnifiedStorage(true);
+
+    // (3) standalone 側のキーは無傷
+    const reread = globalThis.localStorage.getItem('3dpmon-global');
+    expect(reread).toBe(standaloneGlobalRaw); // バイト同一
+    const stillStandalone = JSON.parse(reread);
+    expect(stillStandalone.appSettings.itemkeeper.endpoint).toBe('https://standalone.example/');
+    expect(stillStandalone.appSettings.connectionTargets[0].dest).toBe('192.168.1.1:9999');
+
+    // relay 側にはちゃんと parent データが入っている
+    const relayRaw = globalThis.localStorage.getItem('3dpmon-relay-global');
+    const relaySnap = JSON.parse(relayRaw);
+    expect(relaySnap.appSettings.itemkeeper.endpoint).toBe('https://parent.example/');
+    expect(relaySnap.appSettings.connectionTargets[0].dest).toBe('10.0.0.1:9999');
+  });
+
+  it('relay 側で復元しても standalone の monitorData は読まれない(逆も同様)', () => {
+    // standalone 保存
+    setStorageNamespace('');
+    monitorData.appSettings.itemkeeper = { endpoint: 'https://standalone.example/' };
+    saveUnifiedStorage(true);
+
+    // relay 側で復元 → relay の LS は空なので何も復元されない
+    setStorageNamespace('relay');
+    resetMonitorData();
+    restoreUnifiedStorage();
+    // 既定値のまま(standalone の endpoint は混ざらない)
+    expect(monitorData.appSettings.itemkeeper?.endpoint).toBeUndefined();
+
+    // standalone 側で復元 → 元の値が戻る
+    setStorageNamespace('');
+    resetMonitorData();
+    restoreUnifiedStorage();
+    expect(monitorData.appSettings.itemkeeper?.endpoint).toBe('https://standalone.example/');
+  });
+});


### PR DESCRIPTION
## Summary
- v2.2.1032 リリースに伴う毎回同期 PR(規約: [[feedback_sync_feature_every_release]])
- main の最新(`v2.2.1032` 含む)を feature ブランチへ取り込み

## Test plan
- [ ] GitHub サーバ側でマージし、feature を最新の main と一致させる