### PR TITLE
audit P1 Domain-4(一部): フィラメントパネル destroy＋panel_boot titleBar 修正

### DIFF
--- a/3dp_lib/dashboard_panel_boot.js
+++ b/3dp_lib/dashboard_panel_boot.js
@@ -103,11 +103,12 @@ export function bootPanelSystem() {
   gridContainer.id = "panel-grid";
 
   /* トップメニューバーの直後に挿入 */
+  // ★ 2.9: 旧 `titleBar` fallback を削除。titleBar は未定義変数で、topMenuBar が無い
+  //   経路に入ると ReferenceError になる死んだ分岐だった（旧UIの残骸）。
+  //   現行 UI は top-menu-bar が唯一の基準。未検出時は body 末尾へ append する。
   const topMenuBar = document.getElementById("top-menu-bar");
-  if (topMenuBar && topMenuBar.nextSibling) {
+  if (topMenuBar && topMenuBar.parentNode) {
     topMenuBar.parentNode.insertBefore(gridContainer, topMenuBar.nextSibling);
-  } else if (titleBar && titleBar.nextSibling) {
-    titleBar.parentNode.insertBefore(gridContainer, titleBar.nextSibling);
   } else {
     document.body.appendChild(gridContainer);
   }

--- a/3dp_lib/dashboard_panel_init.js
+++ b/3dp_lib/dashboard_panel_init.js
@@ -366,6 +366,9 @@ function initFilamentPanel(body, hostname) {
     /* per-host Map で管理（グローバル window.filamentPreview は廃止） */
     if (!window._filamentPreviews) window._filamentPreviews = new Map();
     window._filamentPreviews.set(hostname, preview);
+    // ★ P1-6: destroy 時に破棄できるよう body に保持（マルチプリンタでパネル再生成の
+    //   繰り返しによる preview / ResizeObserver / detached DOM リークを防ぐ）。
+    body._filamentPreview = preview;
   } catch (e) {
     console.warn("[panel-init] filament preview 生成エラー:", e);
   }
@@ -381,6 +384,8 @@ function initFilamentPanel(body, hostname) {
         }
       });
       ro.observe(area);
+      // ★ P1-6: destroy 時に disconnect するため body に保持
+      body._filamentResizeObserver = ro;
       // 初回サイズ適用
       requestAnimationFrame(() => {
         const rect = area.getBoundingClientRect();
@@ -878,6 +883,16 @@ export function registerAllPanelInits() {
       clearInterval(body._productionTimer);
       body._productionTimer = null;
     }
+  });
+  // ★ P1-6: フィラメントパネルの ResizeObserver / preview / レジストリ参照を破棄。
+  //   マルチプリンタでパネル削除・再生成を繰り返すと ro/preview/detached DOM が
+  //   リークするため、destroy で確実に解放する。
+  registerPanelDestroy("filament", (body, hostname) => {
+    try { body._filamentResizeObserver?.disconnect?.(); } catch { /* 無視 */ }
+    body._filamentResizeObserver = null;
+    try { body._filamentPreview?.destroy?.(); } catch { /* 無視 */ }
+    body._filamentPreview = null;
+    try { window._filamentPreviews?.delete?.(hostname); } catch { /* 無視 */ }
   });
 }
 


### PR DESCRIPTION
統合監査 Domain-4 の低リスク項目（パネルライフサイクル）。

- **P1-6**: `initFilamentPanel` の preview / ResizeObserver を body に保持し、`registerPanelDestroy("filament")` で disconnect/destroy/レジストリ削除。マルチプリンタでパネル削除・再生成を繰り返す際の preview/ro/detached DOM リークを解消。
- **2.9**: `bootPanelSystem` の未定義変数 `titleBar` を参照する死んだ fallback（top-menu-bar 欠落時に ReferenceError）を削除。

全**773**テスト緑・eslint 0 error。

## 保留（Domain-4 の大物・別途）
- P1-4 旧UI削除（destination-input/connect-button 等の HTML 除去）
- P1-5 `updateConnectionUI` の旧DOM分離
- relay printStore delta の revision counter 化

🤖 Generated with [Claude Code](https://claude.com/claude-code)