### PR TITLE
audit P0 Domain-1: 識別性/接続（dest正規化・IP再利用conflict止血・IPv6移行・guard）

### DIFF
--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -1612,7 +1612,10 @@ export function restoreAggregatorState(hostname) {
   // 履歴に反映して UI を即時更新する
   if (historyPersistFunc && s.prevPrintID && s.actualStartEpoch != null) {
     try {
-      historyPersistFunc(s.prevPrintID);
+      // ★ P0-8: 復元経路だけ host 欠落で historyPersistFunc(id) を呼んでおり、
+      //   マルチホストで別ホスト/既定ホストへ履歴が吸着する恐れがあった。
+      //   他の呼び出し(processData 経路)と同じく host を必ず渡す。
+      historyPersistFunc(s.prevPrintID, host);
     } catch (e) {
       console.error("historyPersistFunc error", e);
     }

--- a/3dp_lib/dashboard_camera_ctrl.js
+++ b/3dp_lib/dashboard_camera_ctrl.js
@@ -34,6 +34,7 @@
 
 import { monitorData } from "./dashboard_data.js";
 import { getDeviceIp, getDeviceDest, getPrinterType } from "./dashboard_connection.js";
+import { extractHost } from "./dashboard_target_identity.js";
 import { pushLog }                  from "./dashboard_log_util.js";
 import { notificationManager }      from "./dashboard_notification_manager.js";
 
@@ -257,7 +258,7 @@ export function startCameraStream(hostname) {
     entry.attempts = 0;
     entry.cameraPort = camPort;
     _cancelTimers(entry);
-    _connectStream(entry, ip.split(":")[0]);
+    _connectStream(entry, extractHost(ip));
     return;
   }
 
@@ -272,7 +273,7 @@ export function startCameraStream(hostname) {
   entry.attempts = 0;
   entry.cameraPort = port;
   _cancelTimers(entry);
-  _connectStream(entry, ip.split(":")[0]);
+  _connectStream(entry, extractHost(ip));
 }
 
 /**

--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -64,6 +64,7 @@ import { migratePanelsToHost, renamePanelsHost, ensureHostPanels, removePanelsFo
 import { saveUnifiedStorage } from "./dashboard_storage.js";
 import { showConfirmDialog } from "./dashboard_ui_confirm.js";
 import { createMoonrakerSession, translateK1CommandToMoonraker } from "./dashboard_moonraker.js";
+import { parseDest, normalizeDest, isIpLiteral, extractHost } from "./dashboard_target_identity.js";
 
 // ---------------------------------------------------------------------------
 // 複数プリンタ接続に対応するため、接続状態をホスト名ごとに保持するマップを用意
@@ -165,15 +166,34 @@ function _setConnectionTargetHostname(dest, hostname) {
   }
 
   if (t.hostname && t.hostname !== hostname) {
-    // ★ 同じ dest(IP) で別の hostname が返ってきた → IP再利用（別機器がこのIPを取得）
-    // ★ 既知の制限: 同一 hostname の複数機器が存在する場合、区別不可能。
-    //   ARP で MAC アドレスが取得できれば _resolveAndSaveMac で検出されるが、
-    //   ブラウザ版や ARP 非対応環境ではコンタミネーションを完全には防げない。
-    console.warn(`[_setConnectionTargetHostname] IP再利用検出: ${dest} の hostname が ${t.hostname} → ${hostname} に変化`);
+    // ★ 同じ dest(IP:PORT) で別の hostname が返ってきた → IP再利用（別機器がこのIPを取得）。
+    //   【P0-3 止血】旧機体の label/color/ports が新機体へ寄る事故を防ぐため、
+    //   hostname を即上書きしない。identityStatus="ip-reuse-conflict" を立てて記録し、
+    //   ユーザーへ通知するだけに留める（解消UIは後続P1）。conflict target は
+    //   connectAllSavedTargets で自動接続対象から除外される。
+    //   ※ MAC 変化による強い同一性判定（Electron）はP1で追加予定。現状は全モード共通で
+    //     hostname 変化＝conflict の安全側に倒す。
+    console.warn(`[_setConnectionTargetHostname] IP再利用conflict: ${dest} の hostname ${t.hostname} → ${hostname}（即上書きせず保留）`);
+    t.identityStatus = "ip-reuse-conflict";
+    t.conflict = {
+      previousHostname: t.hostname,
+      reportedHostname: hostname,
+      dest,
+      previousMac: t.macAddress || null
+    };
+    saveUnifiedStorage(true);
+    pushLog(
+      `⚠ 接続先 ${dest} で機体が入れ替わった可能性（${t.hostname} → ${hostname}）。設定を保護し自動接続を保留しました。接続先設定を確認してください。`,
+      "warn", true, hostname
+    );
+    try { showAlert(`接続先 ${dest} の機体同一性に不一致（${t.hostname} → ${hostname}）。設定を保護しました。`, "warn"); } catch { /* noop */ }
+    try { updatePrinterListUI(); } catch { /* noop */ }
+    return;
   }
 
-  // hostname を設定/更新
+  // hostname を設定/更新（初回確定 or 同一hostname）。conflict は上で return 済み。
   t.hostname = hostname;
+  if (t.identityStatus === "ip-reuse-conflict") delete t.identityStatus;
   saveUnifiedStorage();
   // MAC アドレスを非同期で解決（Electron版のみ）
   _resolveAndSaveMac(dest, hostname);
@@ -244,16 +264,8 @@ function _escAttr(s) {
 }
 
 function _extractIp(dest) {
-  if (!dest) return "";
-  // IPv6 bracket notation: [addr]:port
-  const v6Match = dest.match(/^\[([^\]]+)\]/);
-  if (v6Match) return v6Match[1];
-  // IPv4 or hostname: addr:port — 最後のコロン以降がポート
-  const lastColon = dest.lastIndexOf(":");
-  // IPv6 without brackets (multiple colons): return as-is
-  if ((dest.match(/:/g) || []).length > 1) return dest;
-  // IPv4 or hostname:port
-  return lastColon > 0 ? dest.substring(0, lastColon) : dest;
+  // ★ 宛先解析は dashboard_target_identity.parseDest に一本化（IPv4/IPv6/hostname:port）。
+  return extractHost(dest);
 }
 
 function _findConnectionTarget(destOrHost) {
@@ -263,7 +275,7 @@ function _findConnectionTarget(destOrHost) {
   const exact = targets.find(t => t.dest === destOrHost);
   if (exact) return exact;
   /* 2) ポート補完で再検索（"192.168.54.151" → "192.168.54.151:9999"） */
-  if (!destOrHost.includes(":")) {
+  if (!parseDest(destOrHost).hasPort) {
     const withPort = targets.find(t => t.dest === destOrHost + ":" + DEFAULT_WS_PORT);
     if (withPort) return withPort;
   }
@@ -312,7 +324,7 @@ export function connectAllSavedTargets() {
   const destSet = new Set(targets.map(t => t.dest));
   const toRemove = [];
   for (const t of targets) {
-    if (!t.dest.includes(":") || t.dest.split(":").length === 1) {
+    if (!parseDest(t.dest).hasPort) {
       // ポートなし → ポート付きが存在すれば不要
       const withPort = t.dest + ":" + DEFAULT_WS_PORT;
       if (destSet.has(withPort)) {
@@ -329,14 +341,20 @@ export function connectAllSavedTargets() {
     saveUnifiedStorage(true);
   }
 
-  /* connectionTargets を唯一の接続先リストとして使用 */
+  /* connectionTargets を唯一の接続先リストとして使用。
+     ★ P0-1 dedupe は IP 単位ではなく `printerType|normalizedDest` 単位。
+        これにより「同一IP・別ポート」「K1/Moonraker 混在」を両方とも接続候補にできる
+        （旧: IP だけで捨てると同一IP別ポートの片方が落ちていた）。
+     ★ P0-3 ip-reuse-conflict の target は自動接続対象から除外（保留）。 */
   for (const t of targets) {
-    const dest = t.dest.includes(":") ? t.dest : t.dest + ":" + DEFAULT_WS_PORT;
-    const ip = _extractIp(dest);
-    if (!connected.has(ip)) {
-      connected.add(ip);
-      connectWs(dest);
-    }
+    if (t.identityStatus === "ip-reuse-conflict") continue;
+    const defaultPort = t.printerType === "moonraker" ? 80 : DEFAULT_WS_PORT;
+    const parsed = normalizeDest(t.dest, { defaultPort });
+    if (!parsed.ok) continue;
+    const key = `${t.printerType || "creality-k1"}|${parsed.normalizedDest}`;
+    if (connected.has(key)) continue;
+    connected.add(key);
+    connectWs(parsed.normalizedDest);
   }
 }
 
@@ -507,7 +525,9 @@ export function updateConnectionHost(oldHost, newHost) {
      IP → ホスト名 の遷移（初回接続時）のみ移行する。
      ホスト名 → ホスト名 の遷移（IP再利用で別機器が応答）は
      移行せず、旧データを保護して新キーを新規作成する。 */
-  const _isIpLike = (s) => /^\d{1,3}(\.\d{1,3}){3}$/.test(s);
+  // ★ P0-4: IPv4 だけでなく IPv6 リテラルも「一時到達先キー」として hostname へ移行する。
+  //   旧実装は IPv4 regex のみで、IPv6 接続時に IP 一時キーが machines に残留していた。
+  const _isIpLike = (s) => isIpLiteral(s);
   if (monitorData.machines[oldHost] && oldHost !== newHost) {
     if (_isIpLike(oldHost)) {
       // IP → ホスト名: 正常な初回接続 → machines データを移行
@@ -808,7 +828,9 @@ export function connectWs(hostOrDest) {
 
   let dest = hostOrDest || "";
   if (!dest) return;
-  if (!dest.includes(":")) dest += ":" + DEFAULT_WS_PORT;
+  // ★ ポート補完・正規化は normalizeDest に一本化（IPv6 は角括弧化）。
+  const _n = normalizeDest(dest, { defaultPort: DEFAULT_WS_PORT });
+  if (_n.ok && _n.normalizedDest) dest = _n.normalizedDest;
   const ip = _extractIp(dest);
 
   /* 再接続時に正しいホスト名キーを使うため、connectionTargets に保存済みの
@@ -1051,10 +1073,10 @@ function connectMoonraker(dest, host) {
 export function connectWithType(dest, printerType = "creality-k1") {
   let d = (dest || "").trim();
   if (!d) return;
-  /* ポート未指定なら種別ごとの既定ポートを補完（target.dest と connectWs の dest を一致させ重複登録を防ぐ） */
-  if (!d.includes(":")) {
-    d += (printerType === "moonraker") ? ":80" : ":" + DEFAULT_WS_PORT;
-  }
+  /* ポート未指定なら種別ごとの既定ポートを補完（target.dest と connectWs の dest を一致させ重複登録を防ぐ）。
+     ★ 正規化は normalizeDest に一本化（IPv6 角括弧化・素朴 split 排除）。 */
+  const _dn = normalizeDest(d, { defaultPort: printerType === "moonraker" ? 80 : DEFAULT_WS_PORT });
+  if (_dn.ok && _dn.normalizedDest) d = _dn.normalizedDest;
   /* connectionTargets に printerType を保存（connectWs 内の分岐判定に使用） */
   const targets = monitorData.appSettings.connectionTargets ??= [];
   let t = targets.find(x => x.dest === d);

--- a/3dp_lib/dashboard_integration_itemkeeper.js
+++ b/3dp_lib/dashboard_integration_itemkeeper.js
@@ -28,6 +28,7 @@
 import { monitorData } from "./dashboard_data.js";
 import { saveUnifiedStorage } from "./dashboard_storage.js";
 import { getSpoolById, getMaterialDensity, weightFromLength, formatSpoolDisplayId } from "./dashboard_spool.js";
+import { extractHost } from "./dashboard_target_identity.js";
 import { attributedUsed, deriveSpoolRemaining } from "./dashboard_filament_ledger.js";
 import { notificationManager } from "./dashboard_notification_manager.js";
 import { showConfirmDialog } from "./dashboard_ui_confirm.js";
@@ -362,7 +363,7 @@ export class ItemKeeperIntegration {
         device: {
           alias: t.ikDeviceAlias || t.label || host || "",
           hostname: host,
-          ip: String(t.dest || "").split(":")[0] || "",
+          ip: extractHost(t.dest),
           mac: t.macAddress || "",
           model: machine?.storedData?.model?.rawValue || ""
         },

--- a/3dp_lib/dashboard_panel_factory.js
+++ b/3dp_lib/dashboard_panel_factory.js
@@ -43,6 +43,7 @@
 import { initializePanel, destroyPanel } from "./dashboard_panel_init.js";
 import { monitorData, PLACEHOLDER_HOSTNAME, markAllKeysDirty } from "./dashboard_data.js";
 import { saveUnifiedStorage } from "./dashboard_storage.js";
+import { extractHost } from "./dashboard_target_identity.js";
 import { registerFieldElements, unregisterFieldElements } from "./dashboard_ui.js";
 
 /* ─── localStorage キー ─── */
@@ -682,7 +683,7 @@ export function restoreLayout() {
       if (t.hostname) validHosts.add(t.hostname);
       if (t.dest) {
         // "IP:PORT" からIPのみ抽出して追加（パネルの host はポートなし）
-        const ip = t.dest.split(":")[0];
+        const ip = extractHost(t.dest);
         if (ip) validHosts.add(ip);
       }
     }
@@ -1124,10 +1125,10 @@ export function applyLayoutTemplate(templateId) {
 
   // connectionTargets に hostname がないエントリは dest の IP を使用
   // ★ ただし同じIPで hostname 付きエントリが別にあればスキップ（IP重複防止）
-  const resolvedIps = new Set(targets.filter(t => t.hostname).map(t => t.dest.split(":")[0]));
+  const resolvedIps = new Set(targets.filter(t => t.hostname).map(t => extractHost(t.dest)));
   for (const t of targets) {
     if (!t.hostname && t.dest) {
-      const ip = t.dest.split(":")[0];
+      const ip = extractHost(t.dest);
       if (ip && !allKnownHosts.includes(ip) && !resolvedIps.has(ip)) {
         allKnownHosts.push(ip);
       }
@@ -1308,7 +1309,7 @@ function _getHostConfig(hostname) {
   const targets = monitorData.appSettings.connectionTargets || [];
   /* ホスト名 or IP で接続先設定を検索 */
   for (const t of targets) {
-    const ip = t.dest?.split(":")[0];
+    const ip = extractHost(t.dest);
     if (t.dest === hostname || ip === hostname ||
         t.hostname === hostname) {
       result.color = t.color || "";

--- a/3dp_lib/dashboard_relay_bridge.js
+++ b/3dp_lib/dashboard_relay_bridge.js
@@ -30,6 +30,7 @@
 
 import { monitorData, PLACEHOLDER_HOSTNAME } from "./dashboard_data.js";
 import { sendCommand, getHttpPort } from "./dashboard_connection.js";
+import { extractHost } from "./dashboard_target_identity.js";
 
 /** ブリッジ初期化済みフラグ */
 let _initialized = false;
@@ -260,7 +261,7 @@ export function buildCameraEndpoints(targets, defaultCameraPort = 8080) {
     const hostname = (t && t.hostname || "").trim();
     if (!hostname) continue;                       // 未解決ホストはキーにできない
     const dest = (t && t.dest || "").trim();
-    const ip = dest.split(":")[0].trim();
+    const ip = extractHost(dest);
     if (!ip) continue;                             // IP 不明は転送不可
     const port = (t && t.cameraPort) || defaultCameraPort || 8080;
     map[hostname] = { ip, port };
@@ -289,7 +290,7 @@ function _syncCameraEndpoints() {
   const map = {};
   for (const t of targets) {
     const dest = (t?.dest || "").trim();
-    const ip = dest.split(":")[0].trim();
+    const ip = extractHost(dest);
     if (!ip) continue;                              // IP 不明は転送不可
     const hostname = (t?.hostname || "").trim();
     const label = (t?.label || "").trim();

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -41,6 +41,7 @@ import { FILAMENT_PRESETS } from "./dashboard_filament_presets.js";
 import { logManager } from "./dashboard_log_util.js";
 import { getCurrentTimestamp } from "./dashboard_utils.js";
 import { initLedgerAnchors } from "./dashboard_filament_ledger.js";
+import { parseDest, isIpLiteral, extractHost } from "./dashboard_target_identity.js";
 import {
   initIdb,
   isIdbAvailable,
@@ -278,10 +279,10 @@ export async function importAllData(data) {
   // ── machines: 印刷履歴をマージ ──
   // ★ PLACEHOLDER とIPキー（hostnameが解決済みなら不要）を除外
   if (data.machines && typeof data.machines === "object") {
-    const _isIpLike = (s) => /^\d{1,3}(\.\d{1,3}){3}$/.test(s);
+    const _isIpLike = (s) => isIpLiteral(s);
     const importTargets = data.appSettings?.connectionTargets || [];
     const resolvedHosts = new Set(importTargets.filter(t => t.hostname).map(t => t.hostname));
-    const resolvedIps = new Set(importTargets.filter(t => t.hostname).map(t => t.dest?.split(":")[0]));
+    const resolvedIps = new Set(importTargets.filter(t => t.hostname).map(t => extractHost(t.dest)));
 
     for (const [host, machineData] of Object.entries(data.machines)) {
       // PLACEHOLDER は常にスキップ
@@ -319,16 +320,16 @@ export async function importAllData(data) {
       (monitorData.appSettings.connectionTargets || []).map(t => t.dest)
     );
     const existingIps = new Set(
-      (monitorData.appSettings.connectionTargets || []).map(t => t.dest?.split(":")[0])
+      (monitorData.appSettings.connectionTargets || []).map(t => extractHost(t.dest))
     );
     for (const t of data.appSettings.connectionTargets) {
       if (!t.dest) continue;
       // ポートなしエントリはスキップ（ポート付きが既にあるか追加される）
-      if (!t.dest.includes(":")) continue;
+      if (!parseDest(t.dest).hasPort) continue;
       // 同一 dest は重複スキップ
       if (existingDests.has(t.dest)) continue;
       // 同一 IP で既存エントリがあればスキップ（hostname違いのゴミ防止）
-      const ip = t.dest.split(":")[0];
+      const ip = extractHost(t.dest);
       if (existingIps.has(ip) && !t.hostname) continue;
       monitorData.appSettings.connectionTargets.push(t);
       existingDests.add(t.dest);
@@ -990,7 +991,7 @@ function _restoreFromData(shared, machines) {
     const ipToHostname = new Map();
     for (const t of targets) {
       if (t.hostname && t.dest) {
-        const ip = t.dest.split(":")[0];
+        const ip = extractHost(t.dest);
         ipToHostname.set(ip, t.hostname);
       }
     }

--- a/3dp_lib/dashboard_target_identity.js
+++ b/3dp_lib/dashboard_target_identity.js
@@ -1,0 +1,176 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 接続先(dest)正規化・同一性ヘルパ
+ * @file dashboard_target_identity.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * @author pumpCurry
+ * -----------------------------------------------------------
+ * @module dashboard_target_identity
+ *
+ * 【機能内容サマリ】
+ * - 接続先文字列 dest の解析(parseDest)と正規化(normalizeDest)
+ * - IPv4 / IPv6(bracket・bare) / hostname:port の判定
+ * - `dest.split(":")[0]` / ポート判定 `dest.includes(":")` の唯一の代替
+ *
+ * 【設計意図】
+ * - 「機体同一性(hostname/mac)」「到達先(dest)」を混ぜないための土台。
+ * - dest は到達先でしかない。IPv6 や hostname:port を素朴な split(":") で
+ *   壊さないよう、解析はすべて本モジュールに集約する。
+ *
+ * 【公開関数一覧】
+ * - {@link parseDest}：dest を解析
+ * - {@link normalizeDest}：既定ポート補完つき正規化 dest を得る
+ * - {@link isIPv4}：IPv4 リテラル判定
+ * - {@link isIpLiteral}：IPリテラル(v4/v6)判定
+ * - {@link extractHost}：dest からホスト部のみ抽出(旧 _extractIp 相当)
+ *
+ * @version 1.400.0 (audit P0 identity)
+ * @since   1.400.0
+ * @lastModified 2026-07-04 00:00:00
+ * -----------------------------------------------------------
+ * @todo
+ * - none
+ */
+"use strict";
+
+/**
+ * 文字列が IPv4 リテラルかを判定する。
+ *
+ * @param {string} s - 判定対象
+ * @returns {boolean} IPv4 なら true
+ */
+export function isIPv4(s) {
+  const parts = String(s || "").split(".");
+  if (parts.length !== 4) return false;
+  return parts.every(x => {
+    if (!/^\d{1,3}$/.test(x)) return false;
+    const n = Number(x);
+    return n >= 0 && n <= 255;
+  });
+}
+
+/**
+ * 接続先文字列 dest を解析する。IPv4 / IPv6(bracket・bare) / hostname を扱う。
+ *
+ * 返却オブジェクト:
+ * - `ok`         : 解析成功(hostname:port の port が不正なときのみ false)
+ * - `host`       : ホスト部(IPv6 は角括弧を外した生アドレス)
+ * - `port`       : ポート番号 or null(未指定)
+ * - `hasPort`    : 明示ポートを含むか
+ * - `isIPv4/isIPv6/isHostname`
+ * - `reason`     : ok=false の理由
+ *
+ * @param {string} input - "192.168.1.5:9999" / "[fe80::1]:80" / "fe80::1" / "host" 等
+ * @returns {{ok:boolean, host?:string, port?:number|null, hasPort?:boolean,
+ *   isIPv4?:boolean, isIPv6?:boolean, isHostname?:boolean, reason?:string}}
+ */
+export function parseDest(input) {
+  const raw = String(input || "").trim();
+  if (!raw) return { ok: false, reason: "empty" };
+
+  // [IPv6]:port または [IPv6]
+  const m = raw.match(/^\[([^\]]+)\](?::(\d+))?$/);
+  if (m) {
+    const port = m[2] ? Number(m[2]) : null;
+    return {
+      ok: port == null || (Number.isInteger(port) && port > 0 && port <= 65535),
+      host: m[1],
+      port,
+      hasPort: !!m[2],
+      isIPv4: false,
+      isIPv6: true,
+      isHostname: false
+    };
+  }
+
+  const colonCount = (raw.match(/:/g) || []).length;
+
+  // IPv4:port または hostname:port（コロン1個）
+  if (colonCount === 1) {
+    const idx = raw.indexOf(":");
+    const host = raw.slice(0, idx);
+    const portRaw = raw.slice(idx + 1);
+    const port = Number(portRaw);
+    return {
+      ok: !!host && /^\d+$/.test(portRaw) && Number.isInteger(port) && port > 0 && port <= 65535,
+      host,
+      port,
+      hasPort: true,
+      isIPv4: isIPv4(host),
+      isIPv6: false,
+      isHostname: !isIPv4(host)
+    };
+  }
+
+  // bare IPv6（コロン2個以上・角括弧なし）
+  if (colonCount > 1) {
+    return {
+      ok: true,
+      host: raw,
+      port: null,
+      hasPort: false,
+      isIPv4: false,
+      isIPv6: true,
+      isHostname: false
+    };
+  }
+
+  // bare IPv4 または hostname（コロンなし）
+  return {
+    ok: true,
+    host: raw,
+    port: null,
+    hasPort: false,
+    isIPv4: isIPv4(raw),
+    isIPv6: false,
+    isHostname: !isIPv4(raw)
+  };
+}
+
+/**
+ * dest を「host:port」正規形へ整える。IPv6 は角括弧で包む。
+ * 明示ポートが無ければ `defaultPort` を補完する。
+ *
+ * @param {string} input - 接続先文字列
+ * @param {{defaultPort?:number}} [opts] - 既定ポート
+ * @returns {ReturnType<typeof parseDest> & {normalizedDest?:string, port?:number|null}}
+ *   parseDest の結果に `normalizedDest` を加えたもの。port 不正/欠落時は ok=false。
+ */
+export function normalizeDest(input, { defaultPort } = {}) {
+  const p = parseDest(input);
+  if (!p.ok) return p;
+  const port = p.port || defaultPort;
+  if (!port) return { ...p, ok: false, reason: "missing-port" };
+  const hostPart = p.isIPv6 ? `[${p.host}]` : p.host;
+  return {
+    ...p,
+    port,
+    hasPort: true,
+    normalizedDest: `${hostPart}:${port}`
+  };
+}
+
+/**
+ * dest がIPリテラル(IPv4 または IPv6)かを判定する。
+ * ホスト名は false。IP→hostname 移行の対象判定に使う。
+ *
+ * @param {string} s - 接続先文字列
+ * @returns {boolean} IPv4/IPv6 リテラルなら true
+ */
+export function isIpLiteral(s) {
+  const p = parseDest(s);
+  return !!p.ok && (!!p.isIPv4 || !!p.isIPv6);
+}
+
+/**
+ * dest からホスト部のみを抽出する（旧 `_extractIp` 相当）。
+ * "192.168.1.5:9999" → "192.168.1.5" / "[fe80::1]:80" → "fe80::1" /
+ * "fe80::1" → "fe80::1" / "host" → "host"
+ *
+ * @param {string} dest - 接続先文字列
+ * @returns {string} ホスト部（解析不能時は空文字）
+ */
+export function extractHost(dest) {
+  const p = parseDest(dest);
+  return p.ok ? (p.host || "") : "";
+}

--- a/tests/guards/dest_parsing_guard.test.js
+++ b/tests/guards/dest_parsing_guard.test.js
@@ -1,0 +1,99 @@
+/**
+ * @fileoverview 接続先(dest)解析 anti-pattern 静的ガード（監査 P0-2 / P0-8）
+ *
+ * 目的:
+ *   IPv6 や hostname:port を壊す素朴な dest 解析を「書いた瞬間」に CI で落とす。
+ *   すべて dashboard_target_identity.js の parseDest/normalizeDest/extractHost へ
+ *   寄せること。dest は到達先であり機体同一性ではない、という設計境界を固定する。
+ *
+ * 禁止対象（3dp_lib のコード実体。コメントは除去して走査）:
+ *   - `.split(":")[0]`               → extractHost(dest)
+ *   - ポート判定の `.includes(":")`   → parseDest(dest).hasPort
+ *   - `historyPersistFunc(<x>)`（第2引数 host なし） → historyPersistFunc(id, host)
+ *
+ * 例外: dashboard_target_identity.js（正規化ヘルパ本体。説明コメントを含む）は除外。
+ *
+ * コメント内の言及で誤検出しないよう、行番号を保ったままコメントを除去して走査する。
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, dirname, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "..", "..");
+const LIB_DIR = join(REPO_ROOT, "3dp_lib");
+
+/** 正規化ヘルパ本体は走査対象外（split(":")の言及・実装が正当に存在する） */
+const EXCLUDE = new Set(["dashboard_target_identity.js"]);
+
+/** 3dp_lib 配下の .js を再帰列挙 */
+function listJsFiles(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) out.push(...listJsFiles(p));
+    else if (name.endsWith(".js") && !EXCLUDE.has(name)) out.push(p);
+  }
+  return out;
+}
+
+/** 行数を保ったままコメント(// と ブロック)を空白化する簡易ストリッパ。 */
+function stripCommentsKeepLines(src) {
+  let inBlock = false;
+  return src.split("\n").map((line) => {
+    let out = "";
+    let i = 0;
+    while (i < line.length) {
+      if (inBlock) {
+        const end = line.indexOf("*/", i);
+        if (end === -1) { i = line.length; } else { inBlock = false; i = end + 2; }
+      } else {
+        const lc = line.indexOf("//", i);
+        const bc = line.indexOf("/*", i);
+        if (bc !== -1 && (lc === -1 || bc < lc)) {
+          out += line.slice(i, bc); inBlock = true; i = bc + 2;
+        } else if (lc !== -1) {
+          out += line.slice(i, lc); i = line.length;
+        } else {
+          out += line.slice(i); i = line.length;
+        }
+      }
+    }
+    return out;
+  }).join("\n");
+}
+
+/** 禁止パターン。コメント除去後の各行に対して評価する。 */
+const BANNED = [
+  { re: /\.split\(\s*["']:["']\s*\)\s*\[\s*0\s*\]/, name: '.split(":")[0]', use: "extractHost(dest)" },
+  { re: /\.includes\(\s*["']:["']\s*\)/, name: '.includes(":")', use: "parseDest(dest).hasPort" },
+  { re: /historyPersistFunc\s*\(\s*[^,)]+\)/, name: "historyPersistFunc(x) — host 欠落", use: "historyPersistFunc(id, host)" },
+];
+
+describe("dest 解析 anti-pattern 静的ガード (3dp_lib)", () => {
+  const files = listJsFiles(LIB_DIR);
+
+  it("走査対象ファイルを検出している", () => {
+    expect(files.length).toBeGreaterThan(20);
+  });
+
+  for (const { re, name, use } of BANNED) {
+    it(`「${name}」を使用していない（→ ${use}）`, () => {
+      const offenders = [];
+      for (const f of files) {
+        const stripped = stripCommentsKeepLines(readFileSync(f, "utf8"));
+        stripped.split("\n").forEach((ln, idx) => {
+          if (re.test(ln)) {
+            offenders.push(`${relative(REPO_ROOT, f).replace(/\\/g, "/")}:${idx + 1}  ${ln.trim().slice(0, 90)}`);
+          }
+        });
+      }
+      expect(
+        offenders,
+        `禁止パターン「${name}」を検出。${use} を使うこと:\n${offenders.join("\n")}`
+      ).toEqual([]);
+    });
+  }
+});

--- a/tests/unit/dashboard_connection_identity.test.js
+++ b/tests/unit/dashboard_connection_identity.test.js
@@ -1,0 +1,138 @@
+/**
+ * @fileoverview dashboard_connection.js 同一性/接続先(監査 P0)テスト
+ *
+ * 固定する不変条件:
+ *  - T-ID-01: 同一IP・別ポートは両方とも接続候補になる（IP単位 dedupe 廃止）
+ *  - T-ID-03: 同一 dest で別 hostname が返っても即上書きせず ip-reuse-conflict にする
+ *  - T-ID-04: IPv6 の一時到達先キーも IP→hostname へ移行される
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("../../3dp_lib/dashboard_data.js", () => ({
+  monitorData: {
+    appSettings: { httpPort: 80, connectionTargets: [] },
+    machines: {}, hostSpoolMap: {}, filamentSpools: [],
+  },
+  PLACEHOLDER_HOSTNAME: "_$_NO_MACHINE_$_",
+  setNotificationSuppressed: vi.fn(), setStoredDataForHost: vi.fn(),
+  ensureMachineData: vi.fn(), markAllKeysDirty: vi.fn(), scopedById: vi.fn(),
+  getHostDisplayName: vi.fn((h) => h),
+}));
+vi.mock("../../3dp_lib/dashboard_log_util.js", () => ({ pushLog: vi.fn(), pushGcodeConsole: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_aggregator.js", () => ({
+  aggregatorUpdate: vi.fn(), restoreAggregatorState: vi.fn(),
+  restartAggregatorTimer: vi.fn(), stopAggregatorTimer: vi.fn(), ensureAggregatorTimer: vi.fn(),
+}));
+vi.mock("../../3dp_lib/3dp_dashboard_init.js", () => ({ restorePrintResume: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_msg_handler.js", () => ({ processData: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_printmanager.js", () => ({}));
+vi.mock("../../3dp_lib/dashboard_notification_manager.js", () => ({ showAlert: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_camera_ctrl.js", () => ({
+  startCameraStream: vi.fn(), stopCameraStream: vi.fn(),
+}));
+vi.mock("../../3dp_lib/dashboard_utils.js", () => ({ getCurrentTimestamp: vi.fn(() => "t") }));
+vi.mock("../../3dp_lib/dashboard_panel_menu.js", () => ({ updatePanelMenuHosts: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_panel_factory.js", () => ({
+  migratePanelsToHost: vi.fn(), renamePanelsHost: vi.fn(), ensureHostPanels: vi.fn(),
+  removePanelsForHost: vi.fn(), updateAllPanelHeaders: vi.fn(),
+}));
+vi.mock("../../3dp_lib/dashboard_storage.js", () => ({ saveUnifiedStorage: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_ui_confirm.js", () => ({ showConfirmDialog: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_moonraker.js", () => ({
+  createMoonrakerSession: vi.fn(() => ({ close: vi.fn() })),
+  translateK1CommandToMoonraker: vi.fn(),
+}));
+
+class FakeWebSocket {
+  static CONNECTING = 0; static OPEN = 1; static CLOSING = 2; static CLOSED = 3;
+  static instances = [];
+  constructor(url) {
+    this.url = url; this.binaryType = "";
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen = this.onmessage = this.onerror = this.onclose = null;
+    FakeWebSocket.instances.push(this);
+  }
+  close() { this.readyState = FakeWebSocket.CLOSED; }
+  send() {}
+}
+
+let mod, dataMock;
+beforeEach(async () => {
+  vi.resetModules();
+  FakeWebSocket.instances = [];
+  global.WebSocket = FakeWebSocket;
+  window.WebSocket = FakeWebSocket;
+  delete window._3dpmonRelayChild;
+  mod = await import("../../3dp_lib/dashboard_connection.js");
+  dataMock = await import("../../3dp_lib/dashboard_data.js");
+  dataMock.monitorData.appSettings.connectionTargets = [];
+  dataMock.monitorData.machines = {};
+  dataMock.monitorData.hostSpoolMap = {};
+  dataMock.monitorData.filamentSpools = [];
+});
+afterEach(() => { delete window._3dpmonRelayChild; });
+
+describe("T-ID-01: connectAllSavedTargets — 同一IP別ポートを両方接続", () => {
+  it("同一IP・別ポート(共にK1)は2本とも接続する（IP単位dedupe廃止の証跡）", () => {
+    dataMock.monitorData.appSettings.connectionTargets = [
+      { dest: "192.168.1.50:9999", printerType: "creality-k1", hostname: "" },
+      { dest: "192.168.1.50:9998", printerType: "creality-k1", hostname: "" },
+    ];
+    mod.connectAllSavedTargets();
+    expect(FakeWebSocket.instances.length, "同一IP別ポートで2本").toBe(2);
+    const urls = FakeWebSocket.instances.map(w => w.url).join(" ");
+    expect(urls).toContain("9999");
+    expect(urls).toContain("9998");
+  });
+
+  it("完全同一 dest の重複は1本のみ（normalizedDest dedupe は維持）", () => {
+    dataMock.monitorData.appSettings.connectionTargets = [
+      { dest: "192.168.1.50:9999", printerType: "creality-k1", hostname: "" },
+      { dest: "192.168.1.50:9999", printerType: "creality-k1", hostname: "" },
+    ];
+    mod.connectAllSavedTargets();
+    expect(FakeWebSocket.instances.length).toBe(1);
+  });
+
+  it("ip-reuse-conflict の target は自動接続対象外（保留）", () => {
+    dataMock.monitorData.appSettings.connectionTargets = [
+      { dest: "192.168.1.50:9999", printerType: "creality-k1", hostname: "K1-A", identityStatus: "ip-reuse-conflict" },
+    ];
+    mod.connectAllSavedTargets();
+    expect(FakeWebSocket.instances.length).toBe(0);
+  });
+});
+
+describe("T-ID-03: IP再利用conflict — 即上書きしない", () => {
+  it("同一 dest で別 hostname が返ると identityStatus=ip-reuse-conflict、hostname は保持", () => {
+    dataMock.monitorData.appSettings.connectionTargets = [
+      { dest: "192.168.1.50:9999", printerType: "creality-k1", hostname: "K1Max-A", label: "1号機", color: "#f00" },
+    ];
+    // connectWs で connectionMap["K1Max-A"] を用意（state.dest を確定）
+    mod.connectWs("192.168.1.50:9999");
+    // 別機体 hostname が確定した体で updateConnectionHost を呼ぶ
+    mod.updateConnectionHost("K1Max-A", "K1C-B");
+
+    const t = dataMock.monitorData.appSettings.connectionTargets[0];
+    expect(t.hostname, "hostname は即上書きされない").toBe("K1Max-A");
+    expect(t.identityStatus).toBe("ip-reuse-conflict");
+    expect(t.conflict?.reportedHostname).toBe("K1C-B");
+    expect(t.label, "旧機体の設定は保護").toBe("1号機");
+  });
+});
+
+describe("T-ID-04: IPv6 IP→hostname 移行", () => {
+  it("IPv6 一時キーの machines が hostname キーへ移行され、旧キーは消える", () => {
+    dataMock.monitorData.machines["fe80::1"] = { storedData: { temp: { rawValue: 25 } } };
+    // connectionMap["fe80::1"] を用意（updateConnectionHost の state 前提）
+    mod.connectWs("[fe80::1]:9999");
+    expect(dataMock.monitorData.machines["fe80::1"], "前提: IPv6キー存在").toBeTruthy();
+
+    mod.updateConnectionHost("fe80::1", "K1Max-A");
+
+    expect(dataMock.monitorData.machines["K1Max-A"], "hostnameキーへ移行").toBeTruthy();
+    expect(dataMock.monitorData.machines["fe80::1"], "IPv6一時キーは削除").toBeUndefined();
+  });
+});

--- a/tests/unit/dashboard_target_identity.test.js
+++ b/tests/unit/dashboard_target_identity.test.js
@@ -1,0 +1,119 @@
+/**
+ * @fileoverview dashboard_target_identity.js 純関数テスト（監査 P0: dest 正規化）
+ *
+ * 固定する不変条件:
+ *  - IPv4/IPv6(bracket・bare)/hostname:port を素朴 split(":") で壊さない
+ *  - 既定ポート補完（normalizeDest）が IPv6 を角括弧で包む
+ *  - isIpLiteral が v4/v6 を検出し hostname を除外
+ */
+import { describe, it, expect } from "vitest";
+import {
+  parseDest, normalizeDest, isIPv4, isIpLiteral, extractHost
+} from "../../3dp_lib/dashboard_target_identity.js";
+
+describe("isIPv4", () => {
+  it("正しい IPv4", () => {
+    expect(isIPv4("192.168.1.50")).toBe(true);
+    expect(isIPv4("0.0.0.0")).toBe(true);
+    expect(isIPv4("255.255.255.255")).toBe(true);
+  });
+  it("不正な IPv4 は false", () => {
+    expect(isIPv4("256.1.1.1")).toBe(false);
+    expect(isIPv4("192.168.1")).toBe(false);
+    expect(isIPv4("fe80::1")).toBe(false);
+    expect(isIPv4("host.local")).toBe(false);
+    expect(isIPv4("")).toBe(false);
+  });
+});
+
+describe("parseDest", () => {
+  it("bare IPv4", () => {
+    const p = parseDest("192.168.1.50");
+    expect(p).toMatchObject({ ok: true, host: "192.168.1.50", port: null, hasPort: false, isIPv4: true, isIPv6: false, isHostname: false });
+  });
+  it("IPv4:port", () => {
+    const p = parseDest("192.168.1.50:9999");
+    expect(p).toMatchObject({ ok: true, host: "192.168.1.50", port: 9999, hasPort: true, isIPv4: true });
+  });
+  it("hostname:port", () => {
+    const p = parseDest("k1max.local:80");
+    expect(p).toMatchObject({ ok: true, host: "k1max.local", port: 80, hasPort: true, isHostname: true, isIPv4: false });
+  });
+  it("bare hostname", () => {
+    const p = parseDest("k1max.local");
+    expect(p).toMatchObject({ ok: true, host: "k1max.local", hasPort: false, isHostname: true });
+  });
+  it("[IPv6]:port", () => {
+    const p = parseDest("[fe80::1]:9999");
+    expect(p).toMatchObject({ ok: true, host: "fe80::1", port: 9999, hasPort: true, isIPv6: true });
+  });
+  it("[IPv6] のみ（ポートなし）", () => {
+    const p = parseDest("[fe80::1]");
+    expect(p).toMatchObject({ ok: true, host: "fe80::1", port: null, hasPort: false, isIPv6: true });
+  });
+  it("bare IPv6", () => {
+    const p = parseDest("fe80::1");
+    expect(p).toMatchObject({ ok: true, host: "fe80::1", port: null, hasPort: false, isIPv6: true });
+  });
+  it("空入力は ok=false", () => {
+    expect(parseDest("").ok).toBe(false);
+    expect(parseDest(null).ok).toBe(false);
+  });
+  it("不正ポートは ok=false", () => {
+    expect(parseDest("192.168.1.50:99999").ok).toBe(false);
+    expect(parseDest("192.168.1.50:0").ok).toBe(false);
+    expect(parseDest("host:abc").ok).toBe(false);
+  });
+});
+
+describe("normalizeDest", () => {
+  it("T-ID-02: IPv6 raw に既定ポート補完し角括弧化", () => {
+    expect(normalizeDest("fe80::1", { defaultPort: 9999 }).normalizedDest).toBe("[fe80::1]:9999");
+  });
+  it("T-ID-02: [IPv6]:port はそのまま角括弧維持", () => {
+    expect(normalizeDest("[fe80::1]:9999", { defaultPort: 9999 }).normalizedDest).toBe("[fe80::1]:9999");
+  });
+  it("IPv4 に既定ポート補完", () => {
+    expect(normalizeDest("192.168.1.50", { defaultPort: 9999 }).normalizedDest).toBe("192.168.1.50:9999");
+  });
+  it("IPv4:port は明示ポート優先", () => {
+    expect(normalizeDest("192.168.1.50:80", { defaultPort: 9999 }).normalizedDest).toBe("192.168.1.50:80");
+  });
+  it("hostname に既定ポート補完", () => {
+    expect(normalizeDest("k1max.local", { defaultPort: 80 }).normalizedDest).toBe("k1max.local:80");
+  });
+  it("ポート欠落かつ既定なし → ok=false", () => {
+    const r = normalizeDest("192.168.1.50");
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("missing-port");
+  });
+  it("同一IP・別ポートは別 normalizedDest（dedupe が別物と扱える）", () => {
+    const a = normalizeDest("192.168.1.50:9999", { defaultPort: 9999 }).normalizedDest;
+    const b = normalizeDest("192.168.1.50:80", { defaultPort: 80 }).normalizedDest;
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("isIpLiteral", () => {
+  it("IPv4/IPv6 は true", () => {
+    expect(isIpLiteral("192.168.1.50")).toBe(true);
+    expect(isIpLiteral("192.168.1.50:9999")).toBe(true);
+    expect(isIpLiteral("fe80::1")).toBe(true);
+    expect(isIpLiteral("[fe80::1]:80")).toBe(true);
+  });
+  it("hostname は false（IP→hostname 移行対象外）", () => {
+    expect(isIpLiteral("k1max.local")).toBe(false);
+    expect(isIpLiteral("k1max.local:80")).toBe(false);
+    expect(isIpLiteral("")).toBe(false);
+  });
+});
+
+describe("extractHost", () => {
+  it("各形式からホスト部を抽出", () => {
+    expect(extractHost("192.168.1.50:9999")).toBe("192.168.1.50");
+    expect(extractHost("[fe80::1]:80")).toBe("fe80::1");
+    expect(extractHost("fe80::1")).toBe("fe80::1");
+    expect(extractHost("k1max.local")).toBe("k1max.local");
+    expect(extractHost("")).toBe("");
+  });
+});


### PR DESCRIPTION
統合監査（2026-07-04）Domain-1（識別性/接続）の P0。方針=**危険挙動の停止＋通知、確認UIはP1**。

## 変更（ユニット別コミット）
1. **新規 `dashboard_target_identity.js`**: `parseDest`/`normalizeDest`/`isIPv4`/`isIpLiteral`/`extractHost`（IPv4/IPv6(bracket・bare)/hostname:port を単一ソースで解析）＋21テスト
2. **connection.js**: dest 解析を上記へ一本化。**P0-1** connectAllSavedTargets の dedupe を IP単位→`printerType|normalizedDest`（同一IP別ポート/K1・Moonraker混在を両方接続）／**P0-3** IP再利用は `identityStatus:"ip-reuse-conflict"` を立て**即上書きせず通知のみ**（旧機体設定保護・自動接続保留）／**P0-4** IP→hostname 移行を `isIpLiteral` で IPv6 も対象化＋5テスト
3. **storage.js**: import/restore の dest 解析を extractHost/parseDest へ一掃
4. **周辺4ファイル**（camera_ctrl/panel_factory/itemkeeper/relay_bridge）の `split(":")[0]` を extractHost へ一掃
5. **P0-8**: `restoreAggregatorState` の `historyPersistFunc(id)`→`(id, host)`（復元時の履歴ホスト吸着修正）／**dest解析 静的ガード**投入（`split(":")[0]`/ポート判定`includes(":")`/host欠落`historyPersistFunc(x)` を CI で禁止）

## 受入条件（P0）
- ✅ `dest.split(":")[0]` がコード実体から消滅（guard で恒久禁止）
- ✅ ポート判定 `dest.includes(":")` 消滅
- ✅ 同一IP別ポートを両方接続候補に
- ✅ IPv6 raw/bracket テスト通過
- ✅ IP再利用時に既存 hostname を即上書きしない
- ✅ `restoreAggregatorState` が host 付きで履歴反映

## 保留（P1へ）
- IP再利用 conflict の**解消UI**（現状は保留＋通知のみ）
- MAC同一性（Electron `hostname+MAC`）による自動統合
- storage import の「IP一致のみで machines[ip] をスキップしない」意味変更（data-loss リスクのため behavioral テスト付き専用フォロー）

## テスト
全**773**テスト緑（新規: identity 21 / connection 5 / guard 4）。touched 3dp_lib は eslint 0 error。

🤖 Generated with [Claude Code](https://claude.com/claude-code)