### PR TITLE
v2.2.1036 検証候補: audit P1-3 autoCorrect 境界を mountHistory へ

### DIFF
--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -50,7 +50,8 @@ import {
   reconcileSpool,
   getOpenFilamentEvent,
   resolveFilamentEvent,
-  deriveSpoolRemaining
+  deriveSpoolRemaining,
+  getSpoolIntervals
 } from "./dashboard_filament_ledger.js";
 import { consumeInventory } from "./dashboard_filament_inventory.js";
 import { updateStoredDataToDOM } from "./dashboard_ui.js";
@@ -1850,8 +1851,15 @@ export function autoCorrectCurrentSpool(hostname) {
   try {
     const persistedHistory = loadHistory(hostname);
     if (Array.isArray(persistedHistory) && persistedHistory.length) {
-      // 装着区間の下限（startPrintID/最新 mount の sinceJobId）以降の未紐付け完了印刷を対象
-      const sinceId = Number(spool.startPrintID) || 0;
+      // ★ P1-3: 装着区間の下限は ADR-0004 権威台帳(mountHistory)の open 区間 sinceJobId を使う。
+      //   legacy `spool.startPrintID` は編集等でドリフトしうるため、mount 記録があればそちらを
+      //   権威とし、無い場合(旧データ/未記録)のみ startPrintID へフォールバックする。
+      const _openIv = (getSpoolIntervals(spool.id) || [])
+        .filter(iv => iv.host === hostname && iv.untilJobId == null)
+        .at(-1) || null;
+      const sinceId = _openIv
+        ? (Number(_openIv.sinceJobId) || 0)
+        : (Number(spool.startPrintID) || 0);
       const linkJobIds = new Set();
       for (const entry of persistedHistory) {
         if (!entry || !shouldLinkOfflineJob(entry)) continue;

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <!-- ★ app-version: ビルド時に scripts/sync-version.js が package.json から自動更新する -->
-  <meta name="app-version" content="2.2.1035" />
-  <title>3dpmon - 3Dプリンタ監視ダッシュボード v2.2.1035</title>
+  <meta name="app-version" content="2.2.1036" />
+  <title>3dpmon - 3Dプリンタ監視ダッシュボード v2.2.1036</title>
   <!-- サイトアイコン -->
   <link rel="icon" href="favicon.ico">
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v2.2.1036 (2026-07-04) — ⚠ 実機検証候補（フィラメント帰属の入力変更）
+
+### 統合監査 P1-3: autoCorrect のオフライン紐付け下限を mountHistory 権威境界へ
+
+> **注意**: フィラメント帰属の入力を変更する**実機検証候補**。オフライン完了印刷の遡及紐付けが
+> 正しい装着区間で絞られるか（過剰/過少紐付けが無いか）を実機で確認してから正式リリースすること。
+
+- **P1-3**: `autoCorrectCurrentSpool` の「オフライン中に完了した印刷を現在スプールへ遡及紐付け」する
+  下限を、legacy `spool.startPrintID` から **mountHistory の open 区間 `sinceJobId`（ADR-0004 権威台帳、
+  `getSpoolIntervals`）** へ変更。`startPrintID` が編集等でドリフトした場合の誤紐付け（古い境界で過剰に
+  リンク）を防ぐ。mount 記録が無い旧データのみ `startPrintID` へフォールバック。
+- テスト: 新規2（mountHistory 境界で絞る／記録なし時フォールバック）。全**783**テスト緑・eslint 0 error。
+
+---
+
 ## v2.2.1035 (2026-07-04) — ⚠ 実機検証候補（フィラメント中核変更を含む）
 
 ### 統合監査 残りの P0/P1: フィラメント（resume/live/finalize/runout）＋旧UI削除＋relay revision

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "3dpmon",
-  "version": "2.2.1035",
+  "version": "2.2.1036",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "3dpmon",
-      "version": "2.2.1035",
+      "version": "2.2.1036",
       "license": "BSD-3-Clause",
       "dependencies": {
         "gridstack": "^10.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "3dpmon",
-  "version": "2.2.1035",
+  "version": "2.2.1036",
   "description": "3Dプリンタ監視ダッシュボード - Electron版",
   "main": "electron/main.js",
   "scripts": {

--- a/tests/unit/dashboard_filament_attribution.test.js
+++ b/tests/unit/dashboard_filament_attribution.test.js
@@ -46,8 +46,10 @@ const {
   addInferredSpool,
   confirmInferredSpool,
   revertInferredSpool,
+  autoCorrectCurrentSpool,
 } = await import('../../3dp_lib/dashboard_spool.js');
 const { consumeInventory } = await import('../../3dp_lib/dashboard_filament_inventory.js');
+const pmMock = await import('../../3dp_lib/dashboard_printmanager.js');
 
 let rebaselineSpy;
 
@@ -349,5 +351,54 @@ describe('P6 #3 完全可逆（revertInferredSpool）', () => {
 
     const restored = revertInferredSpool(inferred.id);
     expect(restored.remainingLengthMm).toBe(13100);        // 23100 − 10000
+  });
+});
+
+// =====================================================================
+// P1-3: autoCorrectCurrentSpool の下限は mountHistory の open 区間 sinceJobId
+//   （legacy spool.startPrintID ではなく ADR-0004 権威台帳を使う）
+// =====================================================================
+describe('P1-3: autoCorrect のオフライン紐付け下限は mountHistory sinceJobId', () => {
+  beforeEach(reset);
+
+  it('startPrintID がドリフトしても mountHistory の open 区間 sinceJobId で絞る', () => {
+    // アイドル（currentPrintID なし）でオフライン完了印刷を紐付ける状況
+    setupHost('h', {
+      history: [job(150, 5000), job(250, 6000)],
+      currentId: '', state: 0,
+    });
+    const SP = addSpool({
+      id: 'SP', totalLengthMm: 330000, remainingLengthMm: 300000,
+      isActive: true, hostname: 'h', currentPrintID: '',
+      startPrintID: '100', // ★ legacy 値はドリフトして 100（誤って古い）
+    });
+    mockMonitorData.hostSpoolMap = { h: 'SP' };
+    // ★ 権威台帳の open 区間は since=200（100 ではない）
+    ledger.appendMountEvent({ host: 'h', spoolId: 'SP', anchorRemainingMm: 300000, sinceJobId: 200, ts: 1 });
+    // autoCorrect / _linkOfflineJobsToSpool が読む履歴を供給
+    pmMock.loadHistory.mockReturnValue(mockMonitorData.machines['h'].printStore.history);
+
+    autoCorrectCurrentSpool('h');
+
+    // since=200 基準 → 250(>200) のみ紐付け、150(<=200) は除外。
+    // もし startPrintID=100 を使っていたら 150 も紐付いてしまう（＝バグ）。
+    expect(histJob('h', '250').filamentId, '250(>200) は紐付く').toBe('SP');
+    expect(histJob('h', '150').filamentId, '150(<=200 権威境界) は紐付かない').not.toBe('SP');
+  });
+
+  it('mountHistory が無い場合は startPrintID にフォールバック', () => {
+    setupHost('h', { history: [job(150, 5000), job(250, 6000)], currentId: '', state: 0 });
+    addSpool({
+      id: 'SP2', totalLengthMm: 330000, remainingLengthMm: 300000,
+      isActive: true, hostname: 'h', currentPrintID: '', startPrintID: '200',
+    });
+    mockMonitorData.hostSpoolMap = { h: 'SP2' };
+    // mountHistory は空（open 区間なし）→ startPrintID=200 にフォールバック
+    pmMock.loadHistory.mockReturnValue(mockMonitorData.machines['h'].printStore.history);
+
+    autoCorrectCurrentSpool('h');
+
+    expect(histJob('h', '250').filamentId, '250(>200) 紐付く').toBe('SP2');
+    expect(histJob('h', '150').filamentId, '150(<=200) 紐付かない').not.toBe('SP2');
   });
 });


### PR DESCRIPTION
統合監査 P1-3。**⚠ フィラメント帰属の入力変更＝実機検証候補。main 未マージ**（1035 と同じく検証後にマージ）。

- `autoCorrectCurrentSpool` のオフライン完了印刷 遡及紐付けの下限を、legacy `spool.startPrintID` から
  mountHistory の open 区間 `sinceJobId`（ADR-0004 権威台帳・`getSpoolIntervals`）へ変更。
  `startPrintID` ドリフト時の過剰紐付けを防ぐ。mount 記録が無い旧データのみ `startPrintID` フォールバック。

新規2テスト（境界200で250のみ紐付け／記録なし時フォールバック）。全**783**テスト緑・eslint 0 error。

## 検証観点
- オフライン中（アプリ停止中）に完了した印刷が、**現在装着スプールの装着区間内のジョブだけ**に遡及紐付けされるか（区間外の古いジョブに誤って紐付かないか）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)