### PR TITLE
audit §6: relay delta に printStore 履歴 revision を導入

### DIFF
--- a/3dp_lib/dashboard_relay_bridge.js
+++ b/3dp_lib/dashboard_relay_bridge.js
@@ -391,7 +391,10 @@ function _buildDelta() {
       const hist = ps.history || [];
       const last = hist.length ? hist[hist.length - 1] : null;
       const cur = ps.current || null;
-      const psSig = `${hist.length}|${last?.id ?? ""}|${last?.materialUsedMm ?? last?.usagematerial ?? ""}|`
+      // ★ 監査§6: 履歴 revision(_historyRev) を署名に含める。末尾サンプルでは拾えない
+      //   履歴中間の filamentInfo 編集・分割 upsert・reconcile 等（saveHistory 経由の実変更）を
+      //   子へ確実に伝播させる。rev は savePrintHistory が実書き換え時のみ加算する。
+      const psSig = `${ps._historyRev ?? ""}|${hist.length}|${last?.id ?? ""}|${last?.materialUsedMm ?? last?.usagematerial ?? ""}|`
         + `${last?.printfinish ?? ""}|${last?.filamentId ?? ""}|${last?.observed ?? ""}|`
         + `${cur?.id ?? ""}|${cur?.materialUsedMm ?? ""}|${cur?.filamentId ?? ""}`;
       if (psSig !== _prevPrintHash.get(hostname)) {

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -1354,8 +1354,14 @@ export function savePrintHistory(history, hostname) {
   const host = hostname;
   if (!host) return;
   ensureMachineData(host);
-  monitorData.machines[host].printStore.history =
-    history.slice(0, MAX_PRINT_HISTORY);
+  const ps = monitorData.machines[host].printStore;
+  ps.history = history.slice(0, MAX_PRINT_HISTORY);
+  // ★ 監査§6: 履歴 revision を単調インクリメント。relay delta の変更検出署名は
+  //   O(1) の軽量サンプル（末尾ジョブ＋現在ジョブ）で、履歴中間の filamentInfo 編集・
+  //   分割 upsert・reconcile 等（件数・末尾不変）を取りこぼしうる。履歴を実際に書き換える
+  //   単一チョークポイント（saveHistory の JSON 差分ガード経由のみ）で rev を上げ、
+  //   署名に含めることで子（readonly/satellite）へ確実に伝播させる。
+  ps._historyRev = (Number(ps._historyRev) || 0) + 1;
   saveUnifiedStorage();
 }
 


### PR DESCRIPTION
統合監査 §6。relay delta の変更検出署名（O(1) 軽量サンプル）が履歴中間の filamentInfo 編集・分割 upsert・reconcile 等を取りこぼす問題に対し、履歴書き換えの単一チョークポイント `savePrintHistory` で `printStore._historyRev` を加算し署名に含める。子(readonly/satellite)への確実な伝播を担保。

全773テスト緑・eslint 0 error。実挙動(親→子伝播)は実機CDP検証の領域。

🤖 Generated with [Claude Code](https://claude.com/claude-code)