### PR TITLE
audit P1-4/P1-5: 旧接続UI(死DOM)削除＋updateConnectionUI 縮約

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -130,9 +130,9 @@ export async function initializeDashboard() {
     }
   }
 
-  // ★ 旧接続/切断ボタン (connect-button, disconnect-button) はシングルホスト時代の遺物。
-  //   マルチホスト環境では全台一括 ON/OFF しかできず危険なため、リスナーを設定しない。
-  //   per-host 接続トグルは接続設定モーダル内に実装予定。
+  // ★ 監査 P1-4: 旧接続/切断ボタン (connect-button, disconnect-button) 等の
+  //   シングルホスト時代の旧接続UIは HTML から削除済み（未配線の死DOMだった）。
+  //   per-host 接続操作は接続設定モーダル(conn-modal-*)＋per-host トグルへ移行済み。
   //   → 詳細: docs/LEGACY_UI.md
 
   // 子モードでなければ通常のプリンタ直接接続

--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -1698,140 +1698,23 @@ export function sendGcodeCommand(gcode, host) {
 }
 
 /**
- * 接続 UI の表示状態を一元管理します。
- * - "connecting": 接続試行中 → 「接続中…(n/m)」
- * - "waiting":    再接続待機中 → 「接続中…(n/m) リトライ待ち(あと x 秒)」
- * - "connected":  接続済み     → ホスト名表示・切断ボタン
- * - "disconnected":切断中     → 入力欄再表示・接続ボタン
+ * 接続 UI の表示状態を反映します。
  *
- * NOTE: この関数はレガシー接続 UI 要素（3dp_monitor.html 内の
- * destination-input, destination-display, connection-status,
- * connect-button, disconnect-button, audio-muted-tag）を対象とする。
- * Electron パネルシステムでは接続モーダル（conn-modal-*）が使われるため、
- * これらの要素は存在しない場合がある。各要素アクセスにはnullガードを適用。
+ * ★ 監査 P1-5: シングルホスト時代の旧接続DOM（destination-input/destination-display/
+ *   connection-status/connect-button/disconnect-button）は撤去済み（HTMLからも削除）。
+ *   per-host の接続状態（connecting/waiting/connected/disconnected）は
+ *   {@link updatePrinterListUI} が connectionMap[host].state から新UI
+ *   （printer-status-list / top-menu-bar のステータスドット / conn-modal-*）へ
+ *   描画する。本関数は旧DOMを一切触らず一覧の再描画へ委譲するだけの薄いラッパ。
+ *   引数 state/opt は後方互換のため受けるが、状態は getState 由来で描画される。
  *
- * @param {"connecting"|"waiting"|"connected"|"disconnected"} state
- *   接続状態を指定
- * @param {{attempt?: number, max?: number, wait?: number}} [opt={}]
- *   connecting/waiting 時に使用する { attempt, max, wait }
- * @param {string} [host] - 対象ホスト名
+ * @param {"connecting"|"waiting"|"connected"|"disconnected"} [state] - 接続状態（後方互換・未使用）
+ * @param {{attempt?: number, max?: number, wait?: number}} [opt={}] - 後方互換・未使用
+ * @param {string} [host] - 対象ホスト名（後方互換・未使用。描画は全ホスト一括）
+ * @returns {void}
  */
 export function updateConnectionUI(state, opt = {}, host) {
-  // ホスト指定が無い場合はプリンタ一覧のみ更新
-  if (!host) {
-    updatePrinterListUI();
-    return;
-  }
-
-  /* レガシー接続 UI 要素（Electron モードでは存在しない場合がある） */
-  const ipInput       = document.getElementById("destination-input");
-  const ipDisplay     = document.getElementById("destination-display");
-  const statusEl      = document.getElementById("connection-status");
-  const btnConnect    = document.getElementById("connect-button");
-  const btnDisconnect = document.getElementById("disconnect-button");
-  const muteTag       = document.getElementById("audio-muted-tag");
-
-  // per-host の dest からホスト部のみを取り出す（例 "192.168.1.5:9090" → "192.168.1.5"）
-  const st = getState(host);
-  const rawDest  = st.dest || "";
-  const hostOnly = _extractIp(rawDest) || "";
-
-  // 入力欄を隠し・無効化
-  function hideInput() {
-    if (ipInput) {
-      ipInput.classList.add("hidden");
-      ipInput.setAttribute("disabled", "true");
-    }
-  }
-
-  // 入力欄を表示・有効化し、値を復元
-  function showInput() {
-    if (ipInput) {
-      ipInput.classList.remove("hidden");
-      ipInput.removeAttribute("disabled");
-      ipInput.value = rawDest;
-    }
-  }
-
-  // ミュート中タグを隠す
-  function hideMute() {
-    if (muteTag) {
-      muteTag.classList.add("hidden");
-    }
-  }
-
-  switch (state) {
-    case "connecting": {
-      // --- 接続試行中 ---
-      hideInput();
-      const { attempt = 0, max = 0 } = opt;
-      const label = `接続中…(${attempt}/${max})`;
-      // ホスト名は常に表示
-      if (ipDisplay) {
-        ipDisplay.classList.remove("hidden");
-        ipDisplay.textContent = hostOnly;
-      }
-      if (statusEl) {
-        statusEl.textContent = label;
-      }
-      btnConnect?.classList.add("hidden");
-      btnConnect?.setAttribute("disabled", "true");
-      btnDisconnect?.classList.remove("hidden");
-      break;
-    }
-
-    case "waiting": {
-      // --- 再接続待機中 ---
-      hideInput();
-      const { attempt = 0, max = 0, wait = 0 } = opt;
-      const label = `接続中…(${attempt}/${max}) リトライ待ち(あと ${wait} 秒)`;
-      if (ipDisplay) {
-        ipDisplay.classList.remove("hidden");
-        ipDisplay.textContent = hostOnly;
-      }
-      if (statusEl) {
-        statusEl.textContent = label;
-      }
-      btnConnect?.classList.add("hidden");
-      btnDisconnect?.classList.remove("hidden");
-      break;
-    }
-
-    case "connected": {
-      // --- 接続済み ---
-      hideInput();
-      if (ipDisplay) {
-        ipDisplay.classList.remove("hidden");
-        ipDisplay.textContent = hostOnly;
-      }
-      if (statusEl) {
-        statusEl.textContent = "接続済み";
-      }
-      btnConnect?.classList.add("hidden");
-      btnDisconnect?.classList.remove("hidden");
-      // ミュートタグはそのまま残す
-      break;
-    }
-
-    case "disconnected": {
-      // --- 切断中 ---
-      showInput();
-      if (ipDisplay) {
-        ipDisplay.classList.add("hidden");
-      }
-      if (statusEl) {
-        statusEl.textContent = "切断";
-      }
-      btnConnect?.removeAttribute("disabled");
-      btnConnect?.classList.remove("hidden");
-      btnDisconnect?.classList.add("hidden");
-      hideMute();
-      break;
-    }
-
-    default:
-      console.error(`updateConnectionUI: unknown state="${state}"`);
-  }
+  void state; void opt; void host; // 後方互換のため引数は受けるが未使用（状態は getState 由来で描画）
   updatePrinterListUI();
 }
 

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -221,30 +221,18 @@
       <span id="audio-muted-tag" style="display:none; cursor:pointer; font-size:12px; margin-left:4px;">
         🔇:ミュート中
       </span>
-      <!-- 接続先入力 -->
-      <input id="destination-input" type="text" placeholder="IP アドレス">
-      <span id="destination-display">----</span>
 
-      <!-- プリンタ選択 -->
+      <!-- プリンタ選択（表示用・更新は updatePrinterListUI） -->
       <select id="printer-select" style="font-size:12px;"></select>
 
-      <!-- 追加プリンタ接続 -->
-      <input id="add-printer-input" type="text" placeholder="追加IP:port" style="font-size:12px; width:120px;">
-      <button id="add-printer-button" style="font-size:12px;">追加接続</button>
-
-      <!-- 接続状態一覧 -->
+      <!-- 接続状態一覧（per-host 状態は updatePrinterListUI が描画） -->
       <div id="printer-status-list" style="font-size:12px;"></div>
 
-      <!-- 自動接続(ON/OFF) -->
-      <label style="font-size:12px;">
-        <input type="checkbox" id="auto-connect-toggle">
-        自動接続
-      </label>
-
-      <!-- 接続ボタン / 切断ボタン -->
-      <button id="connect-button" style="font-size:12px;" class="hidden">接続</button>
-      <button id="disconnect-button" style="font-size:12px;" class="hidden">切断</button>
-      <span id="connection-status" style="margin-left:5px; font-size:12px;">----</span>
+      <!-- ★ 監査 P1-4: シングルホスト時代の旧接続UI（destination-input/destination-display/
+           add-printer-input/add-printer-button/auto-connect-toggle/connect-button/
+           disconnect-button/connection-status）を削除。マルチホストでは全台一括操作しか
+           できず危険なため未配線の死DOMだった。接続操作は接続設定モーダル(conn-modal-*)＋
+           per-host トグルへ移行済み。詳細: docs/LEGACY_UI.md -->
     </div>
   </div>
 

--- a/docs/LEGACY_UI.md
+++ b/docs/LEGACY_UI.md
@@ -51,10 +51,17 @@
 - `connectWs(host)` / `disconnectWs(host)` を個別ホストで呼び出し
 - 接続状態インジケーター (🟢/🔴) を per-host で表示
 
-### Phase 3: 旧要素除去 (Phase 2 完了後)
-- 上記「危険な要素」と「死んでいる要素」を HTML から除去
-- `updateConnectionUI()` 内の旧要素参照コードを削除
-- `setupConnectButton()` を削除
+### Phase 3: 旧要素除去 (✅ 完了 — 統合監査 P1-4/P1-5, 2026-07-04)
+- ✅ `destination-input` / `destination-display` / `connection-status` / `connect-button` /
+  `disconnect-button` / `auto-connect-toggle` / `add-printer-input` / `add-printer-button` を
+  HTML から除去（いずれも未配線の死DOM、または cosmetic のみ）。
+- ✅ `updateConnectionUI()` 内の旧要素参照コードを削除し、`updatePrinterListUI()` への
+  薄い委譲に縮約（per-host 状態は connectionMap[host].state から新UIへ描画）。
+- **残置（意図的）**:
+  - `audio-muted-tag`: 監査の除去対象外。JS からは実質「隠す」だけで表示元が無く常に
+    非表示の inert 要素だが、ミュートUI用に HTML には残す（updateConnectionUI からは非参照化）。
+  - `printer-select` / `printer-status-list`: `updatePrinterListUI()` が更新する安全要素として維持。
+- 補足: `setupConnectButton()` は本リポジトリの現行コードには存在しない（既に撤去済み）。
 
 ## 関連コード
 


### PR DESCRIPTION
統合監査 Domain-4 の旧UI整理。

- **P1-4**: シングルホスト時代の旧接続UI 8要素を HTML から削除（destination-input/destination-display/connect-button/disconnect-button/connection-status/auto-connect-toggle/add-printer-input/add-printer-button）。リポジトリ全体＋HTMLインラインで配線なし（未配線の死DOM or cosmetic のみ）を確認済み。配線ありの `audio-muted-tag`/`printer-select`/`printer-status-list` は残置。
- **P1-5**: `updateConnectionUI` を旧DOM操作から切り離し `updatePrinterListUI()` への薄い委譲に縮約（per-host 状態は `connectionMap[host].state` から新UIへ描画）。
- `docs/LEGACY_UI.md` の Phase 3 を完了に更新。

差分: -156/+34。全773テスト緑・eslint 0 error。

🤖 Generated with [Claude Code](https://claude.com/claude-code)