### PR TITLE
fix(filament): close restart idempotency and ledger projection hardening (#410, stacked on #409)

### DIFF
--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -1196,7 +1196,10 @@ export function aggregatorUpdate() {
       s._completionObsId = null;
     } else if (isCompleted && !s._completionObsId && !_isRelayChild()) {
       s._completionObsId = randomEventId();
-      // ★ finalize より前に永続化（クラッシュ耐性）。ID→隔離の順序で保存する。
+      // ★ finalize より「前に」永続化する（クラッシュ耐性・ID→隔離の順序）。
+      //   persistAggregatorState は localStorage.setItem を「同期」で行うため、この行を抜けた時点で
+      //   _completionObsId は耐久保存済み（メモリのみではない）。restoreAggregatorState が localStorage
+      //   から復元する。ゆえに「ID生成→耐久保存→finalize→隔離」の順序が保証される。
       try { persistAggregatorState(host); } catch (e) { console.warn("[aggregator] completionObsId 永続化失敗:", e?.message || e); }
     }
 

--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -60,18 +60,6 @@ import { getConnectionState } from "./dashboard_connection.js";
 import { normalizeJobId } from "./dashboard_utils.js";
 import { monotonicNowMs, randomEventId } from "./dashboard_time.js";
 
-/**
- * ★ RR-1(電源断対策): アプリ起動セッションごとに一意な ID。completionOpId に含めることで、
- * 再起動で per-host の completion seq が 0 へ戻っても、別セッションの別完了が同一
- * completionOpId になって「別々の消費が誤って冪等スキップされる」衝突を防ぐ。
- * @private @returns {string}
- */
-let _aggregatorSessionId = null;
-function _sessionId() {
-  if (!_aggregatorSessionId) _aggregatorSessionId = randomEventId();
-  return _aggregatorSessionId;
-}
-
 // ---------------------------------------------------------------------------
 // 状態変数／タイムスタンプ定義（per-host 管理）
 // ---------------------------------------------------------------------------
@@ -1200,16 +1188,16 @@ export function aggregatorUpdate() {
       catch (e) { console.warn("[aggregator] _evaluateStaleRunout 失敗:", e?.message || e); }
     }
 
-    // ★ RR-1(レビュー2): 完了観測ごとの安定 opId をスタンプする。印刷中→完了エッジで採番し、
-    //   完了状態が続く間は再利用（再送では同一ID＝隔離が冪等）。次の印刷開始で解除し、別の印刷は
-    //   別 seq になる（同一 G-code の2回印刷で jobId 欠落しても別々に隔離＝payload衝突で捨てない）。
+    // ★ #410-1(レビュー3): 完了観測ごとの安定 ID(completionObsId)。印刷中→完了エッジで
+    //   UUID を採番し、finalize/quarantine より「前に」永続化する。これにより保存途中クラッシュ後の
+    //   再観測でも同一完了に同じ ID を再利用でき（＝二重隔離しない）、別完了は別 UUID になる
+    //   （payload衝突で捨てない）。次の印刷開始で解除する。
     if (isPrinting) {
-      s._completionStamped = false;
-    } else if (isCompleted && !s._completionStamped) {
-      s._completionSeq = (s._completionSeq || 0) + 1;
-      // ★ RR-1(電源断対策): セッションIDを含めて再起動を跨いだ seq 衝突を防ぐ。
-      s._completionOpId = `${host}:${_sessionId()}:c${s._completionSeq}`;
-      s._completionStamped = true;
+      s._completionObsId = null;
+    } else if (isCompleted && !s._completionObsId && !_isRelayChild()) {
+      s._completionObsId = randomEventId();
+      // ★ finalize より前に永続化（クラッシュ耐性）。ID→隔離の順序で保存する。
+      try { persistAggregatorState(host); } catch (e) { console.warn("[aggregator] completionObsId 永続化失敗:", e?.message || e); }
     }
 
     if (spool && isCompleted && !isPrinting && spool.currentPrintID) {
@@ -1223,7 +1211,7 @@ export function aggregatorUpdate() {
       //   （下の完了ブロックと相互排他）。
       if (spool.currentJobStartLength != null && s.accumulatedUsedMaterial > 0) {
         const _isSuccess = (st === PRINT_STATE_CODE.printDone);
-        try { finalizeFilamentUsage(s.accumulatedUsedMaterial, _jobId, host, _isSuccess, { completionOpId: s._completionOpId }); }
+        try { finalizeFilamentUsage(s.accumulatedUsedMaterial, _jobId, host, _isSuccess, { completionOpId: s._completionObsId }); }
         catch (e) { console.warn("[aggregator] finalize(P0-7) 失敗:", e?.message || e); }
         try { reconcileSpool(spool.id, { ts: _now }); }
         catch (e2) { console.warn("[aggregator] reconcileSpool(P0-7) 失敗:", e2?.message || e2); }
@@ -1478,7 +1466,7 @@ export function aggregatorUpdate() {
           }
         }
         const isSuccess2 = (st === PRINT_STATE_CODE.printDone);
-        finalizeFilamentUsage(s.accumulatedUsedMaterial, spool.currentPrintID, host, isSuccess2, { completionOpId: s._completionOpId });
+        finalizeFilamentUsage(s.accumulatedUsedMaterial, spool.currentPrintID, host, isSuccess2, { completionOpId: s._completionObsId });
         // ★ ADR-0004: 完了後に信頼ソースから残量を冪等補正（idle で権威補正）。
         //   finalize 内でも reconcile するが、currentPrintID クリア後の確定状態で再度走らせる。
         //   reconcile は印刷中スプールに触れないため二重防御として安全。冪等なので無害。
@@ -1652,7 +1640,9 @@ export function restoreAggregatorState(hostname) {
     "prevProgress",
     "lastPrintState",
     "lastProgressTimestamp",
-    "prevRemainingSec"
+    "prevRemainingSec",
+    // ★ #410-1: 完了観測ID（再起動後に同一完了へ同じIDを再利用するため復元する）
+    "_completionObsId"
   ];
   // まず storedData 側をクリア
   keys.forEach(k => {
@@ -1779,7 +1769,9 @@ export function persistAggregatorState(hostname) {
     notifiedTimeThresholds: [...s.notifiedTimeThresholds],
     notifiedTempMilestones: [...s.notifiedTempMilestones],
     filamentLowWarned: s.filamentLowWarned || false,
-    _removalReminderSent: s._removalReminderSent || false
+    _removalReminderSent: s._removalReminderSent || false,
+    // ★ #410-1: 完了観測ID（クラッシュ後の同一完了 replay を冪等にする＝二重隔離しない）
+    _completionObsId: s._completionObsId || null
   };
   Object.entries(toSave).forEach(([k, v]) => {
     const key = prefix + k;

--- a/3dp_lib/dashboard_attribution_notify.js
+++ b/3dp_lib/dashboard_attribution_notify.js
@@ -22,7 +22,7 @@
 
 "use strict";
 
-import { getAttributionIssueIdsForHost } from "./dashboard_spool.js";
+import { getAttributionIssueIdsForHost, countAttributionIssuesForHost } from "./dashboard_spool.js";
 import { getHostDisplayName } from "./dashboard_data.js";
 import { showAlert } from "./dashboard_notification_manager.js";
 import { monotonicNowMs } from "./dashboard_time.js";
@@ -88,12 +88,16 @@ export function evaluateAttributionNotice(host, { nowMs = 0 } = {}) {
   const st = _getState(host);
   const current = getAttributionIssueIdsForHost(host);
 
+  // ★ #410-7: 通知の total はバッジと一致させるため countAttributionIssuesForHost（詳細＋集約済み）。
+  //   新規判定(newIds)は詳細IDの集合差分で行う（集約済みは詳細IDを持たないため差分対象外）。
+  const total = countAttributionIssuesForHost(host);
+
   if (!st.initialized) {
     st.initialized = true;
     st.observed = new Set(current);
     if (current.size > 0) {
       st.lastNotifiedAt = nowMs;
-      return { host, newIds: [...current], total: current.size, kind: "startup" };
+      return { host, newIds: [...current], total, kind: "startup" };
     }
     return null;
   }
@@ -102,7 +106,7 @@ export function evaluateAttributionNotice(host, { nowMs = 0 } = {}) {
   st.observed = new Set(current); // 解決分も反映（再通知しない）
   if (newIds.length === 0) return null;
   st.lastNotifiedAt = nowMs;
-  return { host, newIds, total: current.size, kind: "new" };
+  return { host, newIds, total, kind: "new" };
 }
 
 /**

--- a/3dp_lib/dashboard_data.js
+++ b/3dp_lib/dashboard_data.js
@@ -267,6 +267,13 @@ export const monitorData = {
    */
   mountHistorySeq: 0,
   /**
+   * ★ #410-9: import/restore 時に参照不整合と判定された mount イベントの隔離領域。
+   * 有効な projection へは適用せず（corrupt 化を防ぐ）、元データは失わない。
+   * 各要素: { event, reason }
+   * @type {Array<Object>}
+   */
+  mountHistoryRejectedEvents: [],
+  /**
    * ★ Phase2A: 有効な jobId が無いまま完了した消費の隔離領域。
    * 電源投入直後などで printStartTime が 0/null の「無効ID」ジョブは
    * 履歴・usedLengthLog・境界へ確定記録を作らず（過去全履歴の誤減算＝退行を防ぐ）、

--- a/3dp_lib/dashboard_filament_ledger.js
+++ b/3dp_lib/dashboard_filament_ledger.js
@@ -123,6 +123,9 @@ function _isCompleted(job) {
   return Number(job?.materialUsedMm || 0) > 0;
 }
 
+/** mountHistoryRejectedEvents の保持上限（rotation で最新のみ保持）。 */
+const REJECTED_CAP = 1000;
+
 /**
  * mountHistory から参照不整合イベントを隔離する（#410-9・import/restore 後の防衛）。
  *
@@ -158,9 +161,15 @@ export function quarantineInvalidMountEvents() {
   }
   if (rejected.length) {
     if (!Array.isArray(monitorData.mountHistoryRejectedEvents)) monitorData.mountHistoryRejectedEvents = [];
+    const now = wallNowMs();
+    for (const r of rejected) r.rejectedAtEpochMs = now; // 監査・将来TTL用
     monitorData.mountHistoryRejectedEvents.push(...rejected);
     monitorData.mountHistory = kept;
-    console.warn(`[quarantineInvalidMountEvents] 参照不整合 ${rejected.length} 件を mountHistoryRejectedEvents へ隔離`);
+    // ★ P0-2(レビュー4): 保持上限（最新 REJECTED_CAP 件）で無制限成長→毎回ロードを防ぐ。
+    //   古い順に溢れた分を捨てる（rotation）。隔離は稀なため件数上限で十分。
+    const arr = monitorData.mountHistoryRejectedEvents;
+    if (arr.length > REJECTED_CAP) arr.splice(0, arr.length - REJECTED_CAP);
+    console.warn(`[quarantineInvalidMountEvents] 参照不整合 ${rejected.length} 件を mountHistoryRejectedEvents へ隔離（保持上限 ${REJECTED_CAP}）`);
   }
   return rejected.length;
 }

--- a/3dp_lib/dashboard_filament_ledger.js
+++ b/3dp_lib/dashboard_filament_ledger.js
@@ -268,13 +268,32 @@ export function appendReanchorEvent({ host, spoolId, targetIntervalId, anchorRem
  * @param {number} [p.ts] - イベント時刻 ms（監査用。省略時 wallNowMs）
  * @returns {Object} 追記イベント
  */
-export function appendSupersedeEvent({ host, spoolId, targetIntervalIds, survivingIntervalId = null, reason, ts = wallNowMs(), opId: providedOpId } = {}) {
+export function appendSupersedeEvent({ host, spoolId, targetIntervalIds, survivingIntervalId = null, reason, ts = wallNowMs(), opId: providedOpId, force = false } = {}) {
   const list = _getMountHistory();
   const ids = Array.isArray(targetIntervalIds) ? targetIntervalIds.slice().sort() : [];
   // ★ Phase2B/P1-1: opId=再送冪等キー。上位提供が無ければ内容ベース composite へフォールバック。
   const opId = providedOpId || `supersede_${spoolId}_${ids.join("+")}_${ts}`;
   const dup = list.find(e => e && (e.opId || e.evId) === opId);
   if (dup) return dup;
+  // ★ #410-2(レビュー3): survivor を指定するなら、追記前に入力整合性を検証する。
+  //   survivor が実在・open・非superseded・host一致で、かつ修復後 open が正確に1件(=survivor)に
+  //   なることを保証する（「たまたま1 openになる」ではなく survivor が保証される）。
+  if (!force && survivingIntervalId != null) {
+    const proj = _buildIntervalProjection(spoolId);
+    const surv = proj.byId.get(survivingIntervalId);
+    if (!surv || surv.superseded || surv.untilJobId != null || surv.host !== host) {
+      console.warn(`[appendSupersedeEvent] survivingIntervalId=${survivingIntervalId} が有効な open 区間でない → 拒否(supersede-invalid-survivor)`);
+      return null;
+    }
+    const targetSet = new Set(ids);
+    const remainingOpen = proj.intervals.filter(iv =>
+      iv.host === host && !iv.superseded && iv.untilJobId == null
+      && iv.intervalId !== survivingIntervalId && !targetSet.has(iv.intervalId));
+    if (remainingOpen.length > 0) {
+      console.warn(`[appendSupersedeEvent] 修復後 open が1件にならない（未対象 open ${remainingOpen.length}件）→ 拒否(supersede-repair-incomplete)`);
+      return null;
+    }
+  }
   const ev = {
     evId: randomEventId(),
     opId,
@@ -423,10 +442,17 @@ function _buildIntervalProjection(spoolId) {
     .filter(e => e && e.spoolId === spoolId
       && (e.type === "mount" || e.type === "unmount" || e.type === "reanchor" || e.type === "supersede"))
     .slice()
+    // ★ #410-3(レビュー3): 全順序ソート。seq→ts→evId(||opId) の3段 tie-break で、
+    //   同一 seq・同一 ts でも決定論的に順序が定まる（非推移比較=Array.sort 未定義動作を排除）。
+    //   seq 無しの旧イベントは seq=0 扱い＝API採番(≥1)より前に置き（旧＝時系列で先）、
+    //   同値は ts→evId で決定的に並べる。
     .sort((a, b) => {
-      const sa = Number(a.seq), sb = Number(b.seq);
-      if (Number.isFinite(sa) && Number.isFinite(sb) && sa !== sb) return sa - sb;
-      return (Number(a.ts) || 0) - (Number(b.ts) || 0);
+      const sa = Number(a.seq) || 0;
+      const sb = Number(b.seq) || 0;
+      if (sa !== sb) return sa - sb;
+      const ta = Number(a.ts) || 0, tb = Number(b.ts) || 0;
+      if (ta !== tb) return ta - tb;
+      return String(a.evId || a.opId || "").localeCompare(String(b.evId || b.opId || ""));
     });
 
   const intervals = [];

--- a/3dp_lib/dashboard_filament_ledger.js
+++ b/3dp_lib/dashboard_filament_ledger.js
@@ -124,6 +124,48 @@ function _isCompleted(job) {
 }
 
 /**
+ * mountHistory から参照不整合イベントを隔離する（#410-9・import/restore 後の防衛）。
+ *
+ * ★ レビュー3: import された不正参照イベントをそのまま本台帳へ入れると projection が corrupt に
+ * なり derive が停止する。自動で survivor を推測して修復するのは誤帰属を確定する恐れがあるため
+ * 行わず、参照先の mount 区間が存在しない reanchor/unmount(target付き)/supersede を
+ * `mountHistoryRejectedEvents` へ退避する（元データは失わず、有効 projection には適用しない）。
+ * closed/superseded 参照は projection が安全に扱うため対象外（存在しない参照のみ隔離）。
+ *
+ * @function quarantineInvalidMountEvents
+ * @returns {number} 隔離した件数
+ */
+export function quarantineInvalidMountEvents() {
+  const list = _getMountHistory();
+  if (!list.length) return 0;
+  const mountIds = new Set();
+  for (const e of list) {
+    if (e && e.type === "mount") mountIds.add(e.intervalId || e.evId);
+  }
+  const rejected = [];
+  const kept = [];
+  for (const e of list) {
+    let reason = null;
+    if (e && e.type === "reanchor") {
+      if (e.targetIntervalId == null || !mountIds.has(e.targetIntervalId)) reason = "reanchor-invalid-reference";
+    } else if (e && e.type === "unmount") {
+      if (e.targetIntervalId != null && !mountIds.has(e.targetIntervalId)) reason = "unmount-invalid-reference";
+    } else if (e && e.type === "supersede") {
+      const ids = Array.isArray(e.targetIntervalIds) ? e.targetIntervalIds : [];
+      if (ids.some(id => !mountIds.has(id))) reason = "supersede-invalid-reference";
+    }
+    if (reason) rejected.push({ event: e, reason }); else kept.push(e);
+  }
+  if (rejected.length) {
+    if (!Array.isArray(monitorData.mountHistoryRejectedEvents)) monitorData.mountHistoryRejectedEvents = [];
+    monitorData.mountHistoryRejectedEvents.push(...rejected);
+    monitorData.mountHistory = kept;
+    console.warn(`[quarantineInvalidMountEvents] 参照不整合 ${rejected.length} 件を mountHistoryRejectedEvents へ隔離`);
+  }
+  return rejected.length;
+}
+
+/**
  * 装着イベントを mountHistory に追記する。
  *
  * @function appendMountEvent

--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -59,7 +59,9 @@ import {
   formatSpoolDisplayId,
   buildFilamentRecommendations,
   getAttributionPresentation,
-  countAttributionIssuesForHost
+  countAttributionIssuesForHost,
+  getAttributionIssueIdsForHost,
+  countUnattributedArchiveForHost
 } from "./dashboard_spool.js";
 import { sendCommand, fetchStoredData, getDeviceIp, getDisplayBaseUrl, getConnectionState, getPrinterType } from "./dashboard_connection.js";
 import { recomputeSpoolFromManualEdit } from "./dashboard_filament_ledger.js";
@@ -1787,12 +1789,20 @@ export function updateAttributionBadge(hostname) {
     if (!panel) return;
     const badge = panel.querySelector(".panel-attr-badge");
     if (!badge) return;
-    const n = countAttributionIssuesForHost(hostname);
-    if (n > 0) {
-      badge.textContent = `未確認 ${n}`;
+    // ★ #410-7: 詳細（履歴/隔離で確認可能）と 集約済み（上限超過で詳細なし）を分けて示す。
+    //   バッジ本文は詳細件数、集約済みがあれば "+M" を付し、ツールチップで内訳を明示する。
+    const detail = getAttributionIssueIdsForHost(hostname).size;
+    const archived = countUnattributedArchiveForHost(hostname);
+    const total = detail + archived;
+    if (total > 0) {
+      badge.textContent = archived > 0 ? `未確認 ${detail}+${archived}` : `未確認 ${detail}`;
+      badge.title = archived > 0
+        ? `未確認 ${total} 件（確認可能 ${detail} 件・集約済み ${archived} 件＝詳細なし）`
+        : `未確認 ${detail} 件`;
       badge.hidden = false;
     } else {
       badge.textContent = "";
+      badge.title = "";
       badge.hidden = true;
     }
   } catch { /* DOM 未構築・環境非DOM は無視 */ }

--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -2091,12 +2091,30 @@ export function shouldLinkOfflineJob(job) {
  * @param {Object} entry - 履歴ジョブ（printStore.history / historyData のエントリ）
  * @returns {boolean} 帰属未確認なら true
  */
+/**
+ * 履歴エントリが「完了」しているかの共通判定（Phase5 P1-5 / #410-8）。
+ * printfinish が正のシグナル。旧保存データは printfinish 欠落でも finishTime/finishTimeSec/
+ * endtime/usagetime による完了証拠があれば完了扱いにする（古いログを未完了と誤判定しない）。
+ *
+ * @function isCompletedHistoryEntry
+ * @param {Object} entry - 履歴ジョブ
+ * @returns {boolean} 完了なら true
+ */
+export function isCompletedHistoryEntry(entry) {
+  if (!entry) return false;
+  if (entry.printfinish != null) return true;
+  if (Number(entry.finishTime) > 0) return true;
+  if (Number(entry.finishTimeSec) > 0) return true;
+  if (Number(entry.endtime) > 0) return true;
+  if (Number(entry.usagetime) > 0) return true;
+  return false;
+}
+
 export function isAttributionPending(entry) {
   if (!entry) return false;
-  // ★ P1-5(レビュー): 完了ジョブのみ対象。printfinish==null は「未確定/印刷中」を意味し
-  //   （K1 は印刷中エントリにも materialUsedMm を載せ得る）、現在進行中の現在ジョブを
-  //   「未確認」と誤判定してチップ/バッジ/通知させないよう除外する。
-  if (entry.printfinish == null) return false;
+  // ★ P1-5/#410-8(レビュー): 完了ジョブのみ対象。印刷中(未完了)の現在ジョブを「未確認」と
+  //   誤判定させない。旧保存データ(printfinish欠落だが finishTime/endtime あり)も完了扱いにする。
+  if (!isCompletedHistoryEntry(entry)) return false;
   // 消費が無い（materialUsedMm<=0）ジョブは帰属対象外＝pending ではない。
   if (!(Number(entry.materialUsedMm || 0) > 0)) return false;
   const info = Array.isArray(entry.filamentInfo) ? entry.filamentInfo : [];
@@ -2186,8 +2204,20 @@ export function getAttributionIssueIdsForHost(host) {
  */
 export function countAttributionIssuesForHost(host) {
   // 詳細レコード（履歴pending＋隔離）＋ 上限超過でアーカイブへ集約された件数。
+  return getAttributionIssueIdsForHost(host).size + countUnattributedArchiveForHost(host);
+}
+
+/**
+ * 指定ホストの「集約済み（詳細なし）」未確認件数を返す（#410-7 バッジ内訳表示用）。
+ * これらは pendingUnattributedUsage の上限超過でアーカイブへ畳まれ、個別詳細は持たない。
+ *
+ * @function countUnattributedArchiveForHost
+ * @param {string} host - ホスト名
+ * @returns {number} 集約済み件数
+ */
+export function countUnattributedArchiveForHost(host) {
   const arch = monitorData.pendingUnattributedUsageArchive?.[host];
-  return getAttributionIssueIdsForHost(host).size + (Number(arch?.count) || 0);
+  return Number(arch?.count) || 0;
 }
 
 /**

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -40,7 +40,7 @@ import { monitorData, ensureMachineData, PLACEHOLDER_HOSTNAME } from "./dashboar
 import { FILAMENT_PRESETS } from "./dashboard_filament_presets.js";
 import { logManager } from "./dashboard_log_util.js";
 import { getCurrentTimestamp } from "./dashboard_utils.js";
-import { initLedgerAnchors } from "./dashboard_filament_ledger.js";
+import { initLedgerAnchors, quarantineInvalidMountEvents } from "./dashboard_filament_ledger.js";
 import { parseDest, isIpLiteral, extractHost } from "./dashboard_target_identity.js";
 import {
   initIdb,
@@ -654,6 +654,8 @@ const LS_GLOBAL_FIELDS = [
   "userPresets", "hiddenPresets", "favoritePresets", "filamentInventory",
   // ★ ADR-0004: フィラメント装着履歴 ＋ watermark(seq)
   "mountHistory", "mountHistorySeq",
+  // ★ #410-9: 参照不整合で隔離した mount イベント（元データを失わない）
+  "mountHistoryRejectedEvents",
   // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない）
   "pendingUnattributedUsage", "pendingUnattributedUsageArchive",
   // ★ RR-2: 台帳修復要求フラグ（破損時に暗黙クローズせず可視化）
@@ -875,6 +877,7 @@ function _flushStorage() {
       // ★ ADR-0004: フィラメント装着履歴（残量導出の権威）＋ watermark(seq)
       queueSharedWrite("mountHistory",       monitorData.mountHistory);
       queueSharedWrite("mountHistorySeq",    monitorData.mountHistorySeq);
+      queueSharedWrite("mountHistoryRejectedEvents", monitorData.mountHistoryRejectedEvents);
       // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない・子へも配信）
       queueSharedWrite("pendingUnattributedUsage",        monitorData.pendingUnattributedUsage);
       queueSharedWrite("pendingUnattributedUsageArchive", monitorData.pendingUnattributedUsageArchive);
@@ -1006,6 +1009,9 @@ function _reconcileAfterRestore() {
     console.debug("[restoreUnifiedStorage] リレー子: 台帳アンカー種付けをスキップ（親が権威）");
     return;
   }
+  // ★ #410-9: 種付け前に、import/復元された参照不整合イベントを隔離する（projection の corrupt 化防止）。
+  try { quarantineInvalidMountEvents(); }
+  catch (e) { console.warn("[restoreUnifiedStorage] quarantineInvalidMountEvents 失敗:", e?.message || e); }
   try {
     const report = initLedgerAnchors({ nowMs: Date.now() });
     if (report && report.seeded > 0) {

--- a/3dp_lib/dashboard_storage_idb.js
+++ b/3dp_lib/dashboard_storage_idb.js
@@ -101,6 +101,8 @@ const SHARED_KEYS = [
   // ★ ADR-0004: フィラメント装着履歴（残量導出の権威）＋ watermark(seq)
   "mountHistory",
   "mountHistorySeq",
+  // ★ #410-9: 参照不整合で隔離した mount イベント
+  "mountHistoryRejectedEvents",
   // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない）
   "pendingUnattributedUsage",
   "pendingUnattributedUsageArchive",

--- a/tests/unit/dashboard_attribution_notify.test.js
+++ b/tests/unit/dashboard_attribution_notify.test.js
@@ -7,6 +7,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 let _issueIds = new Set();
 vi.mock("../../3dp_lib/dashboard_spool.js", () => ({
   getAttributionIssueIdsForHost: vi.fn(() => new Set(_issueIds)),
+  countAttributionIssuesForHost: vi.fn(() => _issueIds.size),
 }));
 vi.mock("../../3dp_lib/dashboard_data.js", () => ({
   getHostDisplayName: vi.fn((h) => h),

--- a/tests/unit/dashboard_filament_ledger.test.js
+++ b/tests/unit/dashboard_filament_ledger.test.js
@@ -1217,6 +1217,19 @@ describe("mount-event モデル再設計(レビュー第3弾 Q1)", () => {
     expect(mockMonitorData.mountHistory.filter(e => e.type === "reanchor")).toHaveLength(0);
   });
 
+  it("#410-9/P0-2: mountHistoryRejectedEvents は上限1000で rotation（古い順に溢れる）", () => {
+    addSpool({ id: "S", totalLengthMm: 330000, remainingLengthMm: 250000 });
+    appendMountEvent({ host: "h", spoolId: "S", anchorRemainingMm: 300000, sinceJobId: 0, ts: 1 });
+    // 既に上限まで隔離済みを模す
+    mockMonitorData.mountHistoryRejectedEvents = Array.from({ length: 1000 }, (_, i) => ({ event: { evId: `old${i}` }, reason: "x" }));
+    // 新たな不正参照を1件隔離 → 溢れ1件を古い順に捨て、上限維持
+    mockMonitorData.mountHistory.push({ evId: "bad", opId: "bad", seq: 9, ts: 2, type: "reanchor", host: "h", spoolId: "S", targetIntervalId: "nope", anchorRemainingMm: 1, sinceJobId: 1 });
+    quarantineInvalidMountEvents();
+    expect(mockMonitorData.mountHistoryRejectedEvents).toHaveLength(1000);
+    expect(mockMonitorData.mountHistoryRejectedEvents[0].event.evId).toBe("old1"); // old0 が溢れた
+    expect(mockMonitorData.mountHistoryRejectedEvents[999].reason).toBe("reanchor-invalid-reference");
+  });
+
   it("Q1: import 済み invalid-reference reanchor（API 迂回）は corrupt で derive を停止", () => {
     // API はもう invalid を作らないが、旧データ/外部importで混入した不整合は projection が検出する。
     addSpool({ id: "S", totalLengthMm: 330000, remainingLengthMm: 250000 });

--- a/tests/unit/dashboard_filament_ledger.test.js
+++ b/tests/unit/dashboard_filament_ledger.test.js
@@ -1132,6 +1132,60 @@ describe("mount-event モデル再設計(レビュー第3弾 Q1)", () => {
     expect(s2).toBe("b");
   });
 
+  it("#410-2: appendSupersedeEvent は不正な survivor を拒否（実在しない/クローズ済み）", () => {
+    addSpool({ id: "S", totalLengthMm: 330000, remainingLengthMm: 260000 });
+    appendMountEvent({ host: "h", spoolId: "S", anchorRemainingMm: 300000, sinceJobId: 0, ts: 1 });
+    const iv = getSpoolIntervals("S")[0].intervalId;
+    // survivor が実在しない
+    expect(appendSupersedeEvent({ host: "h", spoolId: "S", targetIntervalIds: [iv], survivingIntervalId: "ghost", ts: 2 })).toBeNull();
+    // supersede が追記されていない
+    expect(mockMonitorData.mountHistory.filter(e => e.type === "supersede")).toHaveLength(0);
+  });
+
+  it("#410-2: 修復後 open が1件にならない supersede を拒否（未対象openが残る）", () => {
+    addSpool({ id: "S", totalLengthMm: 330000, remainingLengthMm: 260000 });
+    // 3 open を直接注入（破損状態）
+    mockMonitorData.mountHistory.push(
+      { evId: "a", opId: "a", intervalId: "a", seq: 1, ts: 1, type: "mount", host: "h", spoolId: "S", anchorRemainingMm: 300000, sinceJobId: 0, boundaryStatus: "known" },
+      { evId: "b", opId: "b", intervalId: "b", seq: 2, ts: 2, type: "mount", host: "h", spoolId: "S", anchorRemainingMm: 260000, sinceJobId: 5, boundaryStatus: "known" },
+      { evId: "c", opId: "c", intervalId: "c", seq: 3, ts: 3, type: "mount", host: "h", spoolId: "S", anchorRemainingMm: 250000, sinceJobId: 9, boundaryStatus: "known" }
+    );
+    // a のみ対象・survivor=b → c が未対象 open のまま残る → 拒否
+    expect(appendSupersedeEvent({ host: "h", spoolId: "S", targetIntervalIds: ["a"], survivingIntervalId: "b", ts: 4 })).toBeNull();
+    // a,c 対象・survivor=b → 修復後 open は b のみ → 成功
+    const ok = appendSupersedeEvent({ host: "h", spoolId: "S", targetIntervalIds: ["a", "c"], survivingIntervalId: "b", ts: 5 });
+    expect(ok).not.toBeNull();
+    expect(getMountIntervalStatus("S", "h").openInterval.intervalId).toBe("b");
+  });
+
+  it("#410-3: mountHistory を serialize/reload しても survivor が同じ（決定論）", () => {
+    addSpool({ id: "S", totalLengthMm: 330000, remainingLengthMm: 260000 });
+    mockMonitorData.mountHistory.push(
+      { evId: "a", opId: "a", intervalId: "a", seq: 1, ts: 1, type: "mount", host: "h", spoolId: "S", anchorRemainingMm: 300000, sinceJobId: 0, boundaryStatus: "known" },
+      { evId: "b", opId: "b", intervalId: "b", seq: 2, ts: 2, type: "mount", host: "h", spoolId: "S", anchorRemainingMm: 260000, sinceJobId: 5, boundaryStatus: "known" }
+    );
+    appendSupersedeEvent({ host: "h", spoolId: "S", targetIntervalIds: ["a", "b"], survivingIntervalId: "b", ts: 3 });
+    const before = getMountIntervalStatus("S", "h").openInterval.intervalId;
+    // serialize→reload 相当（配列順もシャッフルして順序非依存を確認）
+    const reloaded = JSON.parse(JSON.stringify(mockMonitorData.mountHistory)).reverse();
+    mockMonitorData.mountHistory = reloaded;
+    const after = getMountIntervalStatus("S", "h").openInterval.intervalId;
+    expect(after).toBe(before);
+    expect(after).toBe("b");
+  });
+
+  it("#410-3: 同一seq・同一tsでも evId tie-break で順序決定的", () => {
+    addSpool({ id: "S", totalLengthMm: 100000, remainingLengthMm: 100000 });
+    // 同一 seq・同一 ts の2イベント（配列順を変えても projection 結果が同じ）
+    const ev1 = { evId: "z-mount", opId: "z", intervalId: "z", seq: 5, ts: 100, type: "mount", host: "h", spoolId: "S", anchorRemainingMm: 100000, sinceJobId: 0, boundaryStatus: "known" };
+    const ev2 = { evId: "a-unmount", opId: "a", seq: 5, ts: 100, type: "unmount", host: "h", spoolId: "S", untilJobId: 3, targetIntervalId: "z" };
+    mockMonitorData.mountHistory = [ev1, ev2];
+    const s1 = getMountIntervalStatus("S", "h").status;
+    mockMonitorData.mountHistory = [ev2, ev1]; // 配列順反転
+    const s2 = getMountIntervalStatus("S", "h").status;
+    expect(s1).toBe(s2); // 決定論（配列順に依存しない）
+  });
+
   it("P0-4: appendReanchorEvent は存在しない対象への追記を拒否する（corrupt を作らない）", () => {
     addSpool({ id: "S", totalLengthMm: 330000, remainingLengthMm: 250000 });
     appendMountEvent({ host: "h", spoolId: "S", anchorRemainingMm: 300000, sinceJobId: 0, ts: 1, boundaryStatus: "known" });

--- a/tests/unit/dashboard_filament_ledger.test.js
+++ b/tests/unit/dashboard_filament_ledger.test.js
@@ -29,6 +29,7 @@ const {
   appendUnmountEvent,
   appendReanchorEvent,
   appendSupersedeEvent,
+  quarantineInvalidMountEvents,
   attributedUsed,
   getSpoolIntervals,
   getOpenMountInterval,
@@ -74,6 +75,7 @@ function reset() {
   mockMonitorData.filamentSpools = [];
   mockMonitorData.usageHistory = [];
   mockMonitorData.mountHistory = [];
+  mockMonitorData.mountHistoryRejectedEvents = [];
   mockMonitorData.hostSpoolMap = {};
   mockMonitorData.filamentEventContext = {};
 }
@@ -1194,6 +1196,25 @@ describe("mount-event モデル再設計(レビュー第3弾 Q1)", () => {
     expect(mockMonitorData.mountHistory.filter(e => e.type === "reanchor")).toHaveLength(0);
     // 正常な mount のみ残り projection は ok のまま（corrupt にしない）
     expect(getMountIntervalStatus("S", "h").status).toBe("ok");
+  });
+
+  it("#410-9: quarantineInvalidMountEvents は参照不整合を隔離し projection を ok に戻す", () => {
+    addSpool({ id: "S", totalLengthMm: 330000, remainingLengthMm: 250000 });
+    appendMountEvent({ host: "h", spoolId: "S", anchorRemainingMm: 300000, sinceJobId: 0, ts: 1, boundaryStatus: "known" });
+    // import 相当で不正参照 reanchor を直接注入
+    mockMonitorData.mountHistory.push({
+      evId: "bad", opId: "bad", seq: 99, ts: 2, type: "reanchor", host: "h", spoolId: "S",
+      targetIntervalId: "does-not-exist", anchorRemainingMm: 1, sinceJobId: 1, boundaryStatus: "known"
+    });
+    expect(getMountIntervalStatus("S", "h").status).toBe("corrupt"); // 隔離前は corrupt
+    const n = quarantineInvalidMountEvents();
+    expect(n).toBe(1);
+    // 不正イベントは隔離され元データは失われない
+    expect(mockMonitorData.mountHistoryRejectedEvents).toHaveLength(1);
+    expect(mockMonitorData.mountHistoryRejectedEvents[0].reason).toBe("reanchor-invalid-reference");
+    // 隔離後は正常な mount のみ残り ok
+    expect(getMountIntervalStatus("S", "h").status).toBe("ok");
+    expect(mockMonitorData.mountHistory.filter(e => e.type === "reanchor")).toHaveLength(0);
   });
 
   it("Q1: import 済み invalid-reference reanchor（API 迂回）は corrupt で derive を停止", () => {

--- a/tests/unit/dashboard_printmanager_render_perf.test.js
+++ b/tests/unit/dashboard_printmanager_render_perf.test.js
@@ -60,6 +60,7 @@ vi.mock("../../3dp_lib/dashboard_spool.js", () => ({
   getAttributionPresentation: vi.fn(() => ({ state: "known", label: null, reason: null, severity: "none" })),
   countAttributionIssuesForHost: vi.fn(() => 0),
   getAttributionIssueIdsForHost: vi.fn(() => new Set()),
+  countUnattributedArchiveForHost: vi.fn(() => 0),
 }));
 vi.mock("../../3dp_lib/dashboard_connection.js", () => ({
   sendCommand: vi.fn(),

--- a/tests/unit/dashboard_spool.test.js
+++ b/tests/unit/dashboard_spool.test.js
@@ -710,9 +710,18 @@ describe('isAttributionPending / getUnattributedUsageForHost（Phase4）', () =>
     expect(isAttributionPending(null)).toBe(false);
   });
 
-  it('P1-5: 印刷中/未確定（printfinish=null）は消費ありでも pending でない', () => {
+  it('P1-5: 印刷中/未確定（printfinish=null かつ完了証拠なし）は消費ありでも pending でない', () => {
     expect(isAttributionPending({ id: 1, materialUsedMm: 5000, printfinish: null })).toBe(false);
     expect(isAttributionPending({ id: 1, materialUsedMm: 5000 })).toBe(false); // printfinish 欠落=未確定
+  });
+
+  it('#410-8: 旧保存データ(printfinish欠落だが finishTime/endtime あり)は完了扱いで pending 判定', () => {
+    // printfinish が無くても完了証拠（finishTime/endtime/usagetime）があれば完了→未帰属なら pending
+    expect(isAttributionPending({ id: 1, materialUsedMm: 5000, finishTime: 1784000000 })).toBe(true);
+    expect(isAttributionPending({ id: 1, materialUsedMm: 5000, endtime: 1784000000 })).toBe(true);
+    expect(isAttributionPending({ id: 1, materialUsedMm: 5000, usagetime: 3600 })).toBe(true);
+    // 完了証拠が一切なければ非完了
+    expect(isAttributionPending({ id: 1, materialUsedMm: 5000, finishTime: 0, endtime: 0 })).toBe(false);
   });
 
   it('getUnattributedUsageForHost はホストで絞り込み、count が件数を返す', () => {

--- a/tests/unit/dashboard_storage_migration.test.js
+++ b/tests/unit/dashboard_storage_migration.test.js
@@ -87,7 +87,7 @@ vi.mock('../../3dp_lib/dashboard_data.js', () => ({
 vi.mock('../../3dp_lib/dashboard_filament_presets.js', () => ({ FILAMENT_PRESETS: [] }));
 vi.mock('../../3dp_lib/dashboard_log_util.js', () => ({ logManager: { add: vi.fn() } }));
 vi.mock('../../3dp_lib/dashboard_utils.js', () => ({ getCurrentTimestamp: () => 0 }));
-vi.mock('../../3dp_lib/dashboard_filament_ledger.js', () => ({ initLedgerAnchors: () => ({ seeded: 0 }) }));
+vi.mock('../../3dp_lib/dashboard_filament_ledger.js', () => ({ initLedgerAnchors: () => ({ seeded: 0 }), quarantineInvalidMountEvents: () => 0 }));
 vi.mock('../../3dp_lib/dashboard_storage_idb.js', () => ({
   initIdb: vi.fn(), isIdbAvailable: () => false, getIdbCache: () => null,
   queueSharedWrite: vi.fn(), queueMachineWrite: vi.fn(), flushIdb: vi.fn(),

--- a/tests/unit/dashboard_storage_namespace.test.js
+++ b/tests/unit/dashboard_storage_namespace.test.js
@@ -70,7 +70,7 @@ vi.mock('../../3dp_lib/dashboard_filament_presets.js', () => ({ FILAMENT_PRESETS
 vi.mock('../../3dp_lib/dashboard_log_util.js', () => ({ logManager: { add: vi.fn() } }));
 vi.mock('../../3dp_lib/dashboard_utils.js', () => ({ getCurrentTimestamp: () => 0 }));
 const _initLedgerAnchors = vi.hoisted(() => vi.fn(() => ({ seeded: 0 })));
-vi.mock('../../3dp_lib/dashboard_filament_ledger.js', () => ({ initLedgerAnchors: _initLedgerAnchors }));
+vi.mock('../../3dp_lib/dashboard_filament_ledger.js', () => ({ initLedgerAnchors: _initLedgerAnchors, quarantineInvalidMountEvents: () => 0 }));
 
 /* IDB は実装の setIdbDbName 呼び出しを spy できる本物のモジュールを使う(LS 経路は無効化) */
 const _idbDbNameCalls = [];


### PR DESCRIPTION
## 概要

**#409（安全修正・親権威・未帰属隔離・最小可視化）から分離した、再起動冪等性・台帳決定性のハードニング PR。** レビュー3回目で #409 は「実機検証GO / main merge HOLD」となり、残ハードニングは本 PR へ切り出す方針が確定した（Option4 の推定帰属は **#411** へさらに分離）。

- **base = `claude/filament-parent-authority-fix`（#409）にスタック。** #409 が main へマージされたら本 PR を main へ rebase する。
- **推定帰属（inferred-continuity）は含めない。** 未観測期間の推定・seen job-ID watermark・offline window・confidence・推定減算・承認/取消は #411。

全 **951 テスト緑・lint 0 エラー**。#410 必須9項目すべて実装済。

## 目的（レビュー3の指摘クロージャー）

「衝突しなくなった」と「再起動を跨いで冪等になった」は別問題、という指摘に対応し、**#409 の session-uuid completionOpId を、完了観測時に先行永続化する completionObservationId へ差し替える**。加えて supersede survivor の入力整合性、mount イベントの全順序化を閉じる。

## 実装済

### #410-1 completionObservationId 先行永続化（再起動冪等の本命） `1f7a27a`
- 印刷中→完了エッジで `completionObsId`(UUID) を採番し、**finalize/quarantine より前に** `persistAggregatorState` で永続化（ID→隔離の順序）。
- クラッシュ位置に関わらず冪等: ID生成後〜finalize前で落ちても復元IDを再利用／隔離保存後に落ちても accumulated 未リセットなら再finalizeするが同一IDで冪等。
- 次の印刷開始で解除（別完了は別UUID＝payload衝突で捨てない）。`_completionObsId` を persist/restore へ追加。session-uuid 方式は撤去。リレー子は採番しない。

### #410-2 supersede survivor 入力整合性検証 `67dacde`
- `survivingIntervalId` が projection 内に実在・open・非superseded・host一致、かつ修復後 open が正確に1件(=survivor)になることを追記前に検証。不成立なら supersede-invalid-survivor / supersede-repair-incomplete として拒否。`force` は明示修復用。

### #410-3 mount イベント全順序化 `67dacde`
- projection sort を seq→ts→evId(||opId) の3段 tie-break へ（同一seq・同一tsでも決定論的）。seq 無し旧イベントは seq=0 扱い＝API採番(≥1)より前。serialize/reload・配列順反転しても survivor が同一であることをテスト。

### #410-4 P1クロージャー `6e6e834`
- **#410-8** legacy completion detection: `isCompletedHistoryEntry`（printfinish 欠落でも finishTime/finishTimeSec/endtime/usagetime で完了判定）。`isAttributionPending` をこれ経由に。
- **#410-9** import 不正イベント隔離: `quarantineInvalidMountEvents`（参照先 mount 区間が無い reanchor/unmount/supersede を `mountHistoryRejectedEvents` へ退避＝元データ保持・projection 非適用・自動 survivor 推測なし）。restore が種付け前に実行。LS/IDB 永続化。
- **#410-7** archive/notification 件数整合: `countUnattributedArchiveForHost` で集約済みを分離。バッジは「未確認 詳細+集約」＋ツールチップ内訳、通知 total も `countAttributionIssuesForHost` で統一。

## 残（任意・実機結果次第）

- クラッシュ境界の追加ユニットテスト（電源断は実機で確認する項目）。`mountHistoryRejectedEvents` の明示修復 UI。

## 実機（電源断）検証項目 ※#409 の HOLD 解除条件に対応

クラッシュ位置を分けて実施:
- A: printing→completed 検出前に終了
- B: completionObsId 生成直後に終了
- C: pendingUnattributedUsage 追加直後・保存前に終了
- D: 保存後に終了

再起動後の確認: pendingUnattributedUsage が 0消失も2重生成もしない／usedLengthLog 二重なし／remainingLengthMm 二重減算なし／同一物理完了の再処理挙動が説明可能／ledgerRepairRequired は必要時のみ。

## 禁止（本 PR に入れない）
inferred-continuity、未観測 job の推定帰属、推定結果による残量減算、Option4 の confidence/approval。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
