### PR TITLE
sync: main → feature (v2.2.1035 監査 フィラメント＋旧UI＋relay)

### DIFF
--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -179,12 +179,15 @@ const persistKeys = [
 ];
 
 // 印刷再開用に保存したいスプール関連キー
+// ★ P0-5: remainingLengthMm は「停止前のライブ途中値」であり再起動後の権威値ではない。
+//   resume に残すとアプリ停止中に進んだ印刷を無視して古い残量が復活する。
+//   残量は printStore.history + mountHistory から reconcileSpool で導出するため、
+//   resume では保存も復元もしない。既存 pd_*_remainingLengthMm は restore 時に掃除する。
 const spoolKeys = [
   "currentSpoolId",
   "currentPrintID",
   "currentJobStartLength",
-  "currentJobExpectedLength",
-  "remainingLengthMm"
+  "currentJobExpectedLength"
 ];
 
 /**
@@ -249,13 +252,14 @@ export function restorePrintResume(hostname, currentPrintId = null) {
           case 'currentJobExpectedLength':
             spool.currentJobExpectedLength = val;
             break;
-          case 'remainingLengthMm':
-            spool.remainingLengthMm = val;
-            break;
         }
       } catch (e) { console.debug("[restorePrintResume] スプール復元エラー:", e.message); }
     });
   }
+
+  // ★ P0-5: 旧バージョンが保存した pd_*_remainingLengthMm は権威値ではないため無視・削除する。
+  //   （残量は reconcileSpool が履歴+装着区間から導出する）
+  try { localStorage.removeItem(`pd_${hostname}_remainingLengthMm`); } catch { /* noop */ }
 }
 
 /**
@@ -294,8 +298,6 @@ export function persistPrintResume(hostname) {
             return spool.currentJobStartLength;
           case 'currentJobExpectedLength':
             return spool.currentJobExpectedLength;
-          case 'remainingLengthMm':
-            return spool.remainingLengthMm;
           default:
             return null;
         }

--- a/3dp_lib/3dp_dashboard_init.js
+++ b/3dp_lib/3dp_dashboard_init.js
@@ -130,9 +130,9 @@ export async function initializeDashboard() {
     }
   }
 
-  // ★ 旧接続/切断ボタン (connect-button, disconnect-button) はシングルホスト時代の遺物。
-  //   マルチホスト環境では全台一括 ON/OFF しかできず危険なため、リスナーを設定しない。
-  //   per-host 接続トグルは接続設定モーダル内に実装予定。
+  // ★ 監査 P1-4: 旧接続/切断ボタン (connect-button, disconnect-button) 等の
+  //   シングルホスト時代の旧接続UIは HTML から削除済み（未配線の死DOMだった）。
+  //   per-host 接続操作は接続設定モーダル(conn-modal-*)＋per-host トグルへ移行済み。
   //   → 詳細: docs/LEGACY_UI.md
 
   // 子モードでなければ通常のプリンタ直接接続

--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -1328,11 +1328,13 @@ export function aggregatorUpdate() {
           s.prevUsageProgress = prog;
         }
         s.accumulatedUsedMaterial += delta;
-        remain = spool.currentJobStartLength - s.accumulatedUsedMaterial;
-        // 印刷途中にページを更新しても残量が巻き戻らないよう、
-        // 計算値をスプールオブジェクトへ反映しておく
-        spool.remainingLengthMm = Math.max(0, remain);
-        spool.updatedAt = _now;  // ★ C1: 時系列判定用タイムスタンプ更新
+        // ★ P0-6: 印刷中のライブ残量は「表示用」。権威残量 spool.remainingLengthMm へは
+        //   書き戻さない（runout判定/resume/import/restore の入力になり誤判定が増幅するため）。
+        //   ライブ値は下の _set("filamentRemainingMm", remain) で storedData にだけ出す。
+        //   ページ更新時の巻き戻りは storedData(永続) の filamentRemainingMm が担保する。
+        //   権威残量は完了時に finalizeFilamentUsage→reconcileSpool でのみ更新する。
+        //   （禁止）spool.remainingLengthMm = Math.max(0, remain); spool.updatedAt = _now;
+        remain = Math.max(0, spool.currentJobStartLength - s.accumulatedUsedMaterial);
       } else if (
         spool.currentJobStartLength != null &&
         (Number(machine?.runtimeData?.state) ===

--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -50,9 +50,9 @@ import {
   beginExternalPrint,
   formatFilamentAmount,
   formatSpoolDisplayId,
-  getSpoolById,
-  setCurrentSpoolId,
-  addInferredSpool
+  getSpoolById
+  // ★ P0-9: 自動 inferred 投入停止に伴い setCurrentSpoolId / addInferredSpool の
+  //   aggregator からの利用は撤去（ユーザー明示交換のみ mount）。
 } from "./dashboard_spool.js";
 import { reconcileSpool, recordFilamentEvent, resolveFilamentEvent, getOpenFilamentEvent, runoutGateHeld } from "./dashboard_filament_ledger.js";
 import { getConnectionState } from "./dashboard_connection.js";
@@ -308,28 +308,23 @@ function _resolveRunoutOnReplace(host, machine, nowMs) {
   // ★ F-B 対策: #3 自動投入は「印刷が実際に一時停止した切れ」に限定（短blip/誤動作を除外）。
   const wasPaused = Number(ev.stateAtEvent) === PRINT_STATE_CODE.printPaused;
   if (runoutGateHeld(ev) && wasPaused) {
-    // #3: 高確度（2信号成立＋一時停止）→ 同プリセット新品を inferred 推定投入（R1: 可逆・serial/在庫非消費）
-    const oldSpool = getSpoolById(ev.oldSpoolId) || getCurrentSpool(host);
-    if (oldSpool) {
-      const inferred = addInferredSpool(oldSpool);
-      // ★ F-A 対策: 取消で旧を完全復元するためのスナップショット（zeroing 前の残量）
-      inferred._supersedes = {
-        spoolId: oldSpool.id,
-        host,
-        prevRemaining: Number.isFinite(Number(ev.oldRemainingMm))
-          ? Number(ev.oldRemainingMm) : (Number(oldSpool.remainingLengthMm) || 0),
-        printID: oldSpool.currentPrintID || (ev.inflightJobId != null ? String(ev.inflightJobId) : "")
-      };
-      // 未解決(paused)文脈のまま setCurrentSpoolId → split で 旧→0/新→満 に装着
-      setCurrentSpoolId(inferred.id, host);
-      notificationManager.notify("inferredSpoolCreated", { hostname: host });
-    }
-    // setCurrentSpoolId が解決済みなら no-op。未解決なら inferred として解決。
-    resolveFilamentEvent(host, "inferred", { ts: nowMs });
-  } else {
-    // #4 / F-B: ゲート不成立 or 非一時停止（blip）→ 同一再セット
-    resolveFilamentEvent(host, "reseat", { ts: nowMs });
+    // ★ P0-9 止血: センサー復帰(1→0)は「交換確定」ではない。同一リール再セット・
+    //   詰まり除去・センサー blip でも起きる。ADR-0005 の自動 inferred 作成＋split
+    //   （旧リールを 0 化 / 新リールを満で装着）は、旧リール残量を破壊し復元不能に
+    //   しうるため、ここでは実行しない。
+    //   代わりに pendingResolution を立てて確認待ちにし、通知するだけに留める。
+    //   「新品に交換」をユーザーが明示したときのみ mount する（確認UIは後続P1）。
+    //   未確認のまま完了/オフライン跨ぎになった場合は _evaluateStaleRunout が
+    //   offline-suspect（_remainingVerified=false＋通知・自動mountなし）で安全に処理する。
+    ev.pendingResolution = true;
+    ev.stateLatest = Number(
+      machine?.runtimeData?.state ?? machine?.storedData?.state?.rawValue ?? 0
+    );
+    notificationManager.notify("runoutRecoveredNeedsConfirmation", { hostname: host });
+    return; // 文脈は open のまま（確認待ち）。自動投入はしない。
   }
+  // #4 / F-B: ゲート不成立 or 非一時停止（blip）→ 同一再セット
+  resolveFilamentEvent(host, "reseat", { ts: nowMs });
 }
 
 /**
@@ -1187,10 +1182,28 @@ export function aggregatorUpdate() {
     }
 
     if (spool && isCompleted && !isPrinting && spool.currentPrintID) {
-      console.log(`[aggregatorUpdate] ${host}: state=${st}(完了) で currentPrintID=${spool.currentPrintID} が残留 → クリア`);
+      const _jobId = spool.currentPrintID;
+      // ★ P0-7: transient(currentPrintID/currentJobStartLength) を消す前に finalize を走らせ、
+      //   消費を履歴へ確実に計上する。旧実装はこの完了検出経路で先にクリアしていたため、
+      //   直下の完了ブロック(finalize)の条件(currentJobStartLength != null)が失われ、消費が
+      //   履歴に入らない経路があった。
+      //   二重計上防止: 条件に accumulatedUsedMaterial > 0 を入れる。どちらの経路でも
+      //   finalize 済みなら accumulatedUsedMaterial は 0 に落ちており、ここでは再 finalize しない
+      //   （下の完了ブロックと相互排他）。
+      if (spool.currentJobStartLength != null && s.accumulatedUsedMaterial > 0) {
+        const _isSuccess = (st === PRINT_STATE_CODE.printDone);
+        try { finalizeFilamentUsage(s.accumulatedUsedMaterial, _jobId, host, _isSuccess); }
+        catch (e) { console.warn("[aggregator] finalize(P0-7) 失敗:", e?.message || e); }
+        try { reconcileSpool(spool.id, { ts: _now }); }
+        catch (e2) { console.warn("[aggregator] reconcileSpool(P0-7) 失敗:", e2?.message || e2); }
+        s.accumulatedUsedMaterial = 0;
+        s.prevUsedMaterialLength = null;
+        s.prevUsageProgress = 0;
+      }
+      console.log(`[aggregatorUpdate] ${host}: state=${st}(完了) で currentPrintID=${_jobId} → finalize後クリア`);
       spool.currentJobStartLength = null;
       spool.currentJobExpectedLength = null;
-      spool.lastCompletedPrintID = spool.currentPrintID;
+      spool.lastCompletedPrintID = _jobId;
       spool.currentPrintID = "";
       saveUnifiedStorage(true);
       // ★ クリア直後の同 tick で autoCorrect が走るのを抑制

--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -580,6 +580,11 @@ export function updateConnectionHost(oldHost, newHost) {
           const key = localStorage.key(i);
           if (key && key.startsWith(pdPrefix)) {
             const suffix = key.slice(pdPrefix.length);
+            // ★ P0-5: remainingLengthMm は resume 権威値ではないため移行しない（旧キーは破棄）。
+            if (suffix === "remainingLengthMm") {
+              localStorage.removeItem(key);
+              continue;
+            }
             const newKey = pdNewPrefix + suffix;
             if (!localStorage.getItem(newKey)) {
               localStorage.setItem(newKey, localStorage.getItem(key));

--- a/3dp_lib/dashboard_connection.js
+++ b/3dp_lib/dashboard_connection.js
@@ -1698,140 +1698,23 @@ export function sendGcodeCommand(gcode, host) {
 }
 
 /**
- * 接続 UI の表示状態を一元管理します。
- * - "connecting": 接続試行中 → 「接続中…(n/m)」
- * - "waiting":    再接続待機中 → 「接続中…(n/m) リトライ待ち(あと x 秒)」
- * - "connected":  接続済み     → ホスト名表示・切断ボタン
- * - "disconnected":切断中     → 入力欄再表示・接続ボタン
+ * 接続 UI の表示状態を反映します。
  *
- * NOTE: この関数はレガシー接続 UI 要素（3dp_monitor.html 内の
- * destination-input, destination-display, connection-status,
- * connect-button, disconnect-button, audio-muted-tag）を対象とする。
- * Electron パネルシステムでは接続モーダル（conn-modal-*）が使われるため、
- * これらの要素は存在しない場合がある。各要素アクセスにはnullガードを適用。
+ * ★ 監査 P1-5: シングルホスト時代の旧接続DOM（destination-input/destination-display/
+ *   connection-status/connect-button/disconnect-button）は撤去済み（HTMLからも削除）。
+ *   per-host の接続状態（connecting/waiting/connected/disconnected）は
+ *   {@link updatePrinterListUI} が connectionMap[host].state から新UI
+ *   （printer-status-list / top-menu-bar のステータスドット / conn-modal-*）へ
+ *   描画する。本関数は旧DOMを一切触らず一覧の再描画へ委譲するだけの薄いラッパ。
+ *   引数 state/opt は後方互換のため受けるが、状態は getState 由来で描画される。
  *
- * @param {"connecting"|"waiting"|"connected"|"disconnected"} state
- *   接続状態を指定
- * @param {{attempt?: number, max?: number, wait?: number}} [opt={}]
- *   connecting/waiting 時に使用する { attempt, max, wait }
- * @param {string} [host] - 対象ホスト名
+ * @param {"connecting"|"waiting"|"connected"|"disconnected"} [state] - 接続状態（後方互換・未使用）
+ * @param {{attempt?: number, max?: number, wait?: number}} [opt={}] - 後方互換・未使用
+ * @param {string} [host] - 対象ホスト名（後方互換・未使用。描画は全ホスト一括）
+ * @returns {void}
  */
 export function updateConnectionUI(state, opt = {}, host) {
-  // ホスト指定が無い場合はプリンタ一覧のみ更新
-  if (!host) {
-    updatePrinterListUI();
-    return;
-  }
-
-  /* レガシー接続 UI 要素（Electron モードでは存在しない場合がある） */
-  const ipInput       = document.getElementById("destination-input");
-  const ipDisplay     = document.getElementById("destination-display");
-  const statusEl      = document.getElementById("connection-status");
-  const btnConnect    = document.getElementById("connect-button");
-  const btnDisconnect = document.getElementById("disconnect-button");
-  const muteTag       = document.getElementById("audio-muted-tag");
-
-  // per-host の dest からホスト部のみを取り出す（例 "192.168.1.5:9090" → "192.168.1.5"）
-  const st = getState(host);
-  const rawDest  = st.dest || "";
-  const hostOnly = _extractIp(rawDest) || "";
-
-  // 入力欄を隠し・無効化
-  function hideInput() {
-    if (ipInput) {
-      ipInput.classList.add("hidden");
-      ipInput.setAttribute("disabled", "true");
-    }
-  }
-
-  // 入力欄を表示・有効化し、値を復元
-  function showInput() {
-    if (ipInput) {
-      ipInput.classList.remove("hidden");
-      ipInput.removeAttribute("disabled");
-      ipInput.value = rawDest;
-    }
-  }
-
-  // ミュート中タグを隠す
-  function hideMute() {
-    if (muteTag) {
-      muteTag.classList.add("hidden");
-    }
-  }
-
-  switch (state) {
-    case "connecting": {
-      // --- 接続試行中 ---
-      hideInput();
-      const { attempt = 0, max = 0 } = opt;
-      const label = `接続中…(${attempt}/${max})`;
-      // ホスト名は常に表示
-      if (ipDisplay) {
-        ipDisplay.classList.remove("hidden");
-        ipDisplay.textContent = hostOnly;
-      }
-      if (statusEl) {
-        statusEl.textContent = label;
-      }
-      btnConnect?.classList.add("hidden");
-      btnConnect?.setAttribute("disabled", "true");
-      btnDisconnect?.classList.remove("hidden");
-      break;
-    }
-
-    case "waiting": {
-      // --- 再接続待機中 ---
-      hideInput();
-      const { attempt = 0, max = 0, wait = 0 } = opt;
-      const label = `接続中…(${attempt}/${max}) リトライ待ち(あと ${wait} 秒)`;
-      if (ipDisplay) {
-        ipDisplay.classList.remove("hidden");
-        ipDisplay.textContent = hostOnly;
-      }
-      if (statusEl) {
-        statusEl.textContent = label;
-      }
-      btnConnect?.classList.add("hidden");
-      btnDisconnect?.classList.remove("hidden");
-      break;
-    }
-
-    case "connected": {
-      // --- 接続済み ---
-      hideInput();
-      if (ipDisplay) {
-        ipDisplay.classList.remove("hidden");
-        ipDisplay.textContent = hostOnly;
-      }
-      if (statusEl) {
-        statusEl.textContent = "接続済み";
-      }
-      btnConnect?.classList.add("hidden");
-      btnDisconnect?.classList.remove("hidden");
-      // ミュートタグはそのまま残す
-      break;
-    }
-
-    case "disconnected": {
-      // --- 切断中 ---
-      showInput();
-      if (ipDisplay) {
-        ipDisplay.classList.add("hidden");
-      }
-      if (statusEl) {
-        statusEl.textContent = "切断";
-      }
-      btnConnect?.removeAttribute("disabled");
-      btnConnect?.classList.remove("hidden");
-      btnDisconnect?.classList.add("hidden");
-      hideMute();
-      break;
-    }
-
-    default:
-      console.error(`updateConnectionUI: unknown state="${state}"`);
-  }
+  void state; void opt; void host; // 後方互換のため引数は受けるが未使用（状態は getState 由来で描画）
   updatePrinterListUI();
 }
 

--- a/3dp_lib/dashboard_notification_defaults.js
+++ b/3dp_lib/dashboard_notification_defaults.js
@@ -53,6 +53,7 @@ export const defaultNotificationMap = {
   filamentReplaced: { talk: "{hostname} にフィラメントが補充されました",                         sound: DEFAULT_SOUND, enabled: true, level: "success" },
   inferredSpoolCreated: { talk: "{hostname} で新リールを推定投入しました。確認/訂正してください",   sound: DEFAULT_SOUND, enabled: true, level: "info"    },
   offlineRunoutSuspect: { talk: "{hostname} で切れ/交換の可能性があります。残量を確認してください", sound: DEFAULT_SOUND, enabled: true, level: "warn"    },
+  runoutRecoveredNeedsConfirmation: { talk: "{hostname} でフィラメント復帰を検出しました。同一リール再セットか新品交換かを確認してください", sound: DEFAULT_SOUND, enabled: true, level: "warn" },
   filamentLow:      { talk: "{hostname} フィラメント残量が少なくなっています 残り{remainingText} ({now})",
                  sound: DEFAULT_SOUND, enabled: true, level: "warn"    },
   timeLeft10:       { talk: "{hostname} 印刷終了まで残り10分です",                                 sound: DEFAULT_SOUND, enabled: true, level: "info"    },

--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -1277,6 +1277,17 @@ export function updateHistoryList(
         //   newJobs（historyData バッファ経由）に値がある場合はユーザー操作結果
         //   なのでそちらを優先する。newJobs に値がない場合のみ旧データで補完。
         if (FILAMENT_KEYS.has(k)) {
+          // ★ P1-2: filamentInfo は配列（分割交換の per-reel spoolId/usedMm を保持）。
+          //   薄い incoming（色のみ・spoolId なし）が spoolId/usedMm 付きの既存を丸ごと
+          //   上書き消去しないよう、refreshHistory と同じ _mergeFilamentInfo で upsert する。
+          if (k === "filamentInfo") {
+            if (v != null) {
+              const before = JSON.stringify(cur.filamentInfo || null);
+              cur.filamentInfo = _mergeFilamentInfo(cur.filamentInfo, v);
+              if (JSON.stringify(cur.filamentInfo || null) !== before) merged = true;
+            }
+            return;
+          }
           if (cur[k] == null && v != null) {
             cur[k] = v;
             merged = true;

--- a/3dp_lib/dashboard_relay_bridge.js
+++ b/3dp_lib/dashboard_relay_bridge.js
@@ -391,7 +391,10 @@ function _buildDelta() {
       const hist = ps.history || [];
       const last = hist.length ? hist[hist.length - 1] : null;
       const cur = ps.current || null;
-      const psSig = `${hist.length}|${last?.id ?? ""}|${last?.materialUsedMm ?? last?.usagematerial ?? ""}|`
+      // ★ 監査§6: 履歴 revision(_historyRev) を署名に含める。末尾サンプルでは拾えない
+      //   履歴中間の filamentInfo 編集・分割 upsert・reconcile 等（saveHistory 経由の実変更）を
+      //   子へ確実に伝播させる。rev は savePrintHistory が実書き換え時のみ加算する。
+      const psSig = `${ps._historyRev ?? ""}|${hist.length}|${last?.id ?? ""}|${last?.materialUsedMm ?? last?.usagematerial ?? ""}|`
         + `${last?.printfinish ?? ""}|${last?.filamentId ?? ""}|${last?.observed ?? ""}|`
         + `${cur?.id ?? ""}|${cur?.materialUsedMm ?? ""}|${cur?.filamentId ?? ""}`;
       if (psSig !== _prevPrintHash.get(hostname)) {

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -1354,8 +1354,14 @@ export function savePrintHistory(history, hostname) {
   const host = hostname;
   if (!host) return;
   ensureMachineData(host);
-  monitorData.machines[host].printStore.history =
-    history.slice(0, MAX_PRINT_HISTORY);
+  const ps = monitorData.machines[host].printStore;
+  ps.history = history.slice(0, MAX_PRINT_HISTORY);
+  // ★ 監査§6: 履歴 revision を単調インクリメント。relay delta の変更検出署名は
+  //   O(1) の軽量サンプル（末尾ジョブ＋現在ジョブ）で、履歴中間の filamentInfo 編集・
+  //   分割 upsert・reconcile 等（件数・末尾不変）を取りこぼしうる。履歴を実際に書き換える
+  //   単一チョークポイント（saveHistory の JSON 差分ガード経由のみ）で rev を上げ、
+  //   署名に含めることで子（readonly/satellite）へ確実に伝播させる。
+  ps._historyRev = (Number(ps._historyRev) || 0) + 1;
   saveUnifiedStorage();
 }
 

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -221,30 +221,18 @@
       <span id="audio-muted-tag" style="display:none; cursor:pointer; font-size:12px; margin-left:4px;">
         🔇:ミュート中
       </span>
-      <!-- 接続先入力 -->
-      <input id="destination-input" type="text" placeholder="IP アドレス">
-      <span id="destination-display">----</span>
 
-      <!-- プリンタ選択 -->
+      <!-- プリンタ選択（表示用・更新は updatePrinterListUI） -->
       <select id="printer-select" style="font-size:12px;"></select>
 
-      <!-- 追加プリンタ接続 -->
-      <input id="add-printer-input" type="text" placeholder="追加IP:port" style="font-size:12px; width:120px;">
-      <button id="add-printer-button" style="font-size:12px;">追加接続</button>
-
-      <!-- 接続状態一覧 -->
+      <!-- 接続状態一覧（per-host 状態は updatePrinterListUI が描画） -->
       <div id="printer-status-list" style="font-size:12px;"></div>
 
-      <!-- 自動接続(ON/OFF) -->
-      <label style="font-size:12px;">
-        <input type="checkbox" id="auto-connect-toggle">
-        自動接続
-      </label>
-
-      <!-- 接続ボタン / 切断ボタン -->
-      <button id="connect-button" style="font-size:12px;" class="hidden">接続</button>
-      <button id="disconnect-button" style="font-size:12px;" class="hidden">切断</button>
-      <span id="connection-status" style="margin-left:5px; font-size:12px;">----</span>
+      <!-- ★ 監査 P1-4: シングルホスト時代の旧接続UI（destination-input/destination-display/
+           add-printer-input/add-printer-button/auto-connect-toggle/connect-button/
+           disconnect-button/connection-status）を削除。マルチホストでは全台一括操作しか
+           できず危険なため未配線の死DOMだった。接続操作は接続設定モーダル(conn-modal-*)＋
+           per-host トグルへ移行済み。詳細: docs/LEGACY_UI.md -->
     </div>
   </div>
 

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <!-- ★ app-version: ビルド時に scripts/sync-version.js が package.json から自動更新する -->
-  <meta name="app-version" content="2.2.1034" />
-  <title>3dpmon - 3Dプリンタ監視ダッシュボード v2.2.1034</title>
+  <meta name="app-version" content="2.2.1035" />
+  <title>3dpmon - 3Dプリンタ監視ダッシュボード v2.2.1035</title>
   <!-- サイトアイコン -->
   <link rel="icon" href="favicon.ico">
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v2.2.1035 (2026-07-04) — ⚠ 実機検証候補（フィラメント中核変更を含む）
+
+### 統合監査 残りの P0/P1: フィラメント（resume/live/finalize/runout）＋旧UI削除＋relay revision
+
+> **注意**: 本版は **フィラメント中核の挙動変更**（残量の権威扱い・runout 自動交換推定の反転）を含む
+> **実機検証候補**。残量 reconcile／完了計上／runout 誤発火0 を実機で確認してから正式リリースすること。
+
+#### 修正（不具合）— フィラメント
+- **P0-5 resume に remainingLengthMm を保存・復元しない**: 停止前のライブ途中値で古い残量が復活する問題を解消。残量は printStore.history + mountHistory から reconcileSpool で導出。旧 pd_*_remainingLengthMm は restore 時に掃除、IP→hostname 移行でも非移行。
+- **P0-6 印刷中のライブ残量を権威 `spool.remainingLengthMm` へ直書きしない**: ライブ値は `storedData.filamentRemainingMm` のみへ。権威残量は完了時 finalize→reconcile でのみ更新（runout/resume/import への誤入力を断つ）。
+- **P0-7 完了 finalize 順序**: 完了検出で transient を消す前に finalize→reconcile を実行し、消費の履歴計上漏れを解消。二重計上は `accumulatedUsedMaterial>0` 条件で相互排他。
+- **P0-9 runout 復帰の自動 inferred 作成を停止（ADR-0005 反転）**: センサー復帰（1→0）を「交換確定」とせず、旧リールを 0 化する破壊を止め、`pendingResolution`＋通知に留める。新品交換はユーザー明示時のみ（確認UIは後続）。
+- **P1-2 履歴 merge**: `updateHistoryList` の filamentInfo を `_mergeFilamentInfo` で upsert（色のみ incoming で spoolId/usedMm を消さない）。
+
+#### 修正（不具合）— 旧UI / relay
+- **P1-4/P1-5**: シングルホスト時代の旧接続UI 8要素（destination-input 等）を HTML から削除し、`updateConnectionUI` を `updatePrinterListUI` 委譲へ縮約（旧DOM非依存化）。
+- **§6 relay delta revision**: `savePrintHistory` で `printStore._historyRev` を加算し relay 署名に含め、履歴中間の filamentInfo 編集・分割・reconcile を子（readonly/satellite）へ確実に伝播。
+
+#### テスト・インフラ
+- 全**781**テスト緑。`filament_authority_guard`（印刷中ライブ直書き／resume remainingLengthMm／aggregator の addInferredSpool を CI 禁止）。touched 3dp_lib は eslint 0 error。
+
+---
+
 ## v2.2.1034 (2026-07-04)
 
 ### 統合監査 P0/P1: 接続先同一性（IPv6/DHCP/IP再利用）＋パネルライフサイクル

--- a/docs/LEGACY_UI.md
+++ b/docs/LEGACY_UI.md
@@ -51,10 +51,17 @@
 - `connectWs(host)` / `disconnectWs(host)` を個別ホストで呼び出し
 - 接続状態インジケーター (🟢/🔴) を per-host で表示
 
-### Phase 3: 旧要素除去 (Phase 2 完了後)
-- 上記「危険な要素」と「死んでいる要素」を HTML から除去
-- `updateConnectionUI()` 内の旧要素参照コードを削除
-- `setupConnectButton()` を削除
+### Phase 3: 旧要素除去 (✅ 完了 — 統合監査 P1-4/P1-5, 2026-07-04)
+- ✅ `destination-input` / `destination-display` / `connection-status` / `connect-button` /
+  `disconnect-button` / `auto-connect-toggle` / `add-printer-input` / `add-printer-button` を
+  HTML から除去（いずれも未配線の死DOM、または cosmetic のみ）。
+- ✅ `updateConnectionUI()` 内の旧要素参照コードを削除し、`updatePrinterListUI()` への
+  薄い委譲に縮約（per-host 状態は connectionMap[host].state から新UIへ描画）。
+- **残置（意図的）**:
+  - `audio-muted-tag`: 監査の除去対象外。JS からは実質「隠す」だけで表示元が無く常に
+    非表示の inert 要素だが、ミュートUI用に HTML には残す（updateConnectionUI からは非参照化）。
+  - `printer-select` / `printer-status-list`: `updatePrinterListUI()` が更新する安全要素として維持。
+- 補足: `setupConnectButton()` は本リポジトリの現行コードには存在しない（既に撤去済み）。
 
 ## 関連コード
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "3dpmon",
-  "version": "2.2.1034",
+  "version": "2.2.1035",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "3dpmon",
-      "version": "2.2.1034",
+      "version": "2.2.1035",
       "license": "BSD-3-Clause",
       "dependencies": {
         "gridstack": "^10.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3dpmon",
-  "version": "2.2.1034",
+  "version": "2.2.1035",
   "description": "3Dプリンタ監視ダッシュボード - Electron版",
   "main": "electron/main.js",
   "scripts": {

--- a/tests/guards/filament_authority_guard.test.js
+++ b/tests/guards/filament_authority_guard.test.js
@@ -1,0 +1,95 @@
+/**
+ * @fileoverview フィラメント権威残量 anti-pattern 静的ガード（監査 P0-5 / P0-6）
+ *
+ * 目的:
+ *   「印刷中ライブ残量を権威 spool.remainingLengthMm へ書き戻す」「resume に
+ *   remainingLengthMm を載せる」というアンチパターンの再発を CI で落とす。
+ *   権威残量は完了時に reconcileSpool でのみ更新する、という設計境界を固定する。
+ *
+ * 禁止対象（3dp_lib のコード実体。コメントは除去して走査）:
+ *   - `spool.remainingLengthMm = Math.max(0, remain)`（印刷中ライブ経路の直書き）
+ *   - resume の `case 'remainingLengthMm'` / `case "remainingLengthMm"`（保存・復元）
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, dirname, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "..", "..");
+const LIB_DIR = join(REPO_ROOT, "3dp_lib");
+
+function listJsFiles(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) out.push(...listJsFiles(p));
+    else if (name.endsWith(".js")) out.push(p);
+  }
+  return out;
+}
+
+function stripCommentsKeepLines(src) {
+  let inBlock = false;
+  return src.split("\n").map((line) => {
+    let out = "";
+    let i = 0;
+    while (i < line.length) {
+      if (inBlock) {
+        const end = line.indexOf("*/", i);
+        if (end === -1) { i = line.length; } else { inBlock = false; i = end + 2; }
+      } else {
+        const lc = line.indexOf("//", i);
+        const bc = line.indexOf("/*", i);
+        if (bc !== -1 && (lc === -1 || bc < lc)) {
+          out += line.slice(i, bc); inBlock = true; i = bc + 2;
+        } else if (lc !== -1) {
+          out += line.slice(i, lc); i = line.length;
+        } else {
+          out += line.slice(i); i = line.length;
+        }
+      }
+    }
+    return out;
+  }).join("\n");
+}
+
+const BANNED = [
+  {
+    re: /spool\.remainingLengthMm\s*=\s*Math\.max\s*\(\s*0\s*,\s*remain\s*\)/,
+    name: "spool.remainingLengthMm = Math.max(0, remain)（印刷中ライブ直書き）",
+    use: "ライブ残量は storedData.filamentRemainingMm のみへ。権威は reconcileSpool（完了時）",
+  },
+  {
+    re: /case\s+["']remainingLengthMm["']/,
+    name: "case 'remainingLengthMm'（resume 保存/復元）",
+    use: "remainingLengthMm は resume 対象外（reconcileSpool が導出）",
+  },
+];
+
+describe("フィラメント権威残量 anti-pattern 静的ガード (3dp_lib)", () => {
+  const files = listJsFiles(LIB_DIR);
+
+  it("走査対象ファイルを検出している", () => {
+    expect(files.length).toBeGreaterThan(20);
+  });
+
+  for (const { re, name, use } of BANNED) {
+    it(`「${name}」を使用していない（→ ${use}）`, () => {
+      const offenders = [];
+      for (const f of files) {
+        const stripped = stripCommentsKeepLines(readFileSync(f, "utf8"));
+        stripped.split("\n").forEach((ln, idx) => {
+          if (re.test(ln)) {
+            offenders.push(`${relative(REPO_ROOT, f).replace(/\\/g, "/")}:${idx + 1}  ${ln.trim().slice(0, 90)}`);
+          }
+        });
+      }
+      expect(
+        offenders,
+        `禁止パターン「${name}」を検出。${use}:\n${offenders.join("\n")}`
+      ).toEqual([]);
+    });
+  }
+});

--- a/tests/guards/filament_authority_guard.test.js
+++ b/tests/guards/filament_authority_guard.test.js
@@ -92,4 +92,22 @@ describe("フィラメント権威残量 anti-pattern 静的ガード (3dp_lib)"
       ).toEqual([]);
     });
   }
+
+  // ★ P0-9: aggregator は runout 復帰で自動 inferred 投入しない。
+  //   addInferredSpool の呼び出しは dashboard_spool.js（定義側）等に限り、
+  //   dashboard_aggregator.js からは呼ばない（センサー復帰＝交換確定にしない）。
+  it("dashboard_aggregator.js が addInferredSpool を呼び出さない（P0-9 runout自動投入停止）", () => {
+    const f = join(LIB_DIR, "dashboard_aggregator.js");
+    const stripped = stripCommentsKeepLines(readFileSync(f, "utf8"));
+    const offenders = [];
+    stripped.split("\n").forEach((ln, idx) => {
+      if (/addInferredSpool\s*\(/.test(ln)) {
+        offenders.push(`3dp_lib/dashboard_aggregator.js:${idx + 1}  ${ln.trim().slice(0, 90)}`);
+      }
+    });
+    expect(
+      offenders,
+      `aggregator からの addInferredSpool 呼び出しを検出。runout 復帰は pendingResolution＋通知に留めること:\n${offenders.join("\n")}`
+    ).toEqual([]);
+  });
 });

--- a/tests/unit/dashboard_printmanager_gcode.test.js
+++ b/tests/unit/dashboard_printmanager_gcode.test.js
@@ -300,6 +300,41 @@ describe('printfinish 確定: 印刷中ジョブを成功/失敗へ誤確定し�
     expect(cur.finishTime == null, '終了時刻なし(印刷中)').toBe(true);
     expect(cur.printfinish, '終了時刻なし=未完了 → null へ正規化（誤計上しない）').toBeNull();
   });
+
+  it('★T-FIL-06(P1-2): updateHistoryList は色のみ incoming で既存 spoolId/usedMm を消さない', () => {
+    const HOST = 'K1Max-FIL';
+    const JID = 1700009999;
+    _dataMock.monitorData.machines[HOST] = {
+      runtimeData: { state: 0 }, historyData: [], printStore: { history: [] }, storedData: {},
+    };
+    // 既存ストア: 分割済み per-reel（OLD/NEW の usedMm 付き）
+    _storageMock.loadPrintHistory.mockReturnValue([
+      {
+        id: JID, filename: '/x/split.gcode',
+        startTime: new Date(JID * 1000).toISOString(),
+        finishTime: new Date((JID + 3600) * 1000).toISOString(), printfinish: 1,
+        filamentInfo: [{ spoolId: 'OLD', usedMm: 300000 }, { spoolId: 'NEW', usedMm: 25000 }],
+      },
+    ]);
+    _storageMock.loadPrintVideos.mockReturnValue([]);
+    _storageMock.loadPrintCurrent.mockReturnValue(null);
+    _storageMock.savePrintHistory.mockClear();
+
+    // プリンタ由来の薄い履歴（色のみ・spoolId なし）が同一IDで再取得される
+    updateHistoryList(
+      [{
+        id: JID, filename: '/x/split.gcode', starttime: JID, usagetime: 3600, printfinish: 1,
+        filamentInfo: [{ filamentColor: '#fff' }],
+      }],
+      'http://127.0.0.1', 'print-current-container', HOST
+    );
+
+    const saved = _storageMock.savePrintHistory.mock.calls.at(-1)?.[0] || [];
+    const j = saved.find(x => String(x.id) === String(JID));
+    const byId = Object.fromEntries((j.filamentInfo || []).filter(e => e.spoolId).map(e => [e.spoolId, e]));
+    expect(byId.OLD?.usedMm, 'OLD の usedMm は保持').toBe(300000);
+    expect(byId.NEW?.usedMm, 'NEW の usedMm は保持').toBe(25000);
+  });
 });
 
 // =====================================================================

--- a/tests/unit/dashboard_resume_remaining.test.js
+++ b/tests/unit/dashboard_resume_remaining.test.js
@@ -1,0 +1,72 @@
+/**
+ * @fileoverview 印刷再開(resume)の remainingLengthMm 非復元テスト（監査 P0-5）
+ *
+ * 固定する不変条件:
+ *  - T-FIL-01: pd_<host>_remainingLengthMm が存在しても restorePrintResume 後に
+ *    spool.remainingLengthMm は変化しない（ライブ途中値の復活を防ぐ）。
+ *  - 旧キー pd_<host>_remainingLengthMm は restore 時に削除される。
+ *  - persistPrintResume は remainingLengthMm を保存しない。
+ *
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const spool = { id: "s1", remainingLengthMm: 12345, currentPrintID: "", currentJobStartLength: null, currentJobExpectedLength: null };
+
+vi.mock("../../3dp_lib/dashboard_storage.js", () => ({
+  initStorage: vi.fn(), restoreUnifiedStorage: vi.fn(), saveUnifiedStorage: vi.fn(), setStorageNamespace: vi.fn(),
+}));
+vi.mock("../../3dp_lib/dashboard_panel_factory.js", () => ({ setPanelLayoutNamespace: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_data.js", () => ({
+  PLACEHOLDER_HOSTNAME: "_$_NO_MACHINE_$_",
+  monitorData: { machines: { A: { storedData: {} } } },
+  setStoredDataForHost: vi.fn(),
+}));
+vi.mock("../../3dp_lib/dashboard_connection.js", () => ({ connectAllSavedTargets: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_spool.js", () => ({
+  addSpoolFromPreset: vi.fn(),
+  getCurrentSpool: vi.fn(() => spool),
+  getCurrentSpoolId: vi.fn(() => "s1"),
+  setCurrentSpoolId: vi.fn(),
+}));
+vi.mock("../../3dp_lib/dashboard_filament_presets.js", () => ({ FILAMENT_PRESETS: [] }));
+vi.mock("../../3dp_lib/dashboard_notification_manager.js", () => ({
+  notificationManager: { notify: vi.fn() }, showAlert: vi.fn(),
+}));
+vi.mock("../../3dp_lib/dashboard_integration_itemkeeper.js", () => ({ itemKeeperIntegration: {} }));
+vi.mock("../../3dp_lib/dashboard_aggregator.js", () => ({
+  persistAggregatorState: vi.fn(), stopAggregatorTimer: vi.fn(), aggregatorUpdate: vi.fn(),
+}));
+vi.mock("../../3dp_lib/dashboard_about.js", () => ({ initAboutDialogListener: vi.fn() }));
+
+const { restorePrintResume, persistPrintResume } = await import("../../3dp_lib/3dp_dashboard_init.js");
+
+beforeEach(() => {
+  localStorage.clear();
+  spool.remainingLengthMm = 12345;
+  spool.currentPrintID = "";
+  spool.currentJobStartLength = null;
+  spool.currentJobExpectedLength = null;
+});
+
+describe("T-FIL-01: resume は remainingLengthMm を復元しない", () => {
+  it("pd_A_remainingLengthMm があっても spool.remainingLengthMm は不変", () => {
+    localStorage.setItem("pd_A_remainingLengthMm", JSON.stringify(5000));
+    localStorage.setItem("pd_A_currentPrintID", JSON.stringify("job-1"));
+    restorePrintResume("A");
+    expect(spool.remainingLengthMm, "ライブ途中値5000で上書きされない").toBe(12345);
+    expect(spool.currentPrintID, "他のspoolキーは復元される").toBe("job-1");
+  });
+
+  it("旧 pd_A_remainingLengthMm は restore 時に削除される", () => {
+    localStorage.setItem("pd_A_remainingLengthMm", JSON.stringify(5000));
+    restorePrintResume("A");
+    expect(localStorage.getItem("pd_A_remainingLengthMm")).toBeNull();
+  });
+
+  it("persistPrintResume は pd_A_remainingLengthMm を書き出さない", () => {
+    spool.remainingLengthMm = 9999;
+    persistPrintResume("A");
+    expect(localStorage.getItem("pd_A_remainingLengthMm")).toBeNull();
+  });
+});


### PR DESCRIPTION
定期同期。main の v2.2.1035（統合監査: フィラメント resume/live/finalize/runout P0-5/6/7/9＋P1-2、旧UI削除 P1-4/5、relay §6）を feature へ取り込む。ユーザ実機検証OK済(2026-07-04)。全781緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)