### PR TITLE
feat(filament): Option 4 inferred-continuity — offline continuity attribution (#411, stacked on #410, read-only base)

### DIFF
--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -1280,22 +1280,33 @@ export function aggregatorUpdate() {
     //   現在ジョブ(C)は除外し、filamentInfo/filamentId のみ補完（冪等）。historyList マージで
     //   printStore.history へ A/B が入り、C が解決された後に実行される。idle 時は上の
     //   autoCorrectCurrentSpool 経由でも補完される（冪等なので重複しない）。
-    // ★ #411-O1(Option4): 観測 watermark を read-only で更新する（推定帰属の前段）。
-    //   親のみ・5s throttle。安全基盤（隔離/台帳/completionObsId 等）には一切書き込まない。
-    //   ★ P0-3: spool の有無に依らず記録する（未装着/交換済みという反証を残すため）。
-    //   ★ P0-4: open 区間が一意(ok)のときだけ intervalId を明示配線し、ambiguous/corrupt は null。
-    if (!_isRelayChild() && (!s._lastObs || _mono - s._lastObs > 5000)) {
-      s._lastObs = _mono;
+    // ★ #411-O1(Option4): 観測 current を read-only で更新する（推定帰属の前段。O2 のライブ配線は未実施）。
+    //   親のみ。安全基盤（隔離/台帳/completionObsId 等）には一切書き込まない。
+    //   spool の有無に依らず記録する（未装着/交換済みという反証を残すため）。
+    //   open 区間が一意(ok)のときだけ intervalId を明示配線し、ambiguous/corrupt は null。
+    //   ★ P1-5: 固定5s heartbeat だけでなく、観測 signature（履歴rev/現在ジョブ/印刷状態/装着/interval）
+    //   が変化したら即記録し、稼働中に見たジョブを再起動後 offline と誤認する隙間を減らす。
+    if (!_isRelayChild()) {
+      // ★ read-only 観測は best-effort＝この中の失敗が本流（帰属/消費トラッキング）を止めないよう
+      //   ブロック全体を try で囲う（台帳参照や signature 計算の例外も飲み込む）。
       try {
-        // ★ P1-1: 未装着は「既知の none」（取得失敗の unknown と区別）。装着時は台帳 status。
+        // 未装着は「既知の none」（取得失敗の unknown と区別）。装着時は台帳 status。
         let _ivId = null, _ivStatus = "none";
         if (spool) {
           const _st = getMountIntervalStatus(spool.id, host);
           _ivStatus = _st.status;
           _ivId = (_st.status === "ok" && _st.openInterval) ? _st.openInterval.intervalId : null;
         }
-        recordObservation(host, { mountIntervalId: _ivId, mountIntervalStatus: _ivStatus });
-      } catch (e) { /* read-only 観測失敗は無視 */ }
+        const _activeJobId = machine?.printStore?.current?.id ?? null;
+        const _printState = Number(storedData.state?.rawValue ?? 0);
+        const _histRev = machine?.printStore?.revision ?? null;
+        const _obsSig = `${_histRev}|${_activeJobId}|${_printState}|${spool?.id ?? ""}|${_ivStatus}`;
+        if (!s._lastObs || _mono - s._lastObs > 5000 || s._lastObsSig !== _obsSig) {
+          s._lastObs = _mono;
+          s._lastObsSig = _obsSig;
+          recordObservation(host, { mountIntervalId: _ivId, mountIntervalStatus: _ivStatus, activeJobId: _activeJobId, printState: _printState });
+        }
+      } catch (e) { /* read-only 観測失敗は本流を止めない */ }
     }
 
     // catch-up でリベースが必要になった反映後残量（下の開始基準設定の後で currentJobStartLength へ反映）。

--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -55,7 +55,7 @@ import {
   // ★ P0-9: 自動 inferred 投入停止に伴い setCurrentSpoolId / addInferredSpool の
   //   aggregator からの利用は撤去（ユーザー明示交換のみ mount）。
 } from "./dashboard_spool.js";
-import { reconcileSpool, recordFilamentEvent, resolveFilamentEvent, getOpenFilamentEvent, runoutGateHeld, deriveSpoolRemaining } from "./dashboard_filament_ledger.js";
+import { reconcileSpool, recordFilamentEvent, resolveFilamentEvent, getOpenFilamentEvent, runoutGateHeld, deriveSpoolRemaining, getMountIntervalStatus } from "./dashboard_filament_ledger.js";
 import { getConnectionState } from "./dashboard_connection.js";
 import { normalizeJobId } from "./dashboard_utils.js";
 import { monotonicNowMs, randomEventId } from "./dashboard_time.js";
@@ -1282,10 +1282,19 @@ export function aggregatorUpdate() {
     //   autoCorrectCurrentSpool 経由でも補完される（冪等なので重複しない）。
     // ★ #411-O1(Option4): 観測 watermark を read-only で更新する（推定帰属の前段）。
     //   親のみ・5s throttle。安全基盤（隔離/台帳/completionObsId 等）には一切書き込まない。
-    if (spool && !_isRelayChild() && (!s._lastObs || _mono - s._lastObs > 5000)) {
+    //   ★ P0-3: spool の有無に依らず記録する（未装着/交換済みという反証を残すため）。
+    //   ★ P0-4: open 区間が一意(ok)のときだけ intervalId を明示配線し、ambiguous/corrupt は null。
+    if (!_isRelayChild() && (!s._lastObs || _mono - s._lastObs > 5000)) {
       s._lastObs = _mono;
-      try { recordHostObservation(host); }
-      catch (e) { /* read-only 観測失敗は無視 */ }
+      try {
+        let _ivId = null, _ivStatus = "unknown";
+        if (spool) {
+          const _st = getMountIntervalStatus(spool.id, host);
+          _ivStatus = _st.status;
+          _ivId = (_st.status === "ok" && _st.openInterval) ? _st.openInterval.intervalId : null;
+        }
+        recordHostObservation(host, { mountIntervalId: _ivId, mountIntervalStatus: _ivStatus });
+      } catch (e) { /* read-only 観測失敗は無視 */ }
     }
 
     // catch-up でリベースが必要になった反映後残量（下の開始基準設定の後で currentJobStartLength へ反映）。

--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -59,6 +59,7 @@ import { reconcileSpool, recordFilamentEvent, resolveFilamentEvent, getOpenFilam
 import { getConnectionState } from "./dashboard_connection.js";
 import { normalizeJobId } from "./dashboard_utils.js";
 import { monotonicNowMs, randomEventId } from "./dashboard_time.js";
+import { recordHostObservation } from "./dashboard_offline_observation.js";
 
 // ---------------------------------------------------------------------------
 // 状態変数／タイムスタンプ定義（per-host 管理）
@@ -1279,6 +1280,14 @@ export function aggregatorUpdate() {
     //   現在ジョブ(C)は除外し、filamentInfo/filamentId のみ補完（冪等）。historyList マージで
     //   printStore.history へ A/B が入り、C が解決された後に実行される。idle 時は上の
     //   autoCorrectCurrentSpool 経由でも補完される（冪等なので重複しない）。
+    // ★ #411-O1(Option4): 観測 watermark を read-only で更新する（推定帰属の前段）。
+    //   親のみ・5s throttle。安全基盤（隔離/台帳/completionObsId 等）には一切書き込まない。
+    if (spool && !_isRelayChild() && (!s._lastObs || _mono - s._lastObs > 5000)) {
+      s._lastObs = _mono;
+      try { recordHostObservation(host); }
+      catch (e) { /* read-only 観測失敗は無視 */ }
+    }
+
     // catch-up でリベースが必要になった反映後残量（下の開始基準設定の後で currentJobStartLength へ反映）。
     let _rebaseRemaining = null;
     if (spool && (!s._lastCatchUp || _mono - s._lastCatchUp > 10000)) {

--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -59,7 +59,7 @@ import { reconcileSpool, recordFilamentEvent, resolveFilamentEvent, getOpenFilam
 import { getConnectionState } from "./dashboard_connection.js";
 import { normalizeJobId } from "./dashboard_utils.js";
 import { monotonicNowMs, randomEventId } from "./dashboard_time.js";
-import { recordHostObservation } from "./dashboard_offline_observation.js";
+import { recordObservation } from "./dashboard_offline_observation.js";
 
 // ---------------------------------------------------------------------------
 // 状態変数／タイムスタンプ定義（per-host 管理）
@@ -1294,7 +1294,7 @@ export function aggregatorUpdate() {
           _ivStatus = _st.status;
           _ivId = (_st.status === "ok" && _st.openInterval) ? _st.openInterval.intervalId : null;
         }
-        recordHostObservation(host, { mountIntervalId: _ivId, mountIntervalStatus: _ivStatus });
+        recordObservation(host, { mountIntervalId: _ivId, mountIntervalStatus: _ivStatus });
       } catch (e) { /* read-only 観測失敗は無視 */ }
     }
 

--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -1287,7 +1287,8 @@ export function aggregatorUpdate() {
     if (!_isRelayChild() && (!s._lastObs || _mono - s._lastObs > 5000)) {
       s._lastObs = _mono;
       try {
-        let _ivId = null, _ivStatus = "unknown";
+        // ★ P1-1: 未装着は「既知の none」（取得失敗の unknown と区別）。装着時は台帳 status。
+        let _ivId = null, _ivStatus = "none";
         if (spool) {
           const _st = getMountIntervalStatus(spool.id, host);
           _ivStatus = _st.status;

--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -1299,6 +1299,8 @@ export function aggregatorUpdate() {
         }
         const _activeJobId = machine?.printStore?.current?.id ?? null;
         const _printState = Number(storedData.state?.rawValue ?? 0);
+        // ★ P1-B: 印刷中/一時停止のときだけ「連続印刷証拠」として現在ジョブの複合 identity を残す。
+        const _activePrinting = _printState === PRINT_STATE_CODE.printStarted || _printState === PRINT_STATE_CODE.printPaused;
         // ★ P0-1: 履歴 revision の正式フィールドは _historyRev（relay 側と同一）。revision は存在しない。
         const _histRev = machine?.printStore?._historyRev ?? null;
         // ★ P0-1: signature 判定は純関数 observationDue に集約（intervalId 変化も含め、5s 待たず記録）。
@@ -1310,7 +1312,7 @@ export function aggregatorUpdate() {
         if (_due.record) {
           s._lastObs = _mono;
           s._lastObsSig = _due.signature;
-          recordObservation(host, { mountIntervalId: _ivId, mountIntervalStatus: _ivStatus, activeJobId: _activeJobId, printState: _printState });
+          recordObservation(host, { mountIntervalId: _ivId, mountIntervalStatus: _ivStatus, activeJobId: _activeJobId, printState: _printState, activePrinting: _activePrinting });
         }
       } catch (e) { /* read-only 観測失敗は本流を止めない */ }
     }

--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -59,7 +59,7 @@ import { reconcileSpool, recordFilamentEvent, resolveFilamentEvent, getOpenFilam
 import { getConnectionState } from "./dashboard_connection.js";
 import { normalizeJobId } from "./dashboard_utils.js";
 import { monotonicNowMs, randomEventId } from "./dashboard_time.js";
-import { recordObservation } from "./dashboard_offline_observation.js";
+import { recordObservation, observationDue } from "./dashboard_offline_observation.js";
 
 // ---------------------------------------------------------------------------
 // 状態変数／タイムスタンプ定義（per-host 管理）
@@ -1299,11 +1299,17 @@ export function aggregatorUpdate() {
         }
         const _activeJobId = machine?.printStore?.current?.id ?? null;
         const _printState = Number(storedData.state?.rawValue ?? 0);
-        const _histRev = machine?.printStore?.revision ?? null;
-        const _obsSig = `${_histRev}|${_activeJobId}|${_printState}|${spool?.id ?? ""}|${_ivStatus}`;
-        if (!s._lastObs || _mono - s._lastObs > 5000 || s._lastObsSig !== _obsSig) {
+        // ★ P0-1: 履歴 revision の正式フィールドは _historyRev（relay 側と同一）。revision は存在しない。
+        const _histRev = machine?.printStore?._historyRev ?? null;
+        // ★ P0-1: signature 判定は純関数 observationDue に集約（intervalId 変化も含め、5s 待たず記録）。
+        const _due = observationDue(
+          { lastAtMs: s._lastObs, signature: s._lastObsSig },
+          { historyRevision: _histRev, activeJobId: _activeJobId, printState: _printState, mountedSpoolId: spool?.id ?? null, mountIntervalStatus: _ivStatus, mountIntervalId: _ivId },
+          { nowMs: _mono }
+        );
+        if (_due.record) {
           s._lastObs = _mono;
-          s._lastObsSig = _obsSig;
+          s._lastObsSig = _due.signature;
           recordObservation(host, { mountIntervalId: _ivId, mountIntervalStatus: _ivStatus, activeJobId: _activeJobId, printState: _printState });
         }
       } catch (e) { /* read-only 観測失敗は本流を止めない */ }

--- a/3dp_lib/dashboard_data.js
+++ b/3dp_lib/dashboard_data.js
@@ -285,6 +285,13 @@ export const monitorData = {
    */
   hostObservationWatermark: {},
   /**
+   * ★ #411-O1: 現セッションの最新観測（baseline とは別スロット）。
+   * recordHostObservation が更新し、オフライン窓評価まで baseline を上書きしない
+   * （起動直後に停止前基準を消さないため）。
+   * @type {Object.<string, Object>}
+   */
+  hostObservationCurrent: {},
+  /**
    * ★ Phase2A: 有効な jobId が無いまま完了した消費の隔離領域。
    * 電源投入直後などで printStartTime が 0/null の「無効ID」ジョブは
    * 履歴・usedLengthLog・境界へ確定記録を作らず（過去全履歴の誤減算＝退行を防ぐ）、

--- a/3dp_lib/dashboard_data.js
+++ b/3dp_lib/dashboard_data.js
@@ -274,6 +274,17 @@ export const monitorData = {
    */
   mountHistoryRejectedEvents: [],
   /**
+   * ★ #411-O1(Option4): オフライン推定帰属の前段となる「観測 watermark」。
+   * アプリ稼働中に per-host で「見えていた状態」を記録し、再起動後に
+   * (現在の完了履歴 − 前回観測済み集合) でオフライン新規ジョブを特定する材料にする。
+   * 本フィールドは read-only 運用の追加専用で、安全基盤（completionObservationId/
+   * pendingUnattributedUsage/mountHistory/usedLengthLog 等）には一切影響しない。
+   * host -> { observedAtEpochMs, mountedSpoolId, mountIntervalId, printerIdentity,
+   *           seenCompletedJobIds:Array<number>, historyCount }
+   * @type {Object.<string, Object>}
+   */
+  hostObservationWatermark: {},
+  /**
    * ★ Phase2A: 有効な jobId が無いまま完了した消費の隔離領域。
    * 電源投入直後などで printStartTime が 0/null の「無効ID」ジョブは
    * 履歴・usedLengthLog・境界へ確定記録を作らず（過去全履歴の誤減算＝退行を防ぐ）、

--- a/3dp_lib/dashboard_history_identity.js
+++ b/3dp_lib/dashboard_history_identity.js
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview 履歴ジョブの同一性・完了判定の下位純粋ユーティリティ（#411-P1-4）
+ * @file dashboard_history_identity.js
+ * @copyright (c) pumpCurry 2026 / 5r4ce2
+ * @author pumpCurry
+ * -----------------------------------------------------------
+ * @module dashboard_history_identity
+ *
+ * 完了判定・canonical job key・履歴 generation fingerprint を1か所へ集約する。
+ * dashboard_spool / dashboard_offline_observation の双方から使い、判定ロジックの二重化を排す。
+ * monitorData に依存しない純関数のみ（引数で受ける）。
+ *
+ * @version 2.3.0
+ * @since   2.3.0
+ * -----------------------------------------------------------
+ */
+
+"use strict";
+
+/**
+ * 履歴エントリが「完了」しているかの共通判定。
+ * printfinish が正のシグナル。旧保存データは printfinish 欠落でも
+ * finishTime/finishTimeSec/endtime/usagetime による完了証拠があれば完了扱いにする。
+ *
+ * @function isCompletedHistoryEntry
+ * @param {Object} entry - 履歴ジョブ
+ * @returns {boolean}
+ */
+export function isCompletedHistoryEntry(entry) {
+  if (!entry) return false;
+  if (entry.printfinish != null) return true;
+  return (Number(entry.finishTime) > 0) || (Number(entry.finishTimeSec) > 0)
+    || (Number(entry.endtime) > 0) || (Number(entry.usagetime) > 0);
+}
+
+/**
+ * ジョブの canonical identity key を返す（#411-P1-2）。
+ * Number 化しない（2^53 超・文字列ID・leading zero・複合IDを壊さない）。
+ * 有効な job id（空/"0"/null 以外）を String のまま返す。無効は null。
+ *
+ * @function canonicalJobKey
+ * @param {Object|string|number} entryOrId - 履歴ジョブ または id
+ * @returns {?string} canonical key（無効なら null）
+ */
+export function canonicalJobKey(entryOrId) {
+  const raw = (entryOrId && typeof entryOrId === "object") ? entryOrId.id : entryOrId;
+  if (raw == null) return null;
+  const s = String(raw).trim();
+  if (s === "" || s === "0") return null;
+  // 全ゼロ相当（"00"等）や記号のみを弾く（数値0扱いの偽ID防止）。
+  if (/^0+$/.test(s)) return null;
+  return s;
+}
+
+/**
+ * 指定履歴配列の「完了ジョブ canonical key 集合」を返す（重複排除・ソート済み）。
+ *
+ * @function completedJobKeySet
+ * @param {Array<Object>} history - printStore.history 配列
+ * @returns {string[]} 完了ジョブの canonical key（ユニーク・昇順風の文字列ソート）
+ */
+export function completedJobKeySet(history) {
+  const set = new Set();
+  if (Array.isArray(history)) {
+    for (const j of history) {
+      if (!isCompletedHistoryEntry(j)) continue;
+      const k = canonicalJobKey(j);
+      if (k != null) set.add(k);
+    }
+  }
+  return [...set].sort();
+}
+
+/**
+ * 履歴 generation fingerprint を返す（#411-P0-2 ID再利用/世代交代の反証材料）。
+ * 件数と最古/最新の完了キー、キー集合サイズを含む。プリンタ履歴の全置換・大幅縮小・
+ * ID 再利用を後で検出するために用いる（identity だけでは再起動を検出できないため）。
+ *
+ * @function historyGenerationFingerprint
+ * @param {Array<Object>} history - printStore.history 配列
+ * @returns {{count:number, oldestKey:?string, newestKey:?string}}
+ */
+export function historyGenerationFingerprint(history) {
+  const keys = completedJobKeySet(history);
+  return {
+    count: keys.length,
+    oldestKey: keys.length ? keys[0] : null,
+    newestKey: keys.length ? keys[keys.length - 1] : null
+  };
+}

--- a/3dp_lib/dashboard_history_identity.js
+++ b/3dp_lib/dashboard_history_identity.js
@@ -53,11 +53,105 @@ export function canonicalJobKey(entryOrId) {
 }
 
 /**
- * 指定履歴配列の「完了ジョブ canonical key 集合」を返す（重複排除・ソート済み）。
+ * ジョブの完了時刻/開始時刻/ファイル同一性を抽出する（read-only・ベストエフォート）。
+ * printStore.history のスキーマ差異を吸収する。
+ *
+ * @function jobTemporal
+ * @param {Object} entry - 履歴ジョブ
+ * @returns {{startAt:number, finishAt:number, fileSig:string}}
+ */
+export function jobTemporal(entry) {
+  const startAt = Number(entry?.printStartTime) || Number(entry?.starttime)
+    || Number(entry?.startTime) || Number(entry?.id) || 0; // K1: id = 開始 epoch 秒
+  const finishAt = Number(entry?.finishTime) || Number(entry?.finishTimeSec)
+    || Number(entry?.endtime) || 0;
+  const fileSig = String(entry?.filemd5 ?? entry?.filename ?? entry?.file ?? "");
+  return { startAt, finishAt, fileSig };
+}
+
+/**
+ * ジョブの「物理実行を識別する複合観測キー」を返す（#411-P0-1）。
+ * 単なる job id では、プリンタ再起動で同じ id が別の物理印刷へ再利用された場合に区別できない。
+ * id ＋ 開始/完了時刻 ＋ ファイル同一性で同一実行を識別する。表示用 id は別途 canonicalJobKey。
+ *
+ * @function jobObservationKey
+ * @param {Object} entry - 履歴ジョブ
+ * @returns {?{key:string, id:string, hasDistinguishing:boolean, finishAt:number}}
+ *   識別不能（有効 id 無し）なら null。hasDistinguishing=false は「id 以外の識別材料が無い」。
+ */
+export function jobObservationKey(entry) {
+  const id = canonicalJobKey(entry);
+  if (id == null) return null;
+  const { startAt, finishAt, fileSig } = jobTemporal(entry);
+  // 開始が id と同源(=id を start に使った)場合は識別材料に数えない。
+  const startDistinct = startAt > 0 && String(startAt) !== id;
+  const hasDistinguishing = finishAt > 0 || fileSig !== "" || startDistinct;
+  const key = `${id}|s${startAt}|f${finishAt}|${fileSig}`;
+  return { key, id, hasDistinguishing, finishAt };
+}
+
+/**
+ * 完了ジョブの複合観測キー配列（完了時刻→キーで安定ソート・重複排除）を返す（#411-P0-1/P0-2）。
+ *
+ * @function completedJobObservations
+ * @param {Array<Object>} history - printStore.history 配列
+ * @returns {Array<{key:string, id:string, hasDistinguishing:boolean, finishAt:number}>}
+ *   completion 時系列（finishAt 昇順、tie-break key）で安定ソート済み・キー重複排除済み。
+ */
+export function completedJobObservations(history) {
+  const seen = new Set();
+  const obs = [];
+  if (Array.isArray(history)) {
+    for (const j of history) {
+      if (!isCompletedHistoryEntry(j)) continue;
+      const o = jobObservationKey(j);
+      if (!o || seen.has(o.key)) continue;
+      seen.add(o.key);
+      obs.push(o);
+    }
+  }
+  // ★ #411-P1-4: 文字列 sort ではなく completion 時系列（finishAt）で安定ソート。
+  obs.sort((a, b) => (a.finishAt - b.finishAt) || (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+  return obs;
+}
+
+/** 決定論的な軽量ハッシュ（FNV-1a 32bit 相当）。 */
+function _hash(str) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16);
+}
+
+/**
+ * 履歴 generation fingerprint を返す（#411-P0-2・時系列ベース）。
+ * completion 時刻の最古/最新、件数、順序ハッシュを含む。文字列 sort ではなく時系列で構成し、
+ * computeOfflineWindow で baseline/current を実際に比較して世代交代・時刻巻き戻り・ID 再利用を検出する。
+ *
+ * @function historyGenerationFingerprint
+ * @param {Array<Object>} history - printStore.history 配列
+ * @returns {{count:number, earliestAt:number, latestAt:number, hash:string}}
+ */
+export function historyGenerationFingerprint(history) {
+  const obs = completedJobObservations(history);
+  const finishes = obs.map(o => o.finishAt).filter(t => t > 0);
+  return {
+    count: obs.length,
+    earliestAt: finishes.length ? Math.min(...finishes) : 0,
+    latestAt: finishes.length ? Math.max(...finishes) : 0,
+    hash: _hash(obs.map(o => o.key).join("\n"))
+  };
+}
+
+/**
+ * 完了ジョブの表示用 canonical id 集合（重複排除・文字列ソート）。表示/関連付け用。
+ * ※ 集合差分（オフライン窓）には jobObservationKey（複合キー）を使うこと。
  *
  * @function completedJobKeySet
- * @param {Array<Object>} history - printStore.history 配列
- * @returns {string[]} 完了ジョブの canonical key（ユニーク・昇順風の文字列ソート）
+ * @param {Array<Object>} history
+ * @returns {string[]}
  */
 export function completedJobKeySet(history) {
   const set = new Set();
@@ -69,22 +163,4 @@ export function completedJobKeySet(history) {
     }
   }
   return [...set].sort();
-}
-
-/**
- * 履歴 generation fingerprint を返す（#411-P0-2 ID再利用/世代交代の反証材料）。
- * 件数と最古/最新の完了キー、キー集合サイズを含む。プリンタ履歴の全置換・大幅縮小・
- * ID 再利用を後で検出するために用いる（identity だけでは再起動を検出できないため）。
- *
- * @function historyGenerationFingerprint
- * @param {Array<Object>} history - printStore.history 配列
- * @returns {{count:number, oldestKey:?string, newestKey:?string}}
- */
-export function historyGenerationFingerprint(history) {
-  const keys = completedJobKeySet(history);
-  return {
-    count: keys.length,
-    oldestKey: keys.length ? keys[0] : null,
-    newestKey: keys.length ? keys[keys.length - 1] : null
-  };
 }

--- a/3dp_lib/dashboard_history_identity.js
+++ b/3dp_lib/dashboard_history_identity.js
@@ -20,6 +20,7 @@
  * 履歴エントリが「完了」しているかの共通判定。
  * printfinish は完了フラグ（1=成功/0=失敗、いずれも「完了」。null=未完了）。旧保存データは
  * printfinish 欠落でも finishTime/finishTimeSec/endtime/usagetime による完了証拠があれば完了扱い。
+ * finishTime/endtime は数値 epoch だけでなく ISO 文字列（Z/offset 付き）も完了証拠として受理する。
  *
  * @function isCompletedHistoryEntry
  * @param {Object} entry
@@ -30,8 +31,8 @@ export function isCompletedHistoryEntry(entry) {
   // printfinish は数値フラグのみ完了扱い（空文字等の曖昧値は完了証拠にしない）。
   if (typeof entry.printfinish === "number") return true;
   if (typeof entry.printfinish === "boolean") return true; // 明示 true/false は「完了(成/否)」
-  return (Number(entry.finishTime) > 0) || (Number(entry.finishTimeSec) > 0)
-    || (Number(entry.endtime) > 0) || (Number(entry.usagetime) > 0);
+  return (_epochMs(entry.finishTime) > 0) || (Number(entry.finishTimeSec) > 0)
+    || (_epochMs(entry.endtime) > 0) || (Number(entry.usagetime) > 0);
 }
 
 /**
@@ -51,12 +52,27 @@ export function canonicalJobKey(entryOrId) {
 }
 
 /**
- * epoch 値を ms へ正規化する（秒/ミリ秒を自動判定）。判定不能は 0。
+ * ISO 8601（Z または ±HH:MM offset 付き）文字列を epoch ms へ。曖昧なローカル時刻は拒否。
+ * @private
+ * @param {string} s
+ * @returns {number} epoch ms（不正は 0）
+ */
+function _isoToMs(s) {
+  if (typeof s !== "string") return 0;
+  const t = s.trim();
+  if (!/^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})$/.test(t)) return 0;
+  const ms = Date.parse(t);
+  return Number.isFinite(ms) && ms > 0 ? ms : 0;
+}
+
+/**
+ * epoch 値を ms へ正規化する（秒/ミリ秒を自動判定、ISO 文字列も受理）。判定不能は 0。
  * @private
  * @param {*} v
  * @returns {number} epoch ms（不明は 0）
  */
 function _epochMs(v) {
+  if (typeof v === "string" && v.trim() !== "" && Number.isNaN(Number(v))) return _isoToMs(v);
   const n = Number(v);
   if (!Number.isFinite(n) || n <= 0) return 0;
   if (n >= 1e12) return Math.floor(n);        // すでに ms

--- a/3dp_lib/dashboard_history_identity.js
+++ b/3dp_lib/dashboard_history_identity.js
@@ -1,14 +1,13 @@
 /**
- * @fileoverview 履歴ジョブの同一性・完了判定の下位純粋ユーティリティ（#411-P1-4）
+ * @fileoverview 履歴ジョブの同一性・完了判定の下位純粋ユーティリティ（#411）
  * @file dashboard_history_identity.js
  * @copyright (c) pumpCurry 2026 / 5r4ce2
  * @author pumpCurry
  * -----------------------------------------------------------
  * @module dashboard_history_identity
  *
- * 完了判定・canonical job key・履歴 generation fingerprint を1か所へ集約する。
- * dashboard_spool / dashboard_offline_observation の双方から使い、判定ロジックの二重化を排す。
- * monitorData に依存しない純関数のみ（引数で受ける）。
+ * 完了判定・canonical job id・複合観測 identity・履歴 generation fingerprint を1か所へ集約する。
+ * monitorData に依存しない純関数のみ。
  *
  * @version 2.3.0
  * @since   2.3.0
@@ -19,84 +18,118 @@
 
 /**
  * 履歴エントリが「完了」しているかの共通判定。
- * printfinish が正のシグナル。旧保存データは printfinish 欠落でも
- * finishTime/finishTimeSec/endtime/usagetime による完了証拠があれば完了扱いにする。
+ * printfinish は完了フラグ（1=成功/0=失敗、いずれも「完了」。null=未完了）。旧保存データは
+ * printfinish 欠落でも finishTime/finishTimeSec/endtime/usagetime による完了証拠があれば完了扱い。
  *
  * @function isCompletedHistoryEntry
- * @param {Object} entry - 履歴ジョブ
+ * @param {Object} entry
  * @returns {boolean}
  */
 export function isCompletedHistoryEntry(entry) {
   if (!entry) return false;
-  if (entry.printfinish != null) return true;
+  // printfinish は数値フラグのみ完了扱い（空文字等の曖昧値は完了証拠にしない）。
+  if (typeof entry.printfinish === "number") return true;
+  if (typeof entry.printfinish === "boolean") return true; // 明示 true/false は「完了(成/否)」
   return (Number(entry.finishTime) > 0) || (Number(entry.finishTimeSec) > 0)
     || (Number(entry.endtime) > 0) || (Number(entry.usagetime) > 0);
 }
 
 /**
- * ジョブの canonical identity key を返す（#411-P1-2）。
- * Number 化しない（2^53 超・文字列ID・leading zero・複合IDを壊さない）。
- * 有効な job id（空/"0"/null 以外）を String のまま返す。無効は null。
+ * ジョブの canonical identity key（表示・関連付け用。Number 化しない＝精度損失なし）。
+ * 有効な job id（空/"0"/全ゼロ 以外）を String のまま返す。無効は null。
  *
  * @function canonicalJobKey
- * @param {Object|string|number} entryOrId - 履歴ジョブ または id
- * @returns {?string} canonical key（無効なら null）
+ * @param {Object|string|number} entryOrId
+ * @returns {?string}
  */
 export function canonicalJobKey(entryOrId) {
   const raw = (entryOrId && typeof entryOrId === "object") ? entryOrId.id : entryOrId;
   if (raw == null) return null;
   const s = String(raw).trim();
-  if (s === "" || s === "0") return null;
-  // 全ゼロ相当（"00"等）や記号のみを弾く（数値0扱いの偽ID防止）。
-  if (/^0+$/.test(s)) return null;
+  if (s === "" || /^0+$/.test(s)) return null;
   return s;
 }
 
 /**
- * ジョブの完了時刻/開始時刻/ファイル同一性を抽出する（read-only・ベストエフォート）。
- * printStore.history のスキーマ差異を吸収する。
+ * epoch 値を ms へ正規化する（秒/ミリ秒を自動判定）。判定不能は 0。
+ * @private
+ * @param {*} v
+ * @returns {number} epoch ms（不明は 0）
+ */
+function _epochMs(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  if (n >= 1e12) return Math.floor(n);        // すでに ms
+  if (n >= 1e9) return Math.floor(n * 1000);  // 秒 → ms
+  return 0;                                    // 小さすぎ＝単位不明
+}
+
+/**
+ * ファイル同一性を正規化する（OS差異・URLエンコード・Unicode・大小を吸収）。
+ * @private
+ * @param {*} f
+ * @returns {string}
+ */
+function _normFile(f) {
+  if (f == null) return "";
+  let s = String(f).replace(/\\/g, "/");
+  try { s = decodeURIComponent(s); } catch { /* 不正 %xx はそのまま */ }
+  try { s = s.normalize("NFC"); } catch { /* noop */ }
+  return s.toLowerCase();
+}
+
+/**
+ * ジョブの開始/完了時刻・時刻source を返す（#411-P1-1/P1-3）。
+ * ★ id を時刻 fallback にしない（巨大 id の Number 化＝丸め衝突を防ぐ）。
+ * finishTimeSec は明示的に秒として *1000。finishTime/endtime は秒/ms 自動判定。
  *
  * @function jobTemporal
- * @param {Object} entry - 履歴ジョブ
- * @returns {{startAt:number, finishAt:number, fileSig:string}}
+ * @param {Object} entry
+ * @returns {{startAt:number, finishAt:number, timeSource:string}}  時刻は epoch ms（不明は 0）
  */
 export function jobTemporal(entry) {
-  const startAt = Number(entry?.printStartTime) || Number(entry?.starttime)
-    || Number(entry?.startTime) || Number(entry?.id) || 0; // K1: id = 開始 epoch 秒
-  const finishAt = Number(entry?.finishTime) || Number(entry?.finishTimeSec)
-    || Number(entry?.endtime) || 0;
-  const fileSig = String(entry?.filemd5 ?? entry?.filename ?? entry?.file ?? "");
-  return { startAt, finishAt, fileSig };
+  const startAt = _epochMs(entry?.printStartTime) || _epochMs(entry?.starttime) || _epochMs(entry?.startTime);
+  let finishAt = 0, timeSource = "unknown";
+  if (_epochMs(entry?.finishTime)) { finishAt = _epochMs(entry.finishTime); timeSource = "finishTime"; }
+  else if (Number(entry?.finishTimeSec) > 0) { finishAt = Math.floor(Number(entry.finishTimeSec) * 1000); timeSource = "finishTimeSec"; }
+  else if (_epochMs(entry?.endtime)) { finishAt = _epochMs(entry.endtime); timeSource = "endtime"; }
+  return { startAt, finishAt, timeSource };
 }
 
 /**
- * ジョブの「物理実行を識別する複合観測キー」を返す（#411-P0-1）。
- * 単なる job id では、プリンタ再起動で同じ id が別の物理印刷へ再利用された場合に区別できない。
- * id ＋ 開始/完了時刻 ＋ ファイル同一性で同一実行を識別する。表示用 id は別途 canonicalJobKey。
+ * ジョブの複合観測 identity（構造体）を返す（#411-P0-1/P1-2）。
+ * 文字列連結ではなく構造体＋安定シリアライズでキー化し、区切り文字衝突を排す。
  *
- * @function jobObservationKey
- * @param {Object} entry - 履歴ジョブ
- * @returns {?{key:string, id:string, hasDistinguishing:boolean, finishAt:number}}
- *   識別不能（有効 id 無し）なら null。hasDistinguishing=false は「id 以外の識別材料が無い」。
+ * @function jobObservationIdentity
+ * @param {Object} entry
+ * @returns {?{canonicalJobId:string, startAt:?number, finishAt:?number, fileSignature:?string,
+ *            timeSource:string, hasDistinguishing:boolean, key:string}}
  */
-export function jobObservationKey(entry) {
-  const id = canonicalJobKey(entry);
-  if (id == null) return null;
-  const { startAt, finishAt, fileSig } = jobTemporal(entry);
-  // 開始が id と同源(=id を start に使った)場合は識別材料に数えない。
-  const startDistinct = startAt > 0 && String(startAt) !== id;
-  const hasDistinguishing = finishAt > 0 || fileSig !== "" || startDistinct;
-  const key = `${id}|s${startAt}|f${finishAt}|${fileSig}`;
-  return { key, id, hasDistinguishing, finishAt };
+export function jobObservationIdentity(entry) {
+  const canonicalJobId = canonicalJobKey(entry);
+  if (canonicalJobId == null) return null;
+  const { startAt, finishAt, timeSource } = jobTemporal(entry);
+  const fileSignature = _normFile(entry?.filemd5 ?? entry?.filename ?? entry?.file);
+  const hasDistinguishing = finishAt > 0 || startAt > 0 || fileSignature !== "";
+  // 安定シリアライズ（JSON tuple）＝区切り文字・エスケープ衝突なし。
+  const key = JSON.stringify([canonicalJobId, startAt || 0, finishAt || 0, fileSignature]);
+  return {
+    canonicalJobId,
+    startAt: startAt || null,
+    finishAt: finishAt || null,
+    fileSignature: fileSignature || null,
+    timeSource,
+    hasDistinguishing,
+    key
+  };
 }
 
 /**
- * 完了ジョブの複合観測キー配列（完了時刻→キーで安定ソート・重複排除）を返す（#411-P0-1/P0-2）。
+ * 完了ジョブの複合観測 identity 配列（completion 時系列で安定ソート・キー重複排除）。
  *
  * @function completedJobObservations
- * @param {Array<Object>} history - printStore.history 配列
- * @returns {Array<{key:string, id:string, hasDistinguishing:boolean, finishAt:number}>}
- *   completion 時系列（finishAt 昇順、tie-break key）で安定ソート済み・キー重複排除済み。
+ * @param {Array<Object>} history
+ * @returns {Array<Object>} jobObservationIdentity[]（finishAt 昇順・tie-break startAt→key）
  */
 export function completedJobObservations(history) {
   const seen = new Set();
@@ -104,50 +137,47 @@ export function completedJobObservations(history) {
   if (Array.isArray(history)) {
     for (const j of history) {
       if (!isCompletedHistoryEntry(j)) continue;
-      const o = jobObservationKey(j);
+      const o = jobObservationIdentity(j);
       if (!o || seen.has(o.key)) continue;
       seen.add(o.key);
       obs.push(o);
     }
   }
-  // ★ #411-P1-4: 文字列 sort ではなく completion 時系列（finishAt）で安定ソート。
-  obs.sort((a, b) => (a.finishAt - b.finishAt) || (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
+  obs.sort((a, b) =>
+    ((a.finishAt || 0) - (b.finishAt || 0))
+    || ((a.startAt || 0) - (b.startAt || 0))
+    || (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
   return obs;
 }
 
 /** 決定論的な軽量ハッシュ（FNV-1a 32bit 相当）。 */
 function _hash(str) {
   let h = 0x811c9dc5;
-  for (let i = 0; i < str.length; i++) {
-    h ^= str.charCodeAt(i);
-    h = Math.imul(h, 0x01000193) >>> 0;
-  }
+  for (let i = 0; i < str.length; i++) { h ^= str.charCodeAt(i); h = Math.imul(h, 0x01000193) >>> 0; }
   return h.toString(16);
 }
 
 /**
- * 履歴 generation fingerprint を返す（#411-P0-2・時系列ベース）。
- * completion 時刻の最古/最新、件数、順序ハッシュを含む。文字列 sort ではなく時系列で構成し、
- * computeOfflineWindow で baseline/current を実際に比較して世代交代・時刻巻き戻り・ID 再利用を検出する。
+ * 履歴 generation fingerprint（#411-P0-2・completion 時系列ベース）。
  *
  * @function historyGenerationFingerprint
- * @param {Array<Object>} history - printStore.history 配列
- * @returns {{count:number, earliestAt:number, latestAt:number, hash:string}}
+ * @param {Array<Object>} history
+ * @returns {{completedCount:number, earliestCompletedAt:number, latestCompletedAt:number, retainedHash:string}}
  */
 export function historyGenerationFingerprint(history) {
   const obs = completedJobObservations(history);
-  const finishes = obs.map(o => o.finishAt).filter(t => t > 0);
+  const finishes = obs.map(o => o.finishAt || 0).filter(t => t > 0);
   return {
-    count: obs.length,
-    earliestAt: finishes.length ? Math.min(...finishes) : 0,
-    latestAt: finishes.length ? Math.max(...finishes) : 0,
-    hash: _hash(obs.map(o => o.key).join("\n"))
+    completedCount: obs.length,
+    earliestCompletedAt: finishes.length ? Math.min(...finishes) : 0,
+    latestCompletedAt: finishes.length ? Math.max(...finishes) : 0,
+    retainedHash: _hash(obs.map(o => o.key).join("\n"))
   };
 }
 
 /**
  * 完了ジョブの表示用 canonical id 集合（重複排除・文字列ソート）。表示/関連付け用。
- * ※ 集合差分（オフライン窓）には jobObservationKey（複合キー）を使うこと。
+ * ※ 集合差分（オフライン窓）には jobObservationIdentity.key（複合キー）を使うこと。
  *
  * @function completedJobKeySet
  * @param {Array<Object>} history

--- a/3dp_lib/dashboard_offline_classifier.js
+++ b/3dp_lib/dashboard_offline_classifier.js
@@ -10,9 +10,15 @@
  *   純関数で「分類 → candidate → confidence(理由付き)」を生成するだけの Classification レイヤ。
  *   - 入力は ObservationWindow のみ（computeObservationWindow は USE のみ・変更しない）。
  *   - remaining / projected / 安全基盤には一切触れない（それは O3 以降）。
- *   - 副作用なし（monitorData への書き込みなし）。永続化・relay・確認UIは O4/O5。
+ *   - 副作用なし（monitorData への書き込み・参照なし）。永続化・relay・確認UIは O4/O5。
  *
  *   ObservationWindow → classifyObservationWindow → { classification, candidate, confidence }
+ *
+ * 【継続候補(continuity-candidate)の必須条件（O2レビュー P0-1/P0-2）】
+ *   「停止前に A が付いていた」だけでは不足。復帰後も**同じスプールが観測されている**事実が要る:
+ *   ①current 観測が存在する ②baseline/current とも mounted ③spoolId 一致
+ *   ④current の mount interval が corrupt/ambiguous でない。1つでも欠ければ candidate を出さない
+ *   （current 未観測=observation-incomplete、相違/未装着/corrupt=continuity-contradicted）。
  *
  * @version 2.3.0
  * @since   2.3.0
@@ -25,12 +31,14 @@ import { computeObservationWindow, buildConfidence } from "./dashboard_offline_o
 
 /** 帰属分類（O2 の出力ラベル）。O3/O5 はこれで分岐する。 */
 export const ATTR_CLASS = Object.freeze({
-  CONTINUITY_CANDIDATE: "continuity-candidate", // bounded＋offline完了あり＋装着スプール既知
-  NO_OFFLINE_ACTIVITY: "no-offline-activity",   // bounded だが offline 完了なし（帰属対象なし）
-  NO_MOUNTED_SPOOL: "no-mounted-spool",         // bounded＋offline あるが baseline 未装着＝継続不能
-  UNBOUNDED: "unbounded",                        // 世代交代/identity変化/巻き戻し＝窓を作れない
-  INSUFFICIENT: "insufficient",                  // 識別材料不足/再利用ID未検証＝候補単位で判定不能
-  NO_PRIOR: "no-prior"                           // 前回観測なし（初回導入/移行）
+  CONTINUITY_CANDIDATE: "continuity-candidate",       // 停止前後で同一スプール装着継続を観測＝帰属候補
+  CONTINUITY_CONTRADICTED: "continuity-contradicted", // 復帰後に別スプール/未装着/corrupt＝継続と矛盾
+  NO_OFFLINE_ACTIVITY: "no-offline-activity",         // bounded だが offline 完了なし（帰属対象なし）
+  NO_MOUNTED_SPOOL: "no-mounted-spool",               // baseline 未装着＝どのスプールへ継続か不明
+  OBSERVATION_INCOMPLETE: "observation-incomplete",   // baseline あるが復帰後 current 未観測
+  UNBOUNDED: "unbounded",                              // 世代交代/identity変化/巻き戻し＝窓を作れない
+  INSUFFICIENT: "insufficient",                        // 識別材料不足/再利用ID未検証＝候補単位で判定不能
+  NO_PRIOR: "no-prior"                                 // 前回観測なし（初回導入/移行）
 });
 
 /** 観測鮮度の劣化しきい値（これを超える古さは confidence を1段下げる）。 */
@@ -43,7 +51,8 @@ function _downgrade(level, floor = "none") {
   const i = _LEVELS.indexOf(level);
   const fi = _LEVELS.indexOf(floor);
   if (i < 0) return floor;
-  return _LEVELS[Math.min(Math.max(i + 1, 0), fi < 0 ? _LEVELS.length - 1 : fi)];
+  const cap = fi < 0 ? _LEVELS.length - 1 : fi;
+  return _LEVELS[Math.min(i + 1, cap)];
 }
 
 /** 分類結果オブジェクトを一定形で組み立てる。 */
@@ -51,6 +60,7 @@ function _result(classification, candidate, confidence, window) {
   return {
     classification,
     windowId: window?.windowId ?? null,
+    windowKind: window?.windowKind ?? null,
     bounded: !!window?.bounded,
     reason: window?.reason ?? null,
     candidate: candidate || null,
@@ -66,7 +76,7 @@ function _result(classification, candidate, confidence, window) {
  *
  * @function classifyObservationWindow
  * @param {Object} window computeObservationWindow の戻り値（ObservationWindow）
- * @returns {{classification:string, windowId:?string, bounded:boolean, reason:?string,
+ * @returns {{classification:string, windowId:?string, windowKind:?string, bounded:boolean, reason:?string,
  *   candidate:?Object, confidence:{level:string, reasons:string[]},
  *   offlineObservationKeys:string[], unresolvedJobIds:string[]}}
  */
@@ -74,56 +84,75 @@ export function classifyObservationWindow(window) {
   if (!window || typeof window !== "object") {
     return _result(ATTR_CLASS.NO_PRIOR, null, buildConfidence("none", ["no-window"]), window);
   }
-  const wm = window.watermark || null;
+  const kind = window.windowKind;
   const offline = Array.isArray(window.offlineObservationKeys) ? window.offlineObservationKeys : [];
-  const unresolved = Array.isArray(window.unresolvedJobIds) ? window.unresolvedJobIds : [];
+  const baselineMount = window.baselineMount || {};
+  const currentMount = window.currentMount || {};
 
-  // 前回観測なし（初回導入・移行）
-  if (window.reason === "no-prior-observation") {
+  // 前回観測なし（baseline がない）
+  if (kind === "no-prior" || window.reason === "no-prior-observation") {
     return _result(ATTR_CLASS.NO_PRIOR, null, buildConfidence("none", ["no-prior-observation"]), window);
   }
-
-  // 窓を作れない（bounded=false）
-  if (!window.bounded) {
-    if (window.reason === "reused-job-id-unverifiable" || window.reason === "job-identity-insufficient") {
-      // 候補単位で識別不能：継続推定せず、未解決 id を持ち越す
-      return _result(ATTR_CLASS.INSUFFICIENT, null, buildConfidence("none", [window.reason]), window);
-    }
-    // identity 変化 / 時刻巻き戻し / 世代交代 / 大幅縮小＝境界不成立
+  // baseline はあるが復帰後 current 観測がまだ無い（装着状態を検証できない）
+  if (kind === "incomplete" || window.hasCurrentObservation === false) {
+    return _result(ATTR_CLASS.OBSERVATION_INCOMPLETE, null, buildConfidence("none", ["current-observation-missing"]), window);
+  }
+  // 候補単位で識別不能（再利用ID未検証/識別材料不足）
+  if (kind === "insufficient") {
+    return _result(ATTR_CLASS.INSUFFICIENT, null, buildConfidence("none", [window.reason || "insufficient"]), window);
+  }
+  // 世代交代/identity変化/時刻巻き戻し/大幅縮小＝境界不成立
+  if (kind === "unbounded" || !window.bounded) {
     return _result(ATTR_CLASS.UNBOUNDED, null, buildConfidence("none", [window.reason || "unbounded"]), window);
   }
 
-  // bounded だが offline 完了なし＝帰属対象なし（正常）
+  // ここから bounded 確定。まず offline 完了の有無。
   if (offline.length === 0) {
-    return _result(ATTR_CLASS.NO_OFFLINE_ACTIVITY, null, buildConfidence("high", ["bounded", "no-offline-jobs"]), window);
+    // 帰属対象なし（正常）。ただし truncated/stale は監査用に理由へ残し軽く降格。
+    const reasons = ["bounded", "no-offline-jobs"];
+    let level = "high";
+    if (window.truncated) { reasons.push("history-truncated"); level = _downgrade(level, "medium"); }
+    if ((Number(window.stalenessMs) || 0) > STALE_DOWNGRADE_MS) { reasons.push("stale-observation"); level = _downgrade(level, "medium"); }
+    return _result(ATTR_CLASS.NO_OFFLINE_ACTIVITY, null, buildConfidence(level, reasons), window);
   }
 
-  // bounded かつ offline 完了あり
-  const spoolId = wm?.mountedSpoolId ?? null;
-  if (spoolId == null) {
-    // オフライン期間に装着スプール不明＝どのスプールへ継続帰属すべきか決められない
+  // offline 完了あり → 停止前後の装着一致を必須検証。
+  // ① baseline 未装着＝どのスプールへ継続か決められない
+  if (baselineMount.observationState !== "mounted" || baselineMount.spoolId == null) {
     return _result(ATTR_CLASS.NO_MOUNTED_SPOOL, null, buildConfidence("none", ["bounded", "no-mounted-spool-at-baseline"]), window);
   }
+  // ② current 未装着＝復帰後にスプールが外れている＝継続と矛盾
+  if (currentMount.observationState !== "mounted" || currentMount.spoolId == null) {
+    return _result(ATTR_CLASS.CONTINUITY_CONTRADICTED, null, buildConfidence("none", ["current-unmounted"]), window);
+  }
+  // ③ spoolId 相違＝停止中に別スプールへ交換された＝継続と矛盾（最重要）
+  if (baselineMount.spoolId !== currentMount.spoolId) {
+    return _result(ATTR_CLASS.CONTINUITY_CONTRADICTED, null, buildConfidence("none", ["mounted-spool-changed"]), window);
+  }
+  // ④ current の mount interval が corrupt/ambiguous＝装着継続を信頼できない＝矛盾扱い
+  if (currentMount.intervalStatus === "corrupt" || currentMount.intervalStatus === "ambiguous") {
+    return _result(ATTR_CLASS.CONTINUITY_CONTRADICTED, null, buildConfidence("none", [`current-interval-${currentMount.intervalStatus}`]), window);
+  }
 
-  // 継続候補：装着スプールを candidate に、証拠に応じて confidence を段階付け（下限 low）
+  // 停止前後で同一スプールが装着継続＝continuity candidate。confidence を証拠で段階付け（下限 low）。
   const reasons = ["bounded", "same-mounted-spool"];
   let level = "high";
-  const ivStatus = wm?.mountIntervalStatus || "unknown";
-  if (ivStatus === "ok") {
-    reasons.push("mount-interval-ok");
-  } else {
-    reasons.push(`mount-interval-${ivStatus}`);
-    level = _downgrade(level, "low");
-  }
+  const ivStatus = currentMount.intervalStatus;
+  if (ivStatus === "ok") { reasons.push("current-interval-ok"); }
+  else if (ivStatus === "none") { reasons.push("current-interval-none"); level = _downgrade(level, "low"); }
+  else { reasons.push(`current-interval-${ivStatus}`); level = _downgrade(level, "low"); } // unknown 等
+  // interval id が停止前後で不一致＝途中 detach/reattach の可能性＝同一スプールでも降格。
+  const sameInterval = baselineMount.intervalId != null && baselineMount.intervalId === currentMount.intervalId;
+  if (sameInterval) { reasons.push("same-mount-interval"); }
+  else { reasons.push("mount-interval-changed"); level = _downgrade(level, "low"); }
   if (window.truncated) { reasons.push("history-truncated"); level = _downgrade(level, "low"); }
-  if (unresolved.length > 0) { reasons.push("some-unresolved-jobs"); level = _downgrade(level, "low"); }
   if ((Number(window.stalenessMs) || 0) > STALE_DOWNGRADE_MS) { reasons.push("stale-observation"); level = _downgrade(level, "low"); }
 
   const candidate = {
-    candidateSpoolId: spoolId,
-    candidateIntervalId: wm?.mountIntervalId ?? null,
+    candidateSpoolId: baselineMount.spoolId,
+    candidateBaselineIntervalId: baselineMount.intervalId ?? null,
+    candidateCurrentIntervalId: currentMount.intervalId ?? null,
     offlineObservationKeys: offline.slice(),
-    unresolvedJobIds: unresolved.slice(),
     windowId: window.windowId ?? null
   };
   return _result(ATTR_CLASS.CONTINUITY_CANDIDATE, candidate, buildConfidence(level, reasons), window);

--- a/3dp_lib/dashboard_offline_classifier.js
+++ b/3dp_lib/dashboard_offline_classifier.js
@@ -66,12 +66,24 @@ function _idOfKey(key) {
   try { const a = JSON.parse(key); return Array.isArray(a) ? String(a[0]) : ""; } catch { return ""; }
 }
 
-/** 停止前に印刷中だったジョブ(baseline.activeJobId)が offline 完了集合に現れたか（＝開始をアプリが観測済み）。 */
+/**
+ * 停止前に印刷中だったジョブの完了を offline で観測できたか（＝開始をアプリが観測済み）。
+ * ★ P1-B: ID 一致だけでは不十分（idle の残存 current・ID 再利用で誤判定）。印刷中に取得した
+ *   複合 identity（canonicalJobId＋開始時刻＋file署名）が offline 完了と整合する場合のみ true。
+ */
 function _activeJobContinued(window) {
-  const activeJobId = window?.watermark?.activeJobId ?? null;
-  if (activeJobId == null) return false;
-  const offlineIds = new Set((window?.offlineObservationKeys || []).map(_idOfKey));
-  return offlineIds.has(String(activeJobId));
+  const aj = window?.watermark?.activeJobObservation;
+  if (!aj || aj.canonicalJobId == null) return false; // 印刷中に取得した証拠が無い＝high にしない
+  const cid = String(aj.canonicalJobId);
+  const startAt = Number(aj.startAt) || 0;
+  const fileSig = aj.fileSignature || "";
+  for (const key of window?.offlineObservationKeys || []) {
+    let a; try { a = JSON.parse(key); } catch { continue; }
+    if (!Array.isArray(a)) continue;
+    // 複合一致: id＋開始時刻＋file（finishAt は active=未完了なので比較しない）。
+    if (String(a[0]) === cid && (Number(a[1]) || 0) === startAt && (a[3] || "") === fileSig) return true;
+  }
+  return false;
 }
 
 /** ObservationWindow から証拠（解釈済みの事実サマリ）を組み立てる。 */

--- a/3dp_lib/dashboard_offline_classifier.js
+++ b/3dp_lib/dashboard_offline_classifier.js
@@ -55,23 +55,39 @@ function _downgrade(level, floor = "none") {
   return _LEVELS[Math.min(i + 1, cap)];
 }
 
+/** 2つの confidence レベルのうち低い方（index が大きい方）を返す。 */
+function _levelMin(a, b) {
+  const ia = _LEVELS.indexOf(a), ib = _LEVELS.indexOf(b);
+  return _LEVELS[Math.max(ia < 0 ? 0 : ia, ib < 0 ? 0 : ib)];
+}
+
 /** 複合キー(JSON tuple)から canonicalJobId を取り出す。 */
 function _idOfKey(key) {
   try { const a = JSON.parse(key); return Array.isArray(a) ? String(a[0]) : ""; } catch { return ""; }
 }
 
+/** 停止前に印刷中だったジョブ(baseline.activeJobId)が offline 完了集合に現れたか（＝開始をアプリが観測済み）。 */
+function _activeJobContinued(window) {
+  const activeJobId = window?.watermark?.activeJobId ?? null;
+  if (activeJobId == null) return false;
+  const offlineIds = new Set((window?.offlineObservationKeys || []).map(_idOfKey));
+  return offlineIds.has(String(activeJobId));
+}
+
 /** ObservationWindow から証拠（解釈済みの事実サマリ）を組み立てる。 */
 function _evidence(window) {
   const bm = window?.baselineMount || {}, cm = window?.currentMount || {};
-  const offlineIds = new Set((window?.offlineObservationKeys || []).map(_idOfKey));
-  const activeJobId = window?.watermark?.activeJobId ?? null;
+  const idMatch = window?.printerIdentityMatch || { status: "unverifiable", matchedBy: null };
   return {
-    sameStrongPrinterIdentity: window?.identityChanged === false || window?.identityChanged == null,
+    printerIdentityMatch: idMatch,
+    // ★ P1-1: model 一致だけでは筐体同一を保証しない＝serial/deviceId 一致(same-strong)のみ true。
+    sameStrongPrinterIdentity: idMatch.status === "same-strong",
     sameMountedSpool: bm.spoolId != null && bm.spoolId === cm.spoolId,
     sameMountInterval: bm.intervalId != null && bm.intervalId === cm.intervalId,
-    activeJobContinued: activeJobId != null && offlineIds.has(String(activeJobId)),
+    activeJobContinued: _activeJobContinued(window),
     historyShrank: !!window?.shrunk,
     mountStatus: cm.intervalStatus ?? "unknown",
+    baselineMountStatus: bm.intervalStatus ?? "unknown",
     elapsedMs: window?.stalenessMs ?? null
   };
 }
@@ -146,6 +162,12 @@ export function classifyObservationWindow(window) {
   if (baselineMount.observationState !== "mounted" || baselineMount.spoolId == null) {
     return _result(ATTR_CLASS.NO_MOUNTED_SPOOL, null, buildConfidence("none", ["bounded", "no-mounted-spool-at-baseline"]), window);
   }
+  // ★ P0-2 ①' baseline の mount interval が corrupt/ambiguous＝台帳破損。破損 baseline を
+  //   推定 debit の根拠（candidate の baseline interval）にしてはいけない＝矛盾扱い。
+  if (baselineMount.intervalStatus === "corrupt" || baselineMount.intervalStatus === "ambiguous") {
+    const c = `baseline-interval-${baselineMount.intervalStatus}`;
+    return _result(ATTR_CLASS.CONTINUITY_CONTRADICTED, null, buildConfidence("none", [c], [c]), window);
+  }
   // ② current 未装着＝復帰後にスプールが外れている＝継続と矛盾
   if (currentMount.observationState !== "mounted" || currentMount.spoolId == null) {
     return _result(ATTR_CLASS.CONTINUITY_CONTRADICTED, null, buildConfidence("none", ["current-unmounted"], ["current-unmounted"]), window);
@@ -160,19 +182,27 @@ export function classifyObservationWindow(window) {
     return _result(ATTR_CLASS.CONTINUITY_CONTRADICTED, null, buildConfidence("none", [c], [c]), window);
   }
 
-  // 停止前後で同一スプールが装着継続＝continuity candidate。confidence を証拠で段階付け（下限 low）。
+  // 停止前後で同一スプールが装着継続＝continuity candidate。confidence は cap 方式で段階付け。
+  // ★ P0-3 の tier 定義（reviewer）:
+  //   high  : activeJobContinued＝停止前ジョブの完了を観測＋同一 interval＋前後 interval=ok
+  //   medium: 完全オフライン（開始をアプリが観測していない）だが same spool/same interval・反証なし
+  //   low   : interval none/unknown／interval id 変化／truncated／stale
+  //   （identity 反証は既に unbounded で除外済み。identity の強さは evidence に残す。）
   const reasons = ["bounded", "same-mounted-spool"];
   let level = "high";
-  const ivStatus = currentMount.intervalStatus;
-  if (ivStatus === "ok") { reasons.push("current-interval-ok"); }
-  else if (ivStatus === "none") { reasons.push("current-interval-none"); level = _downgrade(level, "low"); }
-  else { reasons.push(`current-interval-${ivStatus}`); level = _downgrade(level, "low"); } // unknown 等
-  // interval id が停止前後で不一致＝途中 detach/reattach の可能性＝同一スプールでも降格。
+  const cap = (t) => { level = _levelMin(level, t); };
+  if (_activeJobContinued(window)) { reasons.push("active-job-continued"); }
+  else { reasons.push("fully-offline"); cap("medium"); }             // 完全オフラインは high にしない
+  if (currentMount.intervalStatus === "ok") { reasons.push("current-interval-ok"); }
+  else { reasons.push(`current-interval-${currentMount.intervalStatus || "unknown"}`); cap("low"); }
+  if (baselineMount.intervalStatus === "ok") { reasons.push("baseline-interval-ok"); }
+  else { reasons.push(`baseline-interval-${baselineMount.intervalStatus || "unknown"}`); cap("low"); }
   const sameInterval = baselineMount.intervalId != null && baselineMount.intervalId === currentMount.intervalId;
   if (sameInterval) { reasons.push("same-mount-interval"); }
-  else { reasons.push("mount-interval-changed"); level = _downgrade(level, "low"); }
-  if (window.truncated) { reasons.push("history-truncated"); level = _downgrade(level, "low"); }
-  if ((Number(window.stalenessMs) || 0) > STALE_DOWNGRADE_MS) { reasons.push("stale-observation"); level = _downgrade(level, "low"); }
+  else { reasons.push("mount-interval-changed"); cap("low"); }        // detach/reattach 疑い
+  if (window.truncated) { reasons.push("history-truncated"); cap("low"); }
+  if ((Number(window.stalenessMs) || 0) > STALE_DOWNGRADE_MS) { reasons.push("stale-observation"); cap("low"); }
+  reasons.push(`printer-identity-${window?.printerIdentityMatch?.status || "unverifiable"}`);
 
   const candidate = {
     candidateSpoolId: baselineMount.spoolId,

--- a/3dp_lib/dashboard_offline_classifier.js
+++ b/3dp_lib/dashboard_offline_classifier.js
@@ -55,16 +55,41 @@ function _downgrade(level, floor = "none") {
   return _LEVELS[Math.min(i + 1, cap)];
 }
 
+/** 複合キー(JSON tuple)から canonicalJobId を取り出す。 */
+function _idOfKey(key) {
+  try { const a = JSON.parse(key); return Array.isArray(a) ? String(a[0]) : ""; } catch { return ""; }
+}
+
+/** ObservationWindow から証拠（解釈済みの事実サマリ）を組み立てる。 */
+function _evidence(window) {
+  const bm = window?.baselineMount || {}, cm = window?.currentMount || {};
+  const offlineIds = new Set((window?.offlineObservationKeys || []).map(_idOfKey));
+  const activeJobId = window?.watermark?.activeJobId ?? null;
+  return {
+    sameStrongPrinterIdentity: window?.identityChanged === false || window?.identityChanged == null,
+    sameMountedSpool: bm.spoolId != null && bm.spoolId === cm.spoolId,
+    sameMountInterval: bm.intervalId != null && bm.intervalId === cm.intervalId,
+    activeJobContinued: activeJobId != null && offlineIds.has(String(activeJobId)),
+    historyShrank: !!window?.shrunk,
+    mountStatus: cm.intervalStatus ?? "unknown",
+    elapsedMs: window?.stalenessMs ?? null
+  };
+}
+
 /** 分類結果オブジェクトを一定形で組み立てる。 */
 function _result(classification, candidate, confidence, window) {
   return {
     classification,
     windowId: window?.windowId ?? null,
     windowKind: window?.windowKind ?? null,
+    host: window?.host ?? null,
+    baselineSequence: window?.baselineSequence ?? 0,
+    currentSequence: window?.currentSequence ?? 0,
     bounded: !!window?.bounded,
     reason: window?.reason ?? null,
     candidate: candidate || null,
     confidence,
+    evidence: _evidence(window),
     offlineObservationKeys: Array.isArray(window?.offlineObservationKeys) ? window.offlineObservationKeys.slice() : [],
     unresolvedJobIds: Array.isArray(window?.unresolvedJobIds) ? window.unresolvedJobIds.slice() : []
   };
@@ -99,11 +124,11 @@ export function classifyObservationWindow(window) {
   }
   // 候補単位で識別不能（再利用ID未検証/識別材料不足）
   if (kind === "insufficient") {
-    return _result(ATTR_CLASS.INSUFFICIENT, null, buildConfidence("none", [window.reason || "insufficient"]), window);
+    return _result(ATTR_CLASS.INSUFFICIENT, null, buildConfidence("none", [window.reason || "insufficient"], [window.reason || "insufficient"]), window);
   }
   // 世代交代/identity変化/時刻巻き戻し/大幅縮小＝境界不成立
   if (kind === "unbounded" || !window.bounded) {
-    return _result(ATTR_CLASS.UNBOUNDED, null, buildConfidence("none", [window.reason || "unbounded"]), window);
+    return _result(ATTR_CLASS.UNBOUNDED, null, buildConfidence("none", [window.reason || "unbounded"], [window.reason || "unbounded"]), window);
   }
 
   // ここから bounded 確定。まず offline 完了の有無。
@@ -123,15 +148,16 @@ export function classifyObservationWindow(window) {
   }
   // ② current 未装着＝復帰後にスプールが外れている＝継続と矛盾
   if (currentMount.observationState !== "mounted" || currentMount.spoolId == null) {
-    return _result(ATTR_CLASS.CONTINUITY_CONTRADICTED, null, buildConfidence("none", ["current-unmounted"]), window);
+    return _result(ATTR_CLASS.CONTINUITY_CONTRADICTED, null, buildConfidence("none", ["current-unmounted"], ["current-unmounted"]), window);
   }
   // ③ spoolId 相違＝停止中に別スプールへ交換された＝継続と矛盾（最重要）
   if (baselineMount.spoolId !== currentMount.spoolId) {
-    return _result(ATTR_CLASS.CONTINUITY_CONTRADICTED, null, buildConfidence("none", ["mounted-spool-changed"]), window);
+    return _result(ATTR_CLASS.CONTINUITY_CONTRADICTED, null, buildConfidence("none", ["mounted-spool-changed"], ["mounted-spool-changed"]), window);
   }
   // ④ current の mount interval が corrupt/ambiguous＝装着継続を信頼できない＝矛盾扱い
   if (currentMount.intervalStatus === "corrupt" || currentMount.intervalStatus === "ambiguous") {
-    return _result(ATTR_CLASS.CONTINUITY_CONTRADICTED, null, buildConfidence("none", [`current-interval-${currentMount.intervalStatus}`]), window);
+    const c = `current-interval-${currentMount.intervalStatus}`;
+    return _result(ATTR_CLASS.CONTINUITY_CONTRADICTED, null, buildConfidence("none", [c], [c]), window);
   }
 
   // 停止前後で同一スプールが装着継続＝continuity candidate。confidence を証拠で段階付け（下限 low）。

--- a/3dp_lib/dashboard_offline_classifier.js
+++ b/3dp_lib/dashboard_offline_classifier.js
@@ -1,0 +1,142 @@
+/**
+ * @fileoverview オフライン推定帰属(Option4)の分類レイヤ — #411-O2
+ * @file dashboard_offline_classifier.js
+ * @copyright (c) pumpCurry 2026 / 5r4ce2
+ * @author pumpCurry
+ * -----------------------------------------------------------
+ * @module dashboard_offline_classifier
+ *
+ * 【責務（レビュー#411 で固定）】O2 は Observation 層が返す ObservationWindow を入力に、
+ *   純関数で「分類 → candidate → confidence(理由付き)」を生成するだけの Classification レイヤ。
+ *   - 入力は ObservationWindow のみ（computeObservationWindow は USE のみ・変更しない）。
+ *   - remaining / projected / 安全基盤には一切触れない（それは O3 以降）。
+ *   - 副作用なし（monitorData への書き込みなし）。永続化・relay・確認UIは O4/O5。
+ *
+ *   ObservationWindow → classifyObservationWindow → { classification, candidate, confidence }
+ *
+ * @version 2.3.0
+ * @since   2.3.0
+ * -----------------------------------------------------------
+ */
+
+"use strict";
+
+import { computeObservationWindow, buildConfidence } from "./dashboard_offline_observation.js";
+
+/** 帰属分類（O2 の出力ラベル）。O3/O5 はこれで分岐する。 */
+export const ATTR_CLASS = Object.freeze({
+  CONTINUITY_CANDIDATE: "continuity-candidate", // bounded＋offline完了あり＋装着スプール既知
+  NO_OFFLINE_ACTIVITY: "no-offline-activity",   // bounded だが offline 完了なし（帰属対象なし）
+  NO_MOUNTED_SPOOL: "no-mounted-spool",         // bounded＋offline あるが baseline 未装着＝継続不能
+  UNBOUNDED: "unbounded",                        // 世代交代/identity変化/巻き戻し＝窓を作れない
+  INSUFFICIENT: "insufficient",                  // 識別材料不足/再利用ID未検証＝候補単位で判定不能
+  NO_PRIOR: "no-prior"                           // 前回観測なし（初回導入/移行）
+});
+
+/** 観測鮮度の劣化しきい値（これを超える古さは confidence を1段下げる）。 */
+const STALE_DOWNGRADE_MS = 30 * 24 * 3600 * 1000; // 30日
+
+const _LEVELS = ["high", "medium", "low", "none"];
+
+/** confidence レベルを1段下げる（floor 指定で下限を固定）。 */
+function _downgrade(level, floor = "none") {
+  const i = _LEVELS.indexOf(level);
+  const fi = _LEVELS.indexOf(floor);
+  if (i < 0) return floor;
+  return _LEVELS[Math.min(Math.max(i + 1, 0), fi < 0 ? _LEVELS.length - 1 : fi)];
+}
+
+/** 分類結果オブジェクトを一定形で組み立てる。 */
+function _result(classification, candidate, confidence, window) {
+  return {
+    classification,
+    windowId: window?.windowId ?? null,
+    bounded: !!window?.bounded,
+    reason: window?.reason ?? null,
+    candidate: candidate || null,
+    confidence,
+    offlineObservationKeys: Array.isArray(window?.offlineObservationKeys) ? window.offlineObservationKeys.slice() : [],
+    unresolvedJobIds: Array.isArray(window?.unresolvedJobIds) ? window.unresolvedJobIds.slice() : []
+  };
+}
+
+/**
+ * ObservationWindow を分類し candidate + confidence を返す純関数（O2 の中核）。
+ * Observation 層・remaining・安全基盤には触れない。
+ *
+ * @function classifyObservationWindow
+ * @param {Object} window computeObservationWindow の戻り値（ObservationWindow）
+ * @returns {{classification:string, windowId:?string, bounded:boolean, reason:?string,
+ *   candidate:?Object, confidence:{level:string, reasons:string[]},
+ *   offlineObservationKeys:string[], unresolvedJobIds:string[]}}
+ */
+export function classifyObservationWindow(window) {
+  if (!window || typeof window !== "object") {
+    return _result(ATTR_CLASS.NO_PRIOR, null, buildConfidence("none", ["no-window"]), window);
+  }
+  const wm = window.watermark || null;
+  const offline = Array.isArray(window.offlineObservationKeys) ? window.offlineObservationKeys : [];
+  const unresolved = Array.isArray(window.unresolvedJobIds) ? window.unresolvedJobIds : [];
+
+  // 前回観測なし（初回導入・移行）
+  if (window.reason === "no-prior-observation") {
+    return _result(ATTR_CLASS.NO_PRIOR, null, buildConfidence("none", ["no-prior-observation"]), window);
+  }
+
+  // 窓を作れない（bounded=false）
+  if (!window.bounded) {
+    if (window.reason === "reused-job-id-unverifiable" || window.reason === "job-identity-insufficient") {
+      // 候補単位で識別不能：継続推定せず、未解決 id を持ち越す
+      return _result(ATTR_CLASS.INSUFFICIENT, null, buildConfidence("none", [window.reason]), window);
+    }
+    // identity 変化 / 時刻巻き戻し / 世代交代 / 大幅縮小＝境界不成立
+    return _result(ATTR_CLASS.UNBOUNDED, null, buildConfidence("none", [window.reason || "unbounded"]), window);
+  }
+
+  // bounded だが offline 完了なし＝帰属対象なし（正常）
+  if (offline.length === 0) {
+    return _result(ATTR_CLASS.NO_OFFLINE_ACTIVITY, null, buildConfidence("high", ["bounded", "no-offline-jobs"]), window);
+  }
+
+  // bounded かつ offline 完了あり
+  const spoolId = wm?.mountedSpoolId ?? null;
+  if (spoolId == null) {
+    // オフライン期間に装着スプール不明＝どのスプールへ継続帰属すべきか決められない
+    return _result(ATTR_CLASS.NO_MOUNTED_SPOOL, null, buildConfidence("none", ["bounded", "no-mounted-spool-at-baseline"]), window);
+  }
+
+  // 継続候補：装着スプールを candidate に、証拠に応じて confidence を段階付け（下限 low）
+  const reasons = ["bounded", "same-mounted-spool"];
+  let level = "high";
+  const ivStatus = wm?.mountIntervalStatus || "unknown";
+  if (ivStatus === "ok") {
+    reasons.push("mount-interval-ok");
+  } else {
+    reasons.push(`mount-interval-${ivStatus}`);
+    level = _downgrade(level, "low");
+  }
+  if (window.truncated) { reasons.push("history-truncated"); level = _downgrade(level, "low"); }
+  if (unresolved.length > 0) { reasons.push("some-unresolved-jobs"); level = _downgrade(level, "low"); }
+  if ((Number(window.stalenessMs) || 0) > STALE_DOWNGRADE_MS) { reasons.push("stale-observation"); level = _downgrade(level, "low"); }
+
+  const candidate = {
+    candidateSpoolId: spoolId,
+    candidateIntervalId: wm?.mountIntervalId ?? null,
+    offlineObservationKeys: offline.slice(),
+    unresolvedJobIds: unresolved.slice(),
+    windowId: window.windowId ?? null
+  };
+  return _result(ATTR_CLASS.CONTINUITY_CANDIDATE, candidate, buildConfidence(level, reasons), window);
+}
+
+/**
+ * host の観測窓を計算して分類する（O2 の公開エントリ）。
+ * computeObservationWindow を利用するのみで、Observation 層は変更しない。read-only。
+ *
+ * @function classifyHostAttribution
+ * @param {string} host
+ * @returns {Object} classifyObservationWindow の戻り値
+ */
+export function classifyHostAttribution(host) {
+  return classifyObservationWindow(computeObservationWindow(host));
+}

--- a/3dp_lib/dashboard_offline_observation.js
+++ b/3dp_lib/dashboard_offline_observation.js
@@ -37,12 +37,48 @@ import { completedJobObservations, historyGenerationFingerprint } from "./dashbo
 /** 観測キーの保持上限（completion 時系列で最新のみ保持）。 */
 const SEEN_CAP = 5000;
 
-/** @private */
+/**
+ * @private プリンタ識別を構造化して返す（P1-1）。model/serial/deviceId のいずれかが
+ * 機器から届いていれば completeness="strong"、未取得は "weak"（printerType は設定値なので
+ * strong 判定には使わない）。weak→strong は情報補完でありプリンタ交換ではない。
+ */
 function _identity(host) {
   const sd = monitorData.machines?.[host]?.storedData || {};
-  const model = sd.model?.rawValue ?? "";
-  const type = monitorData.appSettings?.connectionTargets?.find?.(t => t && t.hostname === host)?.printerType ?? "";
-  return `${host}|${type}|${model}`;
+  const model = String(sd.model?.rawValue ?? "").trim();
+  const printerType = monitorData.appSettings?.connectionTargets?.find?.(t => t && t.hostname === host)?.printerType ?? "";
+  const serialNumber = String(sd.sn?.rawValue ?? sd.serialNumber?.rawValue ?? "").trim();
+  const deviceId = String(sd.deviceId?.rawValue ?? sd.id?.rawValue ?? "").trim();
+  const completeness = (model || serialNumber || deviceId) ? "strong" : "weak";
+  return { host, printerType, model, serialNumber, deviceId, completeness };
+}
+
+/** @private 文字列（旧保存）/構造体いずれの identity も構造体へ正規化する。 */
+function _normIdentity(id) {
+  if (id && typeof id === "object") {
+    const model = id.model ?? "", serialNumber = id.serialNumber ?? "", deviceId = id.deviceId ?? "";
+    return {
+      host: id.host ?? "", printerType: id.printerType ?? "", model, serialNumber, deviceId,
+      completeness: id.completeness || ((model || serialNumber || deviceId) ? "strong" : "weak")
+    };
+  }
+  if (typeof id === "string") {
+    const [host = "", printerType = "", model = ""] = id.split("|");
+    return { host, printerType, model, serialNumber: "", deviceId: "", completeness: model ? "strong" : "weak" };
+  }
+  return { host: "", printerType: "", model: "", serialNumber: "", deviceId: "", completeness: "weak" };
+}
+
+/**
+ * @private baseline/current の identity が「プリンタ交換」を示すか。
+ * strong 同士の安定識別子（serial→deviceId→model/type）不一致のみ反証。
+ * weak→strong の補完・weak 同士は反証にしない（同一機で情報が後から届く正常系）。
+ */
+function _identityContradicts(baseId, curId) {
+  const a = _normIdentity(baseId), b = _normIdentity(curId);
+  if (a.completeness !== "strong" || b.completeness !== "strong") return false;
+  if (a.serialNumber && b.serialNumber) return a.serialNumber !== b.serialNumber;
+  if (a.deviceId && b.deviceId) return a.deviceId !== b.deviceId;
+  return (a.model !== b.model) || (a.printerType !== b.printerType);
 }
 
 /** @private 継続採番（再起動で 1 へ戻さない）。current/baseline から常に単調増加。 */
@@ -69,8 +105,9 @@ function _mountFacts(snap) {
 }
 
 /** @private 現在履歴から観測スナップショットを構築（read-only）。 */
-function _buildObservation(host, { mountIntervalId = null, mountIntervalStatus = "none" } = {}) {
-  const hist = monitorData.machines?.[host]?.printStore?.history;
+function _buildObservation(host, { mountIntervalId = null, mountIntervalStatus = "none", activeJobId = null, printState = null } = {}) {
+  const machine = monitorData.machines?.[host];
+  const hist = machine?.printStore?.history;
   const obsAll = completedJobObservations(hist); // completion 時系列・重複排除
   const totalCompletedCount = obsAll.length;
   const retained = obsAll.length > SEEN_CAP ? obsAll.slice(obsAll.length - SEEN_CAP) : obsAll;
@@ -86,6 +123,10 @@ function _buildObservation(host, { mountIntervalId = null, mountIntervalStatus =
     mountIntervalId: mountIntervalId ?? null,
     mountIntervalStatus,
     observationState: spoolId ? "mounted" : "unmounted",
+    // ★ P0-4: 連続印刷の証拠（停止前に何を印刷中だったか）。O2 の activeJobContinued 判定に使う。
+    activeJobId: activeJobId ?? (machine?.printStore?.current?.id ?? null),
+    printState: printState ?? null,
+    historyRevision: machine?.printStore?.revision ?? null,
     printerIdentity: _identity(host),
     generation: historyGenerationFingerprint(hist),
     seenObservationKeys: retained.map(o => o.key),
@@ -124,70 +165,84 @@ export function recordObservation(host, opts = {}) {
   return snap;
 }
 
-/**
- * オフライン観測窓を計算する（純関数。O2 はこの ObservationWindow を分類する）。
- *
- * @function computeObservationWindow
- * @param {string} host
- * @returns {{windowId:string, windowKind:string, bounded:boolean, truncated:boolean,
- *   generationChanged:boolean, reason:string, offlineObservationKeys:string[], unresolvedJobIds:string[],
- *   hasCurrentObservation:boolean, baselineMount:Object, currentMount:Object,
- *   baselineFingerprint:?Object, currentFingerprint:Object,
- *   baselineSequence:number, currentSequence:number, stalenessMs:?number, watermark:?Object}}
- */
-export function computeObservationWindow(host) {
-  const wm = monitorData.hostObservationWatermark?.[host] || null;
-  const curSnap = monitorData.hostObservationCurrent?.[host] || null;
-  const hist = monitorData.machines?.[host]?.printStore?.history;
-  const currentObs = completedJobObservations(hist);
-  const currentFingerprint = historyGenerationFingerprint(hist);
-  const baselineSequence = Number(wm?.observationSequence) || 0;
-  const currentSequence = Number(curSnap?.observationSequence) || 0;
-  const windowId = `${host}|b${baselineSequence}|c${currentSequence}`;
+/** @private 複合キー(JSON tuple)から canonicalJobId を取り出す。 */
+function _idOf(key) {
+  try { const a = JSON.parse(key); return Array.isArray(a) ? String(a[0]) : ""; } catch { return ""; }
+}
 
-  // ★ O2-P0: 解釈しない観測事実を ObservationWindow へ載せる（O1 責務は不変・戻り値拡張のみ）。
-  //   O2 は baseline/current の装着一致を candidate 必須条件に使う。
-  const hasCurrentObservation = !!curSnap;
-  const baselineMount = _mountFacts(wm);
-  const currentMount = _mountFacts(curSnap);
+/** @private 複合キー配列から観測 identity を復元する（純関数・履歴非依存）。 */
+function _obsFromKeys(keys) {
+  const out = [];
+  if (!Array.isArray(keys)) return out;
+  for (const key of keys) {
+    let a; try { a = JSON.parse(key); } catch { continue; }
+    if (!Array.isArray(a)) continue;
+    const canonicalJobId = String(a[0]);
+    const startAt = Number(a[1]) || 0;
+    const finishAt = Number(a[2]) || 0;
+    const fileSignature = a[3] || "";
+    out.push({ key, canonicalJobId, startAt, finishAt, fileSignature, hasDistinguishing: finishAt > 0 || startAt > 0 || fileSignature !== "" });
+  }
+  return out;
+}
+
+/**
+ * オフライン観測窓を計算する **完全な純関数**（O1-P1-4）。
+ * 前回観測(previous=baseline)と現在観測(current)の2スナップショットのみを入力にとり、
+ * グローバル状態（watermark/履歴/live identity）を一切参照しない。O2 はこの ObservationWindow を分類する。
+ *
+ * @function computeOfflineWindow
+ * @param {?Object} previous baseline 観測スナップショット
+ * @param {?Object} current  現在観測スナップショット
+ * @param {string} [host] windowId 用のホスト識別（任意・比較には不使用）
+ * @returns {Object} ObservationWindow
+ */
+export function computeOfflineWindow(previous, current, host = "") {
+  const currentFingerprint = current?.generation || { completedCount: 0, earliestCompletedAt: 0, latestCompletedAt: 0, retainedHash: "" };
+  const baselineSequence = Number(previous?.observationSequence) || 0;
+  const currentSequence = Number(current?.observationSequence) || 0;
+  const windowId = `${host ? host + "|" : ""}b${baselineSequence}|c${currentSequence}`;
+  const hasCurrentObservation = !!current;
+  const baselineMount = _mountFacts(previous);
+  const currentMount = _mountFacts(current);
+
   const base = {
-    windowId, truncated: !!wm?.retainedRange?.truncated,
-    baselineFingerprint: wm?.generation || null, currentFingerprint,
-    baselineSequence, currentSequence, watermark: wm,
-    hasCurrentObservation, baselineMount, currentMount
+    windowId, host: host || null, truncated: !!previous?.retainedRange?.truncated,
+    baselineFingerprint: previous?.generation || null, currentFingerprint,
+    baselineSequence, currentSequence, watermark: previous || null,
+    hasCurrentObservation, baselineMount, currentMount, identityChanged: false
   };
 
-  if (!wm || !Array.isArray(wm.seenObservationKeys)) {
+  if (!previous || !Array.isArray(previous.seenObservationKeys)) {
     return { ...base, windowKind: "no-prior", bounded: false, generationChanged: false,
       reason: "no-prior-observation", offlineObservationKeys: [], unresolvedJobIds: [], stalenessMs: null };
   }
-
-  // ★ O2-P0-2: baseline はあるが復帰後の current 観測がまだ無い＝装着状態未確認。
-  //   O2 が装着一致を検証できないため、この段階では窓を不完全として扱う。
+  // ★ O2-P0-2: baseline はあるが復帰後 current 観測がまだ無い＝装着状態未確認。
   if (!hasCurrentObservation) {
     return { ...base, windowKind: "incomplete", bounded: false, generationChanged: false,
       reason: "current-observation-missing", offlineObservationKeys: [], unresolvedJobIds: [], stalenessMs: null };
   }
 
-  const identityChanged = wm.printerIdentity !== _identity(host);
-  const seen = new Set(wm.seenObservationKeys);
-  const baselineIds = new Set(wm.seenObservationKeys.map(_idOf));
-  const firstAt = Number(wm.retainedRange?.firstCompletedAt) || 0;
+  // current 観測は保存済みキーから復元（履歴を再読しない＝純関数化）。
+  const currentObs = _obsFromKeys(current.seenObservationKeys);
+  const identityChanged = _identityContradicts(previous.printerIdentity, current.printerIdentity);
+  const seen = new Set(previous.seenObservationKeys);
+  const baselineIds = new Set(previous.seenObservationKeys.map(_idOf));
+  const firstAt = Number(previous.retainedRange?.firstCompletedAt) || 0;
 
-  // ★ P0-2(世代反証): baseline/current fingerprint を実比較。current キー集合は一度だけ構築（O(n)）。
+  // ★ P0-2(世代反証): baseline/current を実比較。current キー集合は一度だけ構築（O(n)）。
   const currentKeySet = new Set(currentObs.map(o => o.key));
-  const priorCount = wm.seenObservationKeys.length;
+  const priorCount = previous.seenObservationKeys.length;
   let missing = 0;
-  if (priorCount) for (const k of wm.seenObservationKeys) if (!currentKeySet.has(k)) missing++;
+  if (priorCount) for (const k of previous.seenObservationKeys) if (!currentKeySet.has(k)) missing++;
   const mostMissing = priorCount > 0 && missing > Math.floor(priorCount * 0.5);
-  const shrunk = currentObs.length < Math.floor((Number(wm.retainedObservationCount) || 0) * 0.5);
-  const baseLatest = Number(wm.generation?.latestCompletedAt) || 0;
+  const shrunk = currentObs.length < Math.floor((Number(previous.retainedObservationCount) || 0) * 0.5);
+  const baseLatest = Number(previous.generation?.latestCompletedAt) || 0;
   const curLatest = Number(currentFingerprint.latestCompletedAt) || 0;
   const timeRollback = baseLatest > 0 && curLatest > 0 && curLatest < baseLatest;
   const generationChanged = identityChanged || mostMissing || shrunk || timeRollback;
 
   // ★ P0-1(retainedRange 境界): baseline に無く、かつ retained 境界「以降」の完了のみ offline 候補。
-  //   境界より古い履歴（切詰めで捨てた分）は offline にしない。finishAt 不明は候補単位で unresolved。
   const offlineObservationKeys = [];
   const unresolvedJobIds = [];
   let hasIdReuse = false, hasInsufficient = false;
@@ -195,8 +250,6 @@ export function computeObservationWindow(host) {
     if (seen.has(o.key)) continue;                 // 既観測
     if (o.finishAt && firstAt && o.finishAt < firstAt) continue; // 境界より古い＝offline 対象外
     const idReused = baselineIds.has(o.canonicalJobId);
-    // ★ P0-2(候補単位判定): 識別材料が無い候補は unresolved。canonicalJobId が baseline と
-    //   衝突（再利用）で検証できない場合と、単なる識別不足を分けて理由を立てる。
     if (!o.hasDistinguishing) {
       if (idReused) hasIdReuse = true; else hasInsufficient = true;
       unresolvedJobIds.push(o.canonicalJobId);
@@ -207,7 +260,7 @@ export function computeObservationWindow(host) {
       unresolvedJobIds.push(o.canonicalJobId);
       continue;
     }
-    offlineObservationKeys.push(o.key);            // 識別十分＝offline 確定候補（再利用IDでも別実行として保持）
+    offlineObservationKeys.push(o.key);            // 識別十分＝offline 確定候補
   }
 
   let reason;
@@ -219,26 +272,36 @@ export function computeObservationWindow(host) {
   else if (hasInsufficient) reason = "job-identity-insufficient";
   else reason = "diff-ok";
 
-  const persistedAt = Number(wm.persistedAt) || Number(wm.observedAtEpochMs) || 0;
-  const stalenessMs = persistedAt > 0 ? Math.max(0, wallNowMs() - persistedAt) : null;
+  // 鮮度は current 観測時刻 − baseline 永続時刻で算出（wall clock を読まず純関数を保つ）。
+  const baseAt = Number(previous.persistedAt) || Number(previous.observedAtEpochMs) || 0;
+  const curAt = Number(current.observedAtEpochMs) || 0;
+  const stalenessMs = (baseAt > 0 && curAt > 0) ? Math.max(0, curAt - baseAt) : null;
   const bounded = !generationChanged && unresolvedJobIds.length === 0;
 
   // ★ O2-P1-1: 構造化した windowKind を提供し、O2 が reason 文字列に依存しないようにする。
-  //   reason は説明表示用に残す。
   let windowKind;
   if (hasIdReuse || hasInsufficient) windowKind = "insufficient";
   else if (!bounded) windowKind = "unbounded";
   else windowKind = "bounded";
 
   return {
-    ...base, windowKind, bounded,
-    generationChanged, reason, offlineObservationKeys, unresolvedJobIds, stalenessMs
+    ...base, windowKind, bounded, generationChanged, identityChanged, shrunk,
+    reason, offlineObservationKeys, unresolvedJobIds, stalenessMs
   };
 }
 
-/** @private 複合キー(JSON tuple)から canonicalJobId を取り出す。 */
-function _idOf(key) {
-  try { const a = JSON.parse(key); return Array.isArray(a) ? String(a[0]) : ""; } catch { return ""; }
+/**
+ * host の baseline/current 観測から ObservationWindow を計算する（薄いラッパ）。
+ * 実体は純関数 computeOfflineWindow。O2 はこの窓を分類する。read-only。
+ *
+ * @function computeObservationWindow
+ * @param {string} host
+ * @returns {Object} ObservationWindow
+ */
+export function computeObservationWindow(host) {
+  const previous = monitorData.hostObservationWatermark?.[host] || null;
+  const current = monitorData.hostObservationCurrent?.[host] || null;
+  return computeOfflineWindow(previous, current, host);
 }
 
 /**
@@ -282,13 +345,18 @@ export function commitObservationWindow(host, { windowId, expectedSequence, cand
 }
 
 /**
- * confidence（推定確度）を reasons 付きで組み立てる純関数。remaining には影響しない。
+ * confidence（推定確度）を reasons/contradictions 付きで組み立てる純関数。remaining には影響しない。
  * @function buildConfidence
  * @param {"high"|"medium"|"low"|"none"} level
  * @param {string[]} [reasons]
- * @returns {{level:string, reasons:string[]}}
+ * @param {string[]} [contradictions]
+ * @returns {{level:string, reasons:string[], contradictions:string[]}}
  */
-export function buildConfidence(level, reasons = []) {
+export function buildConfidence(level, reasons = [], contradictions = []) {
   const lv = ["high", "medium", "low", "none"].includes(level) ? level : "none";
-  return { level: lv, reasons: Array.isArray(reasons) ? reasons.slice() : [] };
+  return {
+    level: lv,
+    reasons: Array.isArray(reasons) ? reasons.slice() : [],
+    contradictions: Array.isArray(contradictions) ? contradictions.slice() : []
+  };
 }

--- a/3dp_lib/dashboard_offline_observation.js
+++ b/3dp_lib/dashboard_offline_observation.js
@@ -11,6 +11,7 @@
  *   - recordObservation(host)          … 稼働中の観測を current へ記録（baseline 非上書き）
  *   - computeObservationWindow(host)   … baseline vs current で ObservationWindow を返す（純関数）
  *   - commitObservationWindow(host,..) … 窓評価後に baseline 昇格（fail-closed transaction）
+ *   - rollbackObservationWindowCommit(host,..) … baseline 耐久保存失敗時に昇格を巻き戻す
  *
  * 【重要な安全性（レビュー指摘）】
  *   - baseline は「最新 SEEN_CAP 件」に切詰めるため retainedRange（時系列境界）を保存し、
@@ -23,9 +24,9 @@
  *   安全基盤（completionObservationId/pendingUnattributedUsage/mountHistory/intervalId/
  *   usedLengthLog/remainingLengthMm 等）には一切触れない。残量は減らさない。
  *
- * @version 1.390.1247 (PR #411)
+ * @version 1.390.1248 (PR #411)
  * @since   2.3.0
- * @lastModified 2026-07-23 15:21:14
+ * @lastModified 2026-07-23 15:24:14
  * -----------------------------------------------------------
  */
 
@@ -394,7 +395,7 @@ export function computeObservationWindow(host) {
  * @function commitObservationWindow
  * @param {string} host
  * @param {{windowId:string, expectedSequence:number, candidatePersistedAt:number, candidateHash?:string, expectedAppSessionId?:?string}} opts
- * @returns {{ok:boolean, reason:string, baseline?:Object, idempotent?:boolean}}
+ * @returns {{ok:boolean, reason:string, baseline?:Object, previousBaseline?:?Object, idempotent?:boolean}}
  */
 export function commitObservationWindow(host, { windowId, expectedSequence, candidatePersistedAt, candidateHash = null, expectedAppSessionId = null } = {}) {
   if (!host) return { ok: false, reason: "host_required" };
@@ -429,7 +430,38 @@ export function commitObservationWindow(host, { windowId, expectedSequence, cand
     lastCommittedWindowId: windowId
   };
   monitorData.hostObservationWatermark[host] = baseline;
-  return { ok: true, reason: "committed", baseline };
+  return { ok: true, reason: "committed", baseline, previousBaseline: prev ? { ...prev } : null };
+}
+
+/**
+ * baseline 昇格後の耐久保存失敗時に、メモリ上の baseline を直前状態へ戻す。
+ *
+ * 【詳細説明】
+ * - `commitObservationWindow()` はメモリ上の `hostObservationWatermark` を先に昇格する。
+ * - その後の `saveUnifiedStorageDurably()` が失敗した場合、メモリだけ baseline が進むと次回評価が
+ *   idempotent 扱いになり、耐久保存の再試行境界が曖昧になる。
+ * - 巻き戻しは `lastCommittedWindowId` が対象 windowId と一致する場合だけ実行し、別の観測が進んだ
+ *   場合は fail-closed で触らない。
+ *
+ * @function rollbackObservationWindowCommit
+ * @param {string} host - 対象ホスト名。
+ * @param {{windowId:string, previousBaseline?:?Object}} opts - 巻き戻し対象 windowId と直前 baseline。
+ * @returns {{ok:boolean, reason:string, baseline?:?Object}} 巻き戻し結果。
+ */
+export function rollbackObservationWindowCommit(host, { windowId, previousBaseline = null } = {}) {
+  if (!host) return { ok: false, reason: "host_required" };
+  if (windowId == null || String(windowId) === "") return { ok: false, reason: "window_id_required" };
+  const store = monitorData.hostObservationWatermark;
+  const current = store?.[host] || null;
+  if (!current || current.lastCommittedWindowId !== windowId) {
+    return { ok: false, reason: "baseline_changed_since_commit", baseline: current };
+  }
+  if (previousBaseline && typeof previousBaseline === "object") {
+    store[host] = { ...previousBaseline };
+    return { ok: true, reason: "rolled_back", baseline: store[host] };
+  }
+  delete store[host];
+  return { ok: true, reason: "rolled_back_to_empty", baseline: null };
 }
 
 /**

--- a/3dp_lib/dashboard_offline_observation.js
+++ b/3dp_lib/dashboard_offline_observation.js
@@ -7,17 +7,22 @@
  * @module dashboard_offline_observation
  *
  * 【役割】アプリ稼働中に per-host で「見えていた状態」を記録し（観測 watermark）、
- *   再起動後に「現在の完了履歴 − 前回観測済み集合」で “アプリ停止中に新たに現れた
- *   完了ジョブ” を特定できるようにする（= オフライン窓）。ID の巻き戻り（プリンタ再起動/
- *   時計補正）に強くするため、last-seen-id 比較ではなく **集合差分** を用いる。
+ *   再起動後に「現在の完了履歴 − 停止前観測」でオフライン新規ジョブを特定する材料にする。
  *
- * 【安全境界（レビュー4の絶対条件）】本モジュールは **read-only**。
- *   - 参照のみ: mountHistory / hostSpoolMap / printStore.history / machine 情報。
- *   - 書き込みは monitorData.hostObservationWatermark（本 Option4 専用の新規フィールド）のみ。
- *   - completionObservationId / completionOpId / opId / intervalId /
- *     pendingUnattributedUsage / mountHistoryRejectedEvents / ledgerRepairRequired /
- *     mountHistory / usedLengthLog / remainingLengthMm には一切触れない。
- *   - 残量は減らさない。推定帰属・confidence の実利用は O2 以降。
+ * 【ライフサイクル（レビュー#411 P0-1）】
+ *   停止前基準(baseline=hostObservationWatermark)と現セッションの最新観測
+ *   (current=hostObservationCurrent)を**別スロット**にする。
+ *   - recordHostObservation は current を更新し、baseline は上書きしない
+ *     （baseline が無い初回のみ bootstrap＝新規導入は評価対象が無い）。
+ *   - computeOfflineWindow は baseline vs 現在履歴でオフライン窓を計算する。
+ *   - commitObservationBaseline はオフライン窓「評価後」に current を baseline へ昇格する
+ *     （O2 が評価完了後に呼ぶ。O1 では基準を勝手に前進させない）。
+ *
+ * 【安全境界（レビュー4の絶対条件）】read-only。書き込みは hostObservationWatermark /
+ *   hostObservationCurrent（Option4 専用の新規フィールド）のみ。
+ *   completionObservationId / completionOpId / opId / intervalId / pendingUnattributedUsage /
+ *   mountHistoryRejectedEvents / ledgerRepairRequired / mountHistory / usedLengthLog /
+ *   remainingLengthMm には一切触れない。残量は減らさない（O3 以降・ユーザ確認後）。
  *
  * @version 2.3.0
  * @since   2.3.0
@@ -28,133 +33,156 @@
 
 import { monitorData } from "./dashboard_data.js";
 import { wallNowMs } from "./dashboard_time.js";
+import { completedJobKeySet, historyGenerationFingerprint } from "./dashboard_history_identity.js";
+
+/** seen key の保持上限（#411-P1-3。世代 fingerprint と併用して再利用/縮小を検出する）。 */
+const SEEN_CAP = 5000;
+
+/** per-host observationSequence カウンタ（セッション内の観測回数。監査・鮮度用）。 */
+const _obsSeq = new Map();
 
 /**
- * 完了ジョブ判定（printfinish 欠落の旧データも finishTime/endtime/usagetime で完了扱い）。
- * dashboard_spool.isCompletedHistoryEntry と同義だが、本モジュールを安全境界内で
- * self-contained に保つため read-only 判定を内製する（依存を増やさない）。
- *
- * @private
- * @param {Object} j - 履歴ジョブ
- * @returns {boolean}
- */
-function _isCompleted(j) {
-  if (!j) return false;
-  if (j.printfinish != null) return true;
-  return (Number(j.finishTime) > 0) || (Number(j.finishTimeSec) > 0)
-    || (Number(j.endtime) > 0) || (Number(j.usagetime) > 0);
-}
-
-/**
- * 指定ホストの printStore.history から「完了ジョブの printId 集合」を返す（read-only）。
- *
- * @private
- * @param {string} host
- * @returns {number[]} 完了 printId の配列（数値・昇順）
- */
-function _completedJobIds(host) {
-  const hist = monitorData.machines?.[host]?.printStore?.history;
-  if (!Array.isArray(hist)) return [];
-  const ids = [];
-  for (const j of hist) {
-    if (!_isCompleted(j)) continue;
-    const n = Number(j?.id);
-    if (Number.isFinite(n) && n > 0) ids.push(n);
-  }
-  ids.sort((a, b) => a - b);
-  return ids;
-}
-
-/**
- * 指定ホストのプリンタ同一性シグネチャ（read-only）。取得できる範囲で構成する。
- * boot/session ID が将来取れれば加える。現状は model/type/接続識別で近似する。
- *
+ * プリンタ同一性シグネチャ（read-only）。取得できる範囲で構成する
+ * （host/type/model のみでは再起動を検出できないため、世代反証は computeOfflineWindow で別途行う）。
  * @private
  * @param {string} host
  * @returns {string}
  */
-function _printerIdentity(host) {
+function _identity(host) {
   const sd = monitorData.machines?.[host]?.storedData || {};
   const model = sd.model?.rawValue ?? "";
-  const type = monitorData.appSettings?.connectionTargets?.find?.(
-    t => t && (t.hostname === host))?.printerType ?? "";
+  const type = monitorData.appSettings?.connectionTargets?.find?.(t => t && t.hostname === host)?.printerType ?? "";
   return `${host}|${type}|${model}`;
 }
 
 /**
- * アプリ稼働中の観測 watermark を per-host に記録/更新する（#411-O1・read-only 追加専用）。
- *
- * 記録内容:
- * - seenCompletedJobIds: そのホストで観測できた完了 printId 集合（再起動後の差分の基準）。
- * - mountedSpoolId / mountIntervalId: 現在装着スプールとその open 区間（継続推定の候補）。
- * - printerIdentity: プリンタ同一性（再起動/交換の反証検出材料）。
- * - observedAtEpochMs / historyCount: 監査用。
+ * 現在の観測スナップショットを構築する（read-only）。
+ * @private
+ * @param {string} host
+ * @param {{mountIntervalId?:?string, mountIntervalStatus?:string}} opts
+ * @returns {Object}
+ */
+function _buildObservation(host, { mountIntervalId = null, mountIntervalStatus = "unknown" } = {}) {
+  const hist = monitorData.machines?.[host]?.printStore?.history;
+  let keys = completedJobKeySet(hist); // Set 由来・重複排除済み（#411-P1-1/P1-2）
+  if (keys.length > SEEN_CAP) keys = keys.slice(keys.length - SEEN_CAP); // #411-P1-3
+  const spoolId = monitorData.hostSpoolMap?.[host] ?? null;
+  _obsSeq.set(host, (_obsSeq.get(host) || 0) + 1);
+  return {
+    observedAtEpochMs: wallNowMs(),
+    persistedAt: null,                        // durable commit 時に確定（#411-P1-5）
+    observationSequence: _obsSeq.get(host),
+    mountedSpoolId: spoolId,
+    mountIntervalId: mountIntervalId ?? null, // #411-P0-4: 呼び出し側が明示配線
+    mountIntervalStatus: mountIntervalStatus, // ok/none/ambiguous/corrupt/unknown
+    observationState: spoolId ? "mounted" : "unmounted", // #411-P0-3
+    printerIdentity: _identity(host),
+    generation: historyGenerationFingerprint(hist), // #411-P0-2 反証材料
+    seenCompletedJobKeys: keys,
+    historyCount: keys.length
+  };
+}
+
+/**
+ * アプリ稼働中の観測を per-host に記録する（#411-O1・read-only）。
+ * current を更新し、baseline は上書きしない（baseline 未設定の初回のみ bootstrap）。
  *
  * @function recordHostObservation
- * @param {string} host - ホスト名
- * @param {Object} [opts]
- * @param {?string} [opts.mountIntervalId] - 呼び出し側が把握している open 区間ID（任意）。
- * @returns {?Object} 更新後の watermark（host 未指定なら null）
+ * @param {string} host
+ * @param {{mountIntervalId?:?string, mountIntervalStatus?:string}} [opts]
+ * @returns {?Object} current スナップショット（host 未指定なら null）
  */
-export function recordHostObservation(host, { mountIntervalId = null } = {}) {
+export function recordHostObservation(host, opts = {}) {
   if (!host) return null;
   if (!monitorData.hostObservationWatermark || typeof monitorData.hostObservationWatermark !== "object") {
     monitorData.hostObservationWatermark = {};
   }
-  const ids = _completedJobIds(host);
-  const wm = {
-    observedAtEpochMs: wallNowMs(),
-    mountedSpoolId: monitorData.hostSpoolMap?.[host] ?? null,
-    mountIntervalId: mountIntervalId ?? null,
-    printerIdentity: _printerIdentity(host),
-    seenCompletedJobIds: ids,
-    historyCount: ids.length
-  };
-  monitorData.hostObservationWatermark[host] = wm;
-  return wm;
+  if (!monitorData.hostObservationCurrent || typeof monitorData.hostObservationCurrent !== "object") {
+    monitorData.hostObservationCurrent = {};
+  }
+  const snap = _buildObservation(host, opts);
+  monitorData.hostObservationCurrent[host] = snap;
+  // ★ P0-1: 既存 baseline は評価前に上書きしない。無い初回のみ bootstrap（新規導入＝offline無し）。
+  if (!monitorData.hostObservationWatermark[host]) {
+    monitorData.hostObservationWatermark[host] = { ...snap, committedReason: "bootstrap", persistedAt: wallNowMs() };
+  }
+  return snap;
+}
+
+/**
+ * オフライン窓「評価後」に current を baseline へ昇格する（#411-O1。O2 が評価完了後に呼ぶ）。
+ *
+ * @function commitObservationBaseline
+ * @param {string} host
+ * @param {{reason?:string}} [opts]
+ * @returns {?Object} 新しい baseline（current 未設定なら null）
+ */
+export function commitObservationBaseline(host, { reason = "committed" } = {}) {
+  if (!host) return null;
+  const cur = monitorData.hostObservationCurrent?.[host];
+  if (!cur) return null;
+  if (!monitorData.hostObservationWatermark || typeof monitorData.hostObservationWatermark !== "object") {
+    monitorData.hostObservationWatermark = {};
+  }
+  monitorData.hostObservationWatermark[host] = { ...cur, committedReason: reason, persistedAt: wallNowMs() };
+  return monitorData.hostObservationWatermark[host];
 }
 
 /**
  * 「アプリ停止中に新たに現れた完了ジョブ」を集合差分で求める純関数（#411-O1/O2 の基盤）。
  *
- * offlineJobIds = 現在の完了 printId 集合 − 前回観測済み集合。
- * ID の巻き戻り（プリンタ再起動・時計補正）に強いよう last-seen-id 比較を使わない。
- * 前回観測が無い（初回導入/移行/履歴全置換）場合は bounded=false を返す
- * （= どれがオフライン窓のジョブか特定できない＝安全側。O2 で unbounded 分類に使う）。
+ * offlineJobKeys = 現在の完了 key 集合 − baseline の seen 集合。ただし以下は
+ * bounded=false（同じ窓と断定しない）:
+ *   - 前回観測が無い（初回導入/移行）
+ *   - printer identity 変化
+ *   - 履歴 generation 交代の反証（#411-P0-2）: baseline seen の過半が現在履歴から消えた／
+ *     現在履歴が baseline の半分未満へ縮小（＝履歴全置換・ID 再利用の疑い）
  *
  * @function computeOfflineWindow
- * @param {string} host - ホスト名
- * @returns {{bounded:boolean, offlineJobIds:number[], reason:string,
- *            identityChanged:boolean, watermark:?Object}}
+ * @param {string} host
+ * @returns {{bounded:boolean, offlineJobKeys:string[], reason:string,
+ *            identityChanged:boolean, generationChanged:boolean,
+ *            stalenessMs:?number, watermark:?Object}}
  */
 export function computeOfflineWindow(host) {
   const wm = monitorData.hostObservationWatermark?.[host] || null;
-  const current = _completedJobIds(host);
-  if (!wm || !Array.isArray(wm.seenCompletedJobIds)) {
-    return { bounded: false, offlineJobIds: [], reason: "no-prior-observation", identityChanged: false, watermark: wm };
+  const hist = monitorData.machines?.[host]?.printStore?.history;
+  const currentKeys = completedJobKeySet(hist);
+  if (!wm || !Array.isArray(wm.seenCompletedJobKeys)) {
+    return { bounded: false, offlineJobKeys: [], reason: "no-prior-observation",
+      identityChanged: false, generationChanged: false, stalenessMs: null, watermark: wm };
   }
-  const identityChanged = wm.printerIdentity !== _printerIdentity(host);
-  const seen = new Set(wm.seenCompletedJobIds.map(Number));
-  const offlineJobIds = current.filter(id => !seen.has(id));
-  return {
-    // identity が変わっていたら「同じ窓」と断定できない＝bounded にしない（O2 で unbounded/反証へ）。
-    bounded: !identityChanged,
-    offlineJobIds,
-    reason: identityChanged ? "printer-identity-changed" : "diff-ok",
-    identityChanged,
-    watermark: wm
-  };
+  const identityChanged = wm.printerIdentity !== _identity(host);
+  const seen = new Set(wm.seenCompletedJobKeys);
+  const currentSet = new Set(currentKeys);
+  // #411-P0-2: 世代交代/ID 再利用の反証。
+  const priorCount = wm.seenCompletedJobKeys.length;
+  const missing = priorCount ? wm.seenCompletedJobKeys.filter(k => !currentSet.has(k)).length : 0;
+  const mostMissing = priorCount > 0 && missing > Math.floor(priorCount * 0.5);
+  const shrunk = currentKeys.length < Math.floor((Number(wm.historyCount) || 0) * 0.5);
+  const generationChanged = identityChanged || mostMissing || shrunk;
+
+  const offlineJobKeys = currentKeys.filter(k => !seen.has(k));
+  let reason;
+  if (identityChanged) reason = "printer-identity-changed";
+  else if (mostMissing) reason = "history-generation-changed";
+  else if (shrunk) reason = "history-shrunk";
+  else reason = "diff-ok";
+
+  const persistedAt = Number(wm.persistedAt) || Number(wm.observedAtEpochMs) || 0;
+  const stalenessMs = persistedAt > 0 ? Math.max(0, wallNowMs() - persistedAt) : null;
+
+  return { bounded: !generationChanged, offlineJobKeys, reason,
+    identityChanged, generationChanged, stalenessMs, watermark: wm };
 }
 
 /**
- * confidence（推定確度）オブジェクトを reasons 付きで組み立てる純関数（#411-O1 で schema 先行導入）。
- *
- * レビュー4提案: 「なぜその確度なのか」を後から説明できるよう、最初から理由を保持する。
- * O2 以降の分類器がこれを埋める。remaining には一切影響しない（表示・監査用の宣言のみ）。
+ * confidence（推定確度）を reasons 付きで組み立てる純関数（#411 で schema 先行導入）。
+ * remaining には一切影響しない（表示・監査用の宣言のみ）。
  *
  * @function buildConfidence
- * @param {"high"|"medium"|"low"|"none"} level - 確度レベル
- * @param {string[]} [reasons] - 根拠コード（例: "seen-job","continuous-print","no-spool-change","elapsed-time"）
+ * @param {"high"|"medium"|"low"|"none"} level
+ * @param {string[]} [reasons] - 根拠コード（seen-job/continuous-print/no-spool-change/elapsed-time/stale-watermark 等）
  * @returns {{level:string, reasons:string[]}}
  */
 export function buildConfidence(level, reasons = []) {

--- a/3dp_lib/dashboard_offline_observation.js
+++ b/3dp_lib/dashboard_offline_observation.js
@@ -23,8 +23,9 @@
  *   安全基盤（completionObservationId/pendingUnattributedUsage/mountHistory/intervalId/
  *   usedLengthLog/remainingLengthMm 等）には一切触れない。残量は減らさない。
  *
- * @version 2.3.0
+ * @version 1.390.1246 (PR #411)
  * @since   2.3.0
+ * @lastModified 2026-07-23 09:57:05
  * -----------------------------------------------------------
  */
 
@@ -293,6 +294,7 @@ export function computeOfflineWindow(previous, current, opts = {}) {
   const seen = new Set(previous.seenObservationKeys);
   const baselineIds = new Set(previous.seenObservationKeys.map(_idOf));
   const firstAt = Number(previous.retainedRange?.firstCompletedAt) || 0;
+  const truncatedBaseline = !!previous.retainedRange?.truncated;
 
   // ★ P0-2(世代反証): baseline/current を実比較。current キー集合は一度だけ構築（O(n)）。
   const currentKeySet = new Set(currentObs.map(o => o.key));
@@ -309,10 +311,19 @@ export function computeOfflineWindow(previous, current, opts = {}) {
   // ★ P0-1(retainedRange 境界): baseline に無く、かつ retained 境界「以降」の完了のみ offline 候補。
   const offlineObservationKeys = [];
   const unresolvedJobIds = [];
-  let hasIdReuse = false, hasInsufficient = false;
+  let hasIdReuse = false, hasInsufficient = false, hasTruncatedUnverifiable = false;
   for (const o of currentObs) {
     if (seen.has(o.key)) continue;                 // 既観測
     if (o.finishAt && firstAt && o.finishAt < firstAt) continue; // 境界より古い＝offline 対象外
+    // ★ codex-P1: baseline が truncated のとき、retained 時系列境界で「窓の内側」だと確認できない
+    //   （候補の finishAt 不明 or 境界時刻 firstAt 不明）ものは offline 確定しない。切詰めで落ちた
+    //   古い履歴や、履歴再取得で finishTime/複合キーが変わった古い完了を誤って offline 化しないための
+    //   fail-closed（unresolved 扱い＝bounded=false）。
+    if (truncatedBaseline && !(o.finishAt > 0 && firstAt > 0)) {
+      hasTruncatedUnverifiable = true;
+      unresolvedJobIds.push(o.canonicalJobId);
+      continue;
+    }
     const idReused = baselineIds.has(o.canonicalJobId);
     if (!o.hasDistinguishing) {
       if (idReused) hasIdReuse = true; else hasInsufficient = true;
@@ -334,6 +345,7 @@ export function computeOfflineWindow(previous, current, opts = {}) {
   else if (shrunk) reason = "history-shrunk";
   else if (hasIdReuse) reason = "reused-job-id-unverifiable";
   else if (hasInsufficient) reason = "job-identity-insufficient";
+  else if (hasTruncatedUnverifiable) reason = "history-truncated-unverifiable";
   else reason = "diff-ok";
 
   // 鮮度は current 観測時刻 − baseline 永続時刻で算出（wall clock を読まず純関数を保つ）。
@@ -344,7 +356,7 @@ export function computeOfflineWindow(previous, current, opts = {}) {
 
   // ★ O2-P1-1: 構造化した windowKind を提供し、O2 が reason 文字列に依存しないようにする。
   let windowKind;
-  if (hasIdReuse || hasInsufficient) windowKind = "insufficient";
+  if (hasIdReuse || hasInsufficient || hasTruncatedUnverifiable) windowKind = "insufficient";
   else if (!bounded) windowKind = "unbounded";
   else windowKind = "bounded";
 

--- a/3dp_lib/dashboard_offline_observation.js
+++ b/3dp_lib/dashboard_offline_observation.js
@@ -31,11 +31,19 @@
 "use strict";
 
 import { monitorData } from "./dashboard_data.js";
-import { wallNowMs } from "./dashboard_time.js";
+import { wallNowMs, randomEventId } from "./dashboard_time.js";
 import { completedJobObservations, historyGenerationFingerprint } from "./dashboard_history_identity.js";
 
 /** 観測キーの保持上限（completion 時系列で最新のみ保持）。 */
 const SEEN_CAP = 5000;
+
+/** アプリ起動セッションID（P1-2: 永続復元された旧 current と現セッション観測を区別）。 */
+let _appSessionId = null;
+/** @private セッションIDを遅延生成して返す（同一セッション内で安定）。 */
+function _sessionId() {
+  if (_appSessionId == null) { try { _appSessionId = randomEventId(); } catch { _appSessionId = "session-0"; } }
+  return _appSessionId;
+}
 
 /**
  * @private プリンタ識別を構造化して返す（P1-1）。model/serial/deviceId のいずれかが
@@ -69,16 +77,29 @@ function _normIdentity(id) {
 }
 
 /**
- * @private baseline/current の identity が「プリンタ交換」を示すか。
- * strong 同士の安定識別子（serial→deviceId→model/type）不一致のみ反証。
- * weak→strong の補完・weak 同士は反証にしない（同一機で情報が後から届く正常系）。
+ * @private baseline/current identity の一致強度を返す（P1-1）。
+ * model は同機種で共通し得るため「一意識別子」ではない＝一致しても same-strong にしない。
+ *  - same-strong: serialNumber または deviceId が一致（本当に同一筐体）
+ *  - same-descriptive: model/type は一致するが一意IDが無い（同一機とは断定できない）
+ *  - contradicted: 比較可能な一意ID/model が不一致（＝プリンタ交換の反証）
+ *  - unverifiable: 情報不足（weak／weak→strong 補完）。反証にはしない。
+ * @param {*} baseId
+ * @param {*} curId
+ * @returns {{status:string, matchedBy:?string}}
  */
-function _identityContradicts(baseId, curId) {
+function _identityMatch(baseId, curId) {
   const a = _normIdentity(baseId), b = _normIdentity(curId);
-  if (a.completeness !== "strong" || b.completeness !== "strong") return false;
-  if (a.serialNumber && b.serialNumber) return a.serialNumber !== b.serialNumber;
-  if (a.deviceId && b.deviceId) return a.deviceId !== b.deviceId;
-  return (a.model !== b.model) || (a.printerType !== b.printerType);
+  if (a.serialNumber && b.serialNumber) {
+    return { status: a.serialNumber === b.serialNumber ? "same-strong" : "contradicted", matchedBy: "serialNumber" };
+  }
+  if (a.deviceId && b.deviceId) {
+    return { status: a.deviceId === b.deviceId ? "same-strong" : "contradicted", matchedBy: "deviceId" };
+  }
+  if (a.model && b.model) {
+    const same = a.model === b.model && a.printerType === b.printerType;
+    return { status: same ? "same-descriptive" : "contradicted", matchedBy: "model" };
+  }
+  return { status: "unverifiable", matchedBy: null };
 }
 
 /** @private 継続採番（再起動で 1 へ戻さない）。current/baseline から常に単調増加。 */
@@ -126,7 +147,9 @@ function _buildObservation(host, { mountIntervalId = null, mountIntervalStatus =
     // ★ P0-4: 連続印刷の証拠（停止前に何を印刷中だったか）。O2 の activeJobContinued 判定に使う。
     activeJobId: activeJobId ?? (machine?.printStore?.current?.id ?? null),
     printState: printState ?? null,
-    historyRevision: machine?.printStore?.revision ?? null,
+    historyRevision: machine?.printStore?._historyRev ?? null,
+    // ★ P1-2: 現セッションで取得した観測か（永続復元された旧 current と区別する）。
+    appSessionId: _sessionId(),
     printerIdentity: _identity(host),
     generation: historyGenerationFingerprint(hist),
     seenObservationKeys: retained.map(o => o.key),
@@ -165,6 +188,27 @@ export function recordObservation(host, opts = {}) {
   return snap;
 }
 
+/**
+ * 観測を記録すべきかを判定する純関数（P0-1: signature 変化 or heartbeat 経過で記録）。
+ * signature には履歴 revision・現在ジョブ・印刷状態・装着スプール・mount status/interval id を含める。
+ * これにより「稼働中に完了を観測したのに 5s 以内クラッシュで offline 化」する隙間を縮める。
+ *
+ * @function observationDue
+ * @param {?{lastAtMs:?number, signature:?string}} prev 前回記録の時刻(monotonic)と signature
+ * @param {{historyRevision:*, activeJobId:*, printState:*, mountedSpoolId:*, mountIntervalStatus:*, mountIntervalId:*}} facts
+ * @param {{nowMs:number, heartbeatMs?:number}} clock
+ * @returns {{record:boolean, signature:string}}
+ */
+export function observationDue(prev, facts = {}, { nowMs = 0, heartbeatMs = 5000 } = {}) {
+  const signature = [
+    facts.historyRevision ?? "", facts.activeJobId ?? "", facts.printState ?? "",
+    facts.mountedSpoolId ?? "", facts.mountIntervalStatus ?? "", facts.mountIntervalId ?? ""
+  ].join("|");
+  const lastAt = prev?.lastAtMs;
+  const record = lastAt == null || (nowMs - lastAt) > heartbeatMs || prev?.signature !== signature;
+  return { record, signature };
+}
+
 /** @private 複合キー(JSON tuple)から canonicalJobId を取り出す。 */
 function _idOf(key) {
   try { const a = JSON.parse(key); return Array.isArray(a) ? String(a[0]) : ""; } catch { return ""; }
@@ -194,38 +238,47 @@ function _obsFromKeys(keys) {
  * @function computeOfflineWindow
  * @param {?Object} previous baseline 観測スナップショット
  * @param {?Object} current  現在観測スナップショット
- * @param {string} [host] windowId 用のホスト識別（任意・比較には不使用）
+ * @param {string|{host?:string, sessionId?:?string}} [opts] windowId 用 host と、鮮度検証用 sessionId
  * @returns {Object} ObservationWindow
  */
-export function computeOfflineWindow(previous, current, host = "") {
+export function computeOfflineWindow(previous, current, opts = {}) {
+  const { host = "", sessionId = null } = (typeof opts === "string") ? { host: opts } : (opts || {});
   const currentFingerprint = current?.generation || { completedCount: 0, earliestCompletedAt: 0, latestCompletedAt: 0, retainedHash: "" };
   const baselineSequence = Number(previous?.observationSequence) || 0;
   const currentSequence = Number(current?.observationSequence) || 0;
   const windowId = `${host ? host + "|" : ""}b${baselineSequence}|c${currentSequence}`;
-  const hasCurrentObservation = !!current;
+  // ★ P1-2: current は「現セッションで取得した観測」だけを装着状態の根拠にする。
+  //   sessionId 未指定（純関数テスト等）は fresh 扱い。復元された旧 current は stale＝不採用。
+  const currentIsFresh = !!current && (sessionId == null || current.appSessionId === sessionId);
+  const currentObservationStale = !!current && !currentIsFresh;
+  const hasCurrentObservation = currentIsFresh;
   const baselineMount = _mountFacts(previous);
-  const currentMount = _mountFacts(current);
+  const currentMount = _mountFacts(currentIsFresh ? current : null);
+  const printerIdentityMatch = _identityMatch(previous?.printerIdentity, current?.printerIdentity);
 
   const base = {
     windowId, host: host || null, truncated: !!previous?.retainedRange?.truncated,
     baselineFingerprint: previous?.generation || null, currentFingerprint,
     baselineSequence, currentSequence, watermark: previous || null,
-    hasCurrentObservation, baselineMount, currentMount, identityChanged: false
+    hasCurrentObservation, currentObservationStale, baselineMount, currentMount,
+    printerIdentityMatch, identityChanged: false
   };
 
   if (!previous || !Array.isArray(previous.seenObservationKeys)) {
     return { ...base, windowKind: "no-prior", bounded: false, generationChanged: false,
       reason: "no-prior-observation", offlineObservationKeys: [], unresolvedJobIds: [], stalenessMs: null };
   }
-  // ★ O2-P0-2: baseline はあるが復帰後 current 観測がまだ無い＝装着状態未確認。
+  // ★ O2-P0-2 / P1-2: baseline はあるが「現セッションの」current 観測がまだ無い＝装着状態未確認。
+  //   復元された旧 current だけでは復帰後の装着を検証できないため incomplete とする。
   if (!hasCurrentObservation) {
     return { ...base, windowKind: "incomplete", bounded: false, generationChanged: false,
-      reason: "current-observation-missing", offlineObservationKeys: [], unresolvedJobIds: [], stalenessMs: null };
+      reason: currentObservationStale ? "current-observation-stale" : "current-observation-missing",
+      offlineObservationKeys: [], unresolvedJobIds: [], stalenessMs: null };
   }
 
   // current 観測は保存済みキーから復元（履歴を再読しない＝純関数化）。
   const currentObs = _obsFromKeys(current.seenObservationKeys);
-  const identityChanged = _identityContradicts(previous.printerIdentity, current.printerIdentity);
+  const identityChanged = printerIdentityMatch.status === "contradicted";
   const seen = new Set(previous.seenObservationKeys);
   const baselineIds = new Set(previous.seenObservationKeys.map(_idOf));
   const firstAt = Number(previous.retainedRange?.firstCompletedAt) || 0;
@@ -301,7 +354,8 @@ export function computeOfflineWindow(previous, current, host = "") {
 export function computeObservationWindow(host) {
   const previous = monitorData.hostObservationWatermark?.[host] || null;
   const current = monitorData.hostObservationCurrent?.[host] || null;
-  return computeOfflineWindow(previous, current, host);
+  // ★ P1-2: 現セッションで取得した current だけを装着根拠にする（復元された旧 current は stale）。
+  return computeOfflineWindow(previous, current, { host, sessionId: _sessionId() });
 }
 
 /**

--- a/3dp_lib/dashboard_offline_observation.js
+++ b/3dp_lib/dashboard_offline_observation.js
@@ -9,20 +9,21 @@
  * 【役割】アプリ稼働中に per-host で「見えていた状態」を記録し（観測 watermark）、
  *   再起動後に「現在の完了履歴 − 停止前観測」でオフライン新規ジョブを特定する材料にする。
  *
- * 【ライフサイクル（レビュー#411 P0-1）】
- *   停止前基準(baseline=hostObservationWatermark)と現セッションの最新観測
- *   (current=hostObservationCurrent)を**別スロット**にする。
- *   - recordHostObservation は current を更新し、baseline は上書きしない
- *     （baseline が無い初回のみ bootstrap＝新規導入は評価対象が無い）。
- *   - computeOfflineWindow は baseline vs 現在履歴でオフライン窓を計算する。
- *   - commitObservationBaseline はオフライン窓「評価後」に current を baseline へ昇格する
- *     （O2 が評価完了後に呼ぶ。O1 では基準を勝手に前進させない）。
+ * 【同一実行の識別（レビュー#411 P0-1）】job id だけではプリンタ再起動で同じ id が別の
+ *   物理印刷へ再利用された場合を区別できない。id ＋ 開始/完了時刻 ＋ ファイル同一性の
+ *   複合キー（jobObservationKey）を集合差分に使う。識別材料が不足するときは bounded=false。
+ *
+ * 【世代反証（P0-2）】printer identity 変化に加え、履歴 generation fingerprint（completion 時系列
+ *   ベース）を baseline/current で実際に比較し、latest completion 巻き戻り・世代交代・大幅縮小を検出する。
+ *
+ * 【ライフサイクル（P0-1）】baseline(hostObservationWatermark)と current(hostObservationCurrent)を
+ *   別スロット化。record は current のみ更新（baseline 非上書き。未設定初回のみ bootstrap）。
+ *   commitObservationBaseline は「窓評価後」に windowId 付きで昇格する（同一 windowId は冪等）。
  *
  * 【安全境界（レビュー4の絶対条件）】read-only。書き込みは hostObservationWatermark /
- *   hostObservationCurrent（Option4 専用の新規フィールド）のみ。
- *   completionObservationId / completionOpId / opId / intervalId / pendingUnattributedUsage /
- *   mountHistoryRejectedEvents / ledgerRepairRequired / mountHistory / usedLengthLog /
- *   remainingLengthMm には一切触れない。残量は減らさない（O3 以降・ユーザ確認後）。
+ *   hostObservationCurrent のみ。completionObservationId/completionOpId/opId/intervalId/
+ *   pendingUnattributedUsage/mountHistoryRejectedEvents/ledgerRepairRequired/mountHistory/
+ *   usedLengthLog/remainingLengthMm には一切触れない。残量は減らさない（O3 以降・確認後）。
  *
  * @version 2.3.0
  * @since   2.3.0
@@ -33,20 +34,19 @@
 
 import { monitorData } from "./dashboard_data.js";
 import { wallNowMs } from "./dashboard_time.js";
-import { completedJobKeySet, historyGenerationFingerprint } from "./dashboard_history_identity.js";
+import { completedJobObservations, historyGenerationFingerprint } from "./dashboard_history_identity.js";
 
-/** seen key の保持上限（#411-P1-3。世代 fingerprint と併用して再利用/縮小を検出する）。 */
+/** 観測キーの保持上限（#411-P1-4。completion 時系列で最新のみ保持）。 */
 const SEEN_CAP = 5000;
+/** 「識別材料不足」とみなす割合しきい（未識別が半数超なら bounded=false）。 */
+const INSUFFICIENT_RATIO = 0.5;
 
-/** per-host observationSequence カウンタ（セッション内の観測回数。監査・鮮度用）。 */
-const _obsSeq = new Map();
+/** per-host session observation counter（メモリ。再起動後は baseline/current から継続採番）。 */
+const _sessionObsSeq = new Map();
 
 /**
- * プリンタ同一性シグネチャ（read-only）。取得できる範囲で構成する
- * （host/type/model のみでは再起動を検出できないため、世代反証は computeOfflineWindow で別途行う）。
- * @private
- * @param {string} host
- * @returns {string}
+ * プリンタ同一性シグネチャ（read-only・取得できる範囲）。
+ * @private @param {string} host @returns {string}
  */
 function _identity(host) {
   const sd = monitorData.machines?.[host]?.storedData || {};
@@ -56,124 +56,158 @@ function _identity(host) {
 }
 
 /**
+ * 観測 sequence を継続採番する（#411-P1-3。再起動で 1 へ戻さない）。
+ * @private @param {string} host @returns {number}
+ */
+function _nextSeq(host) {
+  const base = Number(monitorData.hostObservationWatermark?.[host]?.observationSequence) || 0;
+  const cur = Number(monitorData.hostObservationCurrent?.[host]?.observationSequence) || 0;
+  const mem = _sessionObsSeq.get(host) || 0;
+  const next = Math.max(base, cur, mem) + 1;
+  _sessionObsSeq.set(host, next);
+  return next;
+}
+
+/**
  * 現在の観測スナップショットを構築する（read-only）。
  * @private
- * @param {string} host
- * @param {{mountIntervalId?:?string, mountIntervalStatus?:string}} opts
- * @returns {Object}
  */
 function _buildObservation(host, { mountIntervalId = null, mountIntervalStatus = "unknown" } = {}) {
   const hist = monitorData.machines?.[host]?.printStore?.history;
-  let keys = completedJobKeySet(hist); // Set 由来・重複排除済み（#411-P1-1/P1-2）
-  if (keys.length > SEEN_CAP) keys = keys.slice(keys.length - SEEN_CAP); // #411-P1-3
+  const obsAll = completedJobObservations(hist);          // completion 時系列・重複排除済み
+  const totalCompletedCount = obsAll.length;
+  // ★ P1-4: 文字列順ではなく completion 時系列の「最新 SEEN_CAP 件」を保持。
+  const retained = obsAll.length > SEEN_CAP ? obsAll.slice(obsAll.length - SEEN_CAP) : obsAll;
   const spoolId = monitorData.hostSpoolMap?.[host] ?? null;
-  _obsSeq.set(host, (_obsSeq.get(host) || 0) + 1);
   return {
     observedAtEpochMs: wallNowMs(),
-    persistedAt: null,                        // durable commit 時に確定（#411-P1-5）
-    observationSequence: _obsSeq.get(host),
+    persistedAt: null,
+    observationSequence: _nextSeq(host),
     mountedSpoolId: spoolId,
-    mountIntervalId: mountIntervalId ?? null, // #411-P0-4: 呼び出し側が明示配線
-    mountIntervalStatus: mountIntervalStatus, // ok/none/ambiguous/corrupt/unknown
-    observationState: spoolId ? "mounted" : "unmounted", // #411-P0-3
+    mountIntervalId: mountIntervalId ?? null,
+    mountIntervalStatus,                                   // ok/none/ambiguous/corrupt/unknown
+    observationState: spoolId ? "mounted" : "unmounted",
     printerIdentity: _identity(host),
-    generation: historyGenerationFingerprint(hist), // #411-P0-2 反証材料
-    seenCompletedJobKeys: keys,
-    historyCount: keys.length
+    generation: historyGenerationFingerprint(hist),       // 時系列ベース fingerprint
+    seenObservationKeys: retained.map(o => o.key),         // 複合キー（diff 基準）
+    undistinguishedCount: retained.filter(o => !o.hasDistinguishing).length,
+    retainedObservationCount: retained.length,
+    totalCompletedCount,
+    truncated: totalCompletedCount > retained.length
   };
 }
 
 /**
- * アプリ稼働中の観測を per-host に記録する（#411-O1・read-only）。
- * current を更新し、baseline は上書きしない（baseline 未設定の初回のみ bootstrap）。
- *
+ * アプリ稼働中の観測を per-host に記録する（#411-O1・read-only）。current を更新し baseline は不変。
  * @function recordHostObservation
  * @param {string} host
  * @param {{mountIntervalId?:?string, mountIntervalStatus?:string}} [opts]
- * @returns {?Object} current スナップショット（host 未指定なら null）
+ * @returns {?Object}
  */
 export function recordHostObservation(host, opts = {}) {
   if (!host) return null;
-  if (!monitorData.hostObservationWatermark || typeof monitorData.hostObservationWatermark !== "object") {
-    monitorData.hostObservationWatermark = {};
-  }
-  if (!monitorData.hostObservationCurrent || typeof monitorData.hostObservationCurrent !== "object") {
-    monitorData.hostObservationCurrent = {};
-  }
+  if (!monitorData.hostObservationWatermark || typeof monitorData.hostObservationWatermark !== "object") monitorData.hostObservationWatermark = {};
+  if (!monitorData.hostObservationCurrent || typeof monitorData.hostObservationCurrent !== "object") monitorData.hostObservationCurrent = {};
   const snap = _buildObservation(host, opts);
   monitorData.hostObservationCurrent[host] = snap;
   // ★ P0-1: 既存 baseline は評価前に上書きしない。無い初回のみ bootstrap（新規導入＝offline無し）。
   if (!monitorData.hostObservationWatermark[host]) {
-    monitorData.hostObservationWatermark[host] = { ...snap, committedReason: "bootstrap", persistedAt: wallNowMs() };
+    monitorData.hostObservationWatermark[host] = {
+      ...snap, committedReason: "bootstrap", persistedAt: wallNowMs(),
+      baselineObservationSequence: snap.observationSequence, lastCommittedWindowId: "bootstrap"
+    };
   }
   return snap;
 }
 
 /**
- * オフライン窓「評価後」に current を baseline へ昇格する（#411-O1。O2 が評価完了後に呼ぶ）。
+ * オフライン窓「評価後」に current を baseline へ昇格する（#411-O1/P1-2）。
+ *
+ * ★ commit 順序契約（O2 が守る）: ①window 評価 → ②candidate/report を永続化 →
+ *   ③同一 windowId で本関数を呼び baseline 昇格 → ④durable flush。baseline を先に進めない。
+ * 同一 windowId の再処理は冪等（既昇格なら no-op）＝クラッシュ後の再実行で二重昇格しない。
  *
  * @function commitObservationBaseline
  * @param {string} host
- * @param {{reason?:string}} [opts]
- * @returns {?Object} 新しい baseline（current 未設定なら null）
+ * @param {{reason?:string, windowId?:?string, candidatePersistedAt?:?number}} [opts]
+ * @returns {?Object} 新しい baseline（未昇格 or current 無しなら null）
  */
-export function commitObservationBaseline(host, { reason = "committed" } = {}) {
+export function commitObservationBaseline(host, { reason = "committed", windowId = null, candidatePersistedAt = null } = {}) {
   if (!host) return null;
   const cur = monitorData.hostObservationCurrent?.[host];
   if (!cur) return null;
-  if (!monitorData.hostObservationWatermark || typeof monitorData.hostObservationWatermark !== "object") {
-    monitorData.hostObservationWatermark = {};
-  }
-  monitorData.hostObservationWatermark[host] = { ...cur, committedReason: reason, persistedAt: wallNowMs() };
+  if (!monitorData.hostObservationWatermark || typeof monitorData.hostObservationWatermark !== "object") monitorData.hostObservationWatermark = {};
+  const prev = monitorData.hostObservationWatermark[host];
+  // 冪等: 同一 windowId で既に昇格済みなら何もしない。
+  if (windowId != null && prev && prev.lastCommittedWindowId === windowId) return prev;
+  monitorData.hostObservationWatermark[host] = {
+    ...cur,
+    committedReason: reason,
+    persistedAt: wallNowMs(),
+    baselineCommittedAt: wallNowMs(),
+    baselineObservationSequence: cur.observationSequence,
+    currentObservationSequence: cur.observationSequence,
+    candidatePersistedAt: candidatePersistedAt ?? (prev?.candidatePersistedAt ?? null),
+    lastCommittedWindowId: windowId ?? (prev?.lastCommittedWindowId ?? null)
+  };
   return monitorData.hostObservationWatermark[host];
 }
 
 /**
- * 「アプリ停止中に新たに現れた完了ジョブ」を集合差分で求める純関数（#411-O1/O2 の基盤）。
- *
- * offlineJobKeys = 現在の完了 key 集合 − baseline の seen 集合。ただし以下は
- * bounded=false（同じ窓と断定しない）:
- *   - 前回観測が無い（初回導入/移行）
- *   - printer identity 変化
- *   - 履歴 generation 交代の反証（#411-P0-2）: baseline seen の過半が現在履歴から消えた／
- *     現在履歴が baseline の半分未満へ縮小（＝履歴全置換・ID 再利用の疑い）
+ * 「アプリ停止中に新たに現れた完了ジョブ」を複合観測キーの集合差分で求める純関数（#411-O1/O2 基盤）。
  *
  * @function computeOfflineWindow
  * @param {string} host
- * @returns {{bounded:boolean, offlineJobKeys:string[], reason:string,
- *            identityChanged:boolean, generationChanged:boolean,
- *            stalenessMs:?number, watermark:?Object}}
+ * @returns {{bounded:boolean, offlineJobKeys:string[], reason:string, identityChanged:boolean,
+ *            generationChanged:boolean, stalenessMs:?number, watermark:?Object}}
  */
 export function computeOfflineWindow(host) {
   const wm = monitorData.hostObservationWatermark?.[host] || null;
   const hist = monitorData.machines?.[host]?.printStore?.history;
-  const currentKeys = completedJobKeySet(hist);
-  if (!wm || !Array.isArray(wm.seenCompletedJobKeys)) {
+  const currentObs = completedJobObservations(hist);
+  const currentGen = historyGenerationFingerprint(hist);
+
+  if (!wm || !Array.isArray(wm.seenObservationKeys)) {
     return { bounded: false, offlineJobKeys: [], reason: "no-prior-observation",
       identityChanged: false, generationChanged: false, stalenessMs: null, watermark: wm };
   }
-  const identityChanged = wm.printerIdentity !== _identity(host);
-  const seen = new Set(wm.seenCompletedJobKeys);
-  const currentSet = new Set(currentKeys);
-  // #411-P0-2: 世代交代/ID 再利用の反証。
-  const priorCount = wm.seenCompletedJobKeys.length;
-  const missing = priorCount ? wm.seenCompletedJobKeys.filter(k => !currentSet.has(k)).length : 0;
-  const mostMissing = priorCount > 0 && missing > Math.floor(priorCount * 0.5);
-  const shrunk = currentKeys.length < Math.floor((Number(wm.historyCount) || 0) * 0.5);
-  const generationChanged = identityChanged || mostMissing || shrunk;
 
+  const identityChanged = wm.printerIdentity !== _identity(host);
+  const seen = new Set(wm.seenObservationKeys);
+  const currentKeys = currentObs.map(o => o.key);
+  const currentSet = new Set(currentKeys);
+
+  // #411-P0-2: 世代反証（baseline/current fingerprint を実際に比較）。
+  const priorCount = wm.seenObservationKeys.length;
+  const missing = priorCount ? wm.seenObservationKeys.filter(k => !currentSet.has(k)).length : 0;
+  const mostMissing = priorCount > 0 && missing > Math.floor(priorCount * 0.5);
+  const shrunk = currentObs.length < Math.floor((Number(wm.retainedObservationCount) || 0) * 0.5);
+  const baseLatest = Number(wm.generation?.latestAt) || 0;
+  const curLatest = Number(currentGen.latestAt) || 0;
+  const timeRollback = baseLatest > 0 && curLatest > 0 && curLatest < baseLatest;
+
+  // #411-P0-1: 識別材料不足（id 以外の distinguishing が半数超で無い）→ 複合キーを信頼できない。
+  const undist = currentObs.filter(o => !o.hasDistinguishing).length;
+  const identityInsufficient = currentObs.length > 0 && undist > Math.floor(currentObs.length * INSUFFICIENT_RATIO);
+
+  const generationChanged = identityChanged || mostMissing || shrunk || timeRollback;
   const offlineJobKeys = currentKeys.filter(k => !seen.has(k));
+
   let reason;
   if (identityChanged) reason = "printer-identity-changed";
+  else if (timeRollback) reason = "history-time-rollback";
   else if (mostMissing) reason = "history-generation-changed";
   else if (shrunk) reason = "history-shrunk";
+  else if (identityInsufficient) reason = "job-identity-insufficient";
   else reason = "diff-ok";
 
   const persistedAt = Number(wm.persistedAt) || Number(wm.observedAtEpochMs) || 0;
   const stalenessMs = persistedAt > 0 ? Math.max(0, wallNowMs() - persistedAt) : null;
 
-  return { bounded: !generationChanged, offlineJobKeys, reason,
-    identityChanged, generationChanged, stalenessMs, watermark: wm };
+  return {
+    bounded: !generationChanged && !identityInsufficient,
+    offlineJobKeys, reason, identityChanged, generationChanged, stalenessMs, watermark: wm
+  };
 }
 
 /**
@@ -182,7 +216,7 @@ export function computeOfflineWindow(host) {
  *
  * @function buildConfidence
  * @param {"high"|"medium"|"low"|"none"} level
- * @param {string[]} [reasons] - 根拠コード（seen-job/continuous-print/no-spool-change/elapsed-time/stale-watermark 等）
+ * @param {string[]} [reasons]
  * @returns {{level:string, reasons:string[]}}
  */
 export function buildConfidence(level, reasons = []) {

--- a/3dp_lib/dashboard_offline_observation.js
+++ b/3dp_lib/dashboard_offline_observation.js
@@ -32,7 +32,7 @@
 
 import { monitorData } from "./dashboard_data.js";
 import { wallNowMs, randomEventId } from "./dashboard_time.js";
-import { completedJobObservations, historyGenerationFingerprint } from "./dashboard_history_identity.js";
+import { completedJobObservations, historyGenerationFingerprint, jobObservationIdentity } from "./dashboard_history_identity.js";
 
 /** 観測キーの保持上限（completion 時系列で最新のみ保持）。 */
 const SEEN_CAP = 5000;
@@ -126,8 +126,18 @@ function _mountFacts(snap) {
 }
 
 /** @private 現在履歴から観測スナップショットを構築（read-only）。 */
-function _buildObservation(host, { mountIntervalId = null, mountIntervalStatus = "none", activeJobId = null, printState = null } = {}) {
+function _buildObservation(host, { mountIntervalId = null, mountIntervalStatus = "none", activeJobId = null, printState = null, activePrinting = false } = {}) {
   const machine = monitorData.machines?.[host];
+  // ★ P1-B: 印刷中/一時停止のときだけ、印刷中ジョブの複合 identity（id+開始時刻+file）を保存。
+  //   idle の残存 current や ID 再利用で high 誤判定しないよう、O2 は composite 一致を要求する。
+  let activeJobObservation = null;
+  if (activePrinting) {
+    const cur = machine?.printStore?.current;
+    const oid = cur ? jobObservationIdentity(cur) : null;
+    if (oid && oid.canonicalJobId != null) {
+      activeJobObservation = { canonicalJobId: oid.canonicalJobId, startAt: oid.startAt ?? null, fileSignature: oid.fileSignature ?? null };
+    }
+  }
   const hist = machine?.printStore?.history;
   const obsAll = completedJobObservations(hist); // completion 時系列・重複排除
   const totalCompletedCount = obsAll.length;
@@ -146,6 +156,7 @@ function _buildObservation(host, { mountIntervalId = null, mountIntervalStatus =
     observationState: spoolId ? "mounted" : "unmounted",
     // ★ P0-4: 連続印刷の証拠（停止前に何を印刷中だったか）。O2 の activeJobContinued 判定に使う。
     activeJobId: activeJobId ?? (machine?.printStore?.current?.id ?? null),
+    activeJobObservation, // ★ P1-B: 印刷中のみ非null（複合 identity）
     printState: printState ?? null,
     historyRevision: machine?.printStore?._historyRev ?? null,
     // ★ P1-2: 現セッションで取得した観測か（永続復元された旧 current と区別する）。
@@ -366,10 +377,10 @@ export function computeObservationWindow(host) {
  *
  * @function commitObservationWindow
  * @param {string} host
- * @param {{windowId:string, expectedSequence:number, candidatePersistedAt:number, candidateHash?:string}} opts
+ * @param {{windowId:string, expectedSequence:number, candidatePersistedAt:number, candidateHash?:string, expectedAppSessionId?:?string}} opts
  * @returns {{ok:boolean, reason:string, baseline?:Object, idempotent?:boolean}}
  */
-export function commitObservationWindow(host, { windowId, expectedSequence, candidatePersistedAt, candidateHash = null } = {}) {
+export function commitObservationWindow(host, { windowId, expectedSequence, candidatePersistedAt, candidateHash = null, expectedAppSessionId = null } = {}) {
   if (!host) return { ok: false, reason: "host_required" };
   if (windowId == null || String(windowId) === "") return { ok: false, reason: "window_id_required" };
   if (!monitorData.hostObservationWatermark || typeof monitorData.hostObservationWatermark !== "object") monitorData.hostObservationWatermark = {};
@@ -382,6 +393,13 @@ export function commitObservationWindow(host, { windowId, expectedSequence, cand
   if (!(Number(candidatePersistedAt) > 0)) return { ok: false, reason: "candidate_not_persisted" };
   const cur = monitorData.hostObservationCurrent?.[host];
   if (!cur) return { ok: false, reason: "no_current_observation" };
+  // ★ P1-A: current は「現セッションで取得した観測」でなければ baseline へ昇格しない。
+  //   candidate 永続化直後・baseline 昇格前にクラッシュ→旧 current を復元→sequence 一致でも
+  //   fresh 観測が無いまま commit されるのを防ぐ（stale current で確定させない）。
+  if (cur.appSessionId !== _sessionId()) return { ok: false, reason: "current_observation_stale" };
+  if (expectedAppSessionId != null && cur.appSessionId !== expectedAppSessionId) {
+    return { ok: false, reason: "app_session_changed_since_evaluation" };
+  }
   if (Number(expectedSequence) !== Number(cur.observationSequence)) {
     return { ok: false, reason: "observation_changed_since_evaluation" };
   }

--- a/3dp_lib/dashboard_offline_observation.js
+++ b/3dp_lib/dashboard_offline_observation.js
@@ -1,0 +1,163 @@
+/**
+ * @fileoverview オフライン推定帰属(Option4)の観測 watermark 層 — #411-O1
+ * @file dashboard_offline_observation.js
+ * @copyright (c) pumpCurry 2026 / 5r4ce2
+ * @author pumpCurry
+ * -----------------------------------------------------------
+ * @module dashboard_offline_observation
+ *
+ * 【役割】アプリ稼働中に per-host で「見えていた状態」を記録し（観測 watermark）、
+ *   再起動後に「現在の完了履歴 − 前回観測済み集合」で “アプリ停止中に新たに現れた
+ *   完了ジョブ” を特定できるようにする（= オフライン窓）。ID の巻き戻り（プリンタ再起動/
+ *   時計補正）に強くするため、last-seen-id 比較ではなく **集合差分** を用いる。
+ *
+ * 【安全境界（レビュー4の絶対条件）】本モジュールは **read-only**。
+ *   - 参照のみ: mountHistory / hostSpoolMap / printStore.history / machine 情報。
+ *   - 書き込みは monitorData.hostObservationWatermark（本 Option4 専用の新規フィールド）のみ。
+ *   - completionObservationId / completionOpId / opId / intervalId /
+ *     pendingUnattributedUsage / mountHistoryRejectedEvents / ledgerRepairRequired /
+ *     mountHistory / usedLengthLog / remainingLengthMm には一切触れない。
+ *   - 残量は減らさない。推定帰属・confidence の実利用は O2 以降。
+ *
+ * @version 2.3.0
+ * @since   2.3.0
+ * -----------------------------------------------------------
+ */
+
+"use strict";
+
+import { monitorData } from "./dashboard_data.js";
+import { wallNowMs } from "./dashboard_time.js";
+
+/**
+ * 完了ジョブ判定（printfinish 欠落の旧データも finishTime/endtime/usagetime で完了扱い）。
+ * dashboard_spool.isCompletedHistoryEntry と同義だが、本モジュールを安全境界内で
+ * self-contained に保つため read-only 判定を内製する（依存を増やさない）。
+ *
+ * @private
+ * @param {Object} j - 履歴ジョブ
+ * @returns {boolean}
+ */
+function _isCompleted(j) {
+  if (!j) return false;
+  if (j.printfinish != null) return true;
+  return (Number(j.finishTime) > 0) || (Number(j.finishTimeSec) > 0)
+    || (Number(j.endtime) > 0) || (Number(j.usagetime) > 0);
+}
+
+/**
+ * 指定ホストの printStore.history から「完了ジョブの printId 集合」を返す（read-only）。
+ *
+ * @private
+ * @param {string} host
+ * @returns {number[]} 完了 printId の配列（数値・昇順）
+ */
+function _completedJobIds(host) {
+  const hist = monitorData.machines?.[host]?.printStore?.history;
+  if (!Array.isArray(hist)) return [];
+  const ids = [];
+  for (const j of hist) {
+    if (!_isCompleted(j)) continue;
+    const n = Number(j?.id);
+    if (Number.isFinite(n) && n > 0) ids.push(n);
+  }
+  ids.sort((a, b) => a - b);
+  return ids;
+}
+
+/**
+ * 指定ホストのプリンタ同一性シグネチャ（read-only）。取得できる範囲で構成する。
+ * boot/session ID が将来取れれば加える。現状は model/type/接続識別で近似する。
+ *
+ * @private
+ * @param {string} host
+ * @returns {string}
+ */
+function _printerIdentity(host) {
+  const sd = monitorData.machines?.[host]?.storedData || {};
+  const model = sd.model?.rawValue ?? "";
+  const type = monitorData.appSettings?.connectionTargets?.find?.(
+    t => t && (t.hostname === host))?.printerType ?? "";
+  return `${host}|${type}|${model}`;
+}
+
+/**
+ * アプリ稼働中の観測 watermark を per-host に記録/更新する（#411-O1・read-only 追加専用）。
+ *
+ * 記録内容:
+ * - seenCompletedJobIds: そのホストで観測できた完了 printId 集合（再起動後の差分の基準）。
+ * - mountedSpoolId / mountIntervalId: 現在装着スプールとその open 区間（継続推定の候補）。
+ * - printerIdentity: プリンタ同一性（再起動/交換の反証検出材料）。
+ * - observedAtEpochMs / historyCount: 監査用。
+ *
+ * @function recordHostObservation
+ * @param {string} host - ホスト名
+ * @param {Object} [opts]
+ * @param {?string} [opts.mountIntervalId] - 呼び出し側が把握している open 区間ID（任意）。
+ * @returns {?Object} 更新後の watermark（host 未指定なら null）
+ */
+export function recordHostObservation(host, { mountIntervalId = null } = {}) {
+  if (!host) return null;
+  if (!monitorData.hostObservationWatermark || typeof monitorData.hostObservationWatermark !== "object") {
+    monitorData.hostObservationWatermark = {};
+  }
+  const ids = _completedJobIds(host);
+  const wm = {
+    observedAtEpochMs: wallNowMs(),
+    mountedSpoolId: monitorData.hostSpoolMap?.[host] ?? null,
+    mountIntervalId: mountIntervalId ?? null,
+    printerIdentity: _printerIdentity(host),
+    seenCompletedJobIds: ids,
+    historyCount: ids.length
+  };
+  monitorData.hostObservationWatermark[host] = wm;
+  return wm;
+}
+
+/**
+ * 「アプリ停止中に新たに現れた完了ジョブ」を集合差分で求める純関数（#411-O1/O2 の基盤）。
+ *
+ * offlineJobIds = 現在の完了 printId 集合 − 前回観測済み集合。
+ * ID の巻き戻り（プリンタ再起動・時計補正）に強いよう last-seen-id 比較を使わない。
+ * 前回観測が無い（初回導入/移行/履歴全置換）場合は bounded=false を返す
+ * （= どれがオフライン窓のジョブか特定できない＝安全側。O2 で unbounded 分類に使う）。
+ *
+ * @function computeOfflineWindow
+ * @param {string} host - ホスト名
+ * @returns {{bounded:boolean, offlineJobIds:number[], reason:string,
+ *            identityChanged:boolean, watermark:?Object}}
+ */
+export function computeOfflineWindow(host) {
+  const wm = monitorData.hostObservationWatermark?.[host] || null;
+  const current = _completedJobIds(host);
+  if (!wm || !Array.isArray(wm.seenCompletedJobIds)) {
+    return { bounded: false, offlineJobIds: [], reason: "no-prior-observation", identityChanged: false, watermark: wm };
+  }
+  const identityChanged = wm.printerIdentity !== _printerIdentity(host);
+  const seen = new Set(wm.seenCompletedJobIds.map(Number));
+  const offlineJobIds = current.filter(id => !seen.has(id));
+  return {
+    // identity が変わっていたら「同じ窓」と断定できない＝bounded にしない（O2 で unbounded/反証へ）。
+    bounded: !identityChanged,
+    offlineJobIds,
+    reason: identityChanged ? "printer-identity-changed" : "diff-ok",
+    identityChanged,
+    watermark: wm
+  };
+}
+
+/**
+ * confidence（推定確度）オブジェクトを reasons 付きで組み立てる純関数（#411-O1 で schema 先行導入）。
+ *
+ * レビュー4提案: 「なぜその確度なのか」を後から説明できるよう、最初から理由を保持する。
+ * O2 以降の分類器がこれを埋める。remaining には一切影響しない（表示・監査用の宣言のみ）。
+ *
+ * @function buildConfidence
+ * @param {"high"|"medium"|"low"|"none"} level - 確度レベル
+ * @param {string[]} [reasons] - 根拠コード（例: "seen-job","continuous-print","no-spool-change","elapsed-time"）
+ * @returns {{level:string, reasons:string[]}}
+ */
+export function buildConfidence(level, reasons = []) {
+  const lv = ["high", "medium", "low", "none"].includes(level) ? level : "none";
+  return { level: lv, reasons: Array.isArray(reasons) ? reasons.slice() : [] };
+}

--- a/3dp_lib/dashboard_offline_observation.js
+++ b/3dp_lib/dashboard_offline_observation.js
@@ -1,29 +1,27 @@
 /**
- * @fileoverview オフライン推定帰属(Option4)の観測 watermark 層 — #411-O1
+ * @fileoverview オフライン推定帰属(Option4)の観測レイヤ — #411-O1
  * @file dashboard_offline_observation.js
  * @copyright (c) pumpCurry 2026 / 5r4ce2
  * @author pumpCurry
  * -----------------------------------------------------------
  * @module dashboard_offline_observation
  *
- * 【役割】アプリ稼働中に per-host で「見えていた状態」を記録し（観測 watermark）、
- *   再起動後に「現在の完了履歴 − 停止前観測」でオフライン新規ジョブを特定する材料にする。
+ * 【責務（レビュー#411 で固定）】O1 は「観測・保存・比較」だけを行う Observation レイヤ。
+ *   解釈・分類・candidate 生成（O2）や推定残量（O3）は含めない。公開 API は3つ:
+ *   - recordObservation(host)          … 稼働中の観測を current へ記録（baseline 非上書き）
+ *   - computeObservationWindow(host)   … baseline vs current で ObservationWindow を返す（純関数）
+ *   - commitObservationWindow(host,..) … 窓評価後に baseline 昇格（fail-closed transaction）
  *
- * 【同一実行の識別（レビュー#411 P0-1）】job id だけではプリンタ再起動で同じ id が別の
- *   物理印刷へ再利用された場合を区別できない。id ＋ 開始/完了時刻 ＋ ファイル同一性の
- *   複合キー（jobObservationKey）を集合差分に使う。識別材料が不足するときは bounded=false。
+ * 【重要な安全性（レビュー指摘）】
+ *   - baseline は「最新 SEEN_CAP 件」に切詰めるため retainedRange（時系列境界）を保存し、
+ *     比較は境界内/以降のみ。境界より古い履歴を offline 扱いしない（5000件問題の根治）。
+ *   - 同一実行は jobObservationIdentity（id＋開始/完了時刻＋file）の複合キーで識別。
+ *     識別材料不足/再利用IDは offline **候補単位**で判定し bounded=false／unresolved へ。
+ *   - commit は fail-closed（windowId/candidatePersistedAt/expectedSequence 必須・不一致は拒否）。
  *
- * 【世代反証（P0-2）】printer identity 変化に加え、履歴 generation fingerprint（completion 時系列
- *   ベース）を baseline/current で実際に比較し、latest completion 巻き戻り・世代交代・大幅縮小を検出する。
- *
- * 【ライフサイクル（P0-1）】baseline(hostObservationWatermark)と current(hostObservationCurrent)を
- *   別スロット化。record は current のみ更新（baseline 非上書き。未設定初回のみ bootstrap）。
- *   commitObservationBaseline は「窓評価後」に windowId 付きで昇格する（同一 windowId は冪等）。
- *
- * 【安全境界（レビュー4の絶対条件）】read-only。書き込みは hostObservationWatermark /
- *   hostObservationCurrent のみ。completionObservationId/completionOpId/opId/intervalId/
- *   pendingUnattributedUsage/mountHistoryRejectedEvents/ledgerRepairRequired/mountHistory/
- *   usedLengthLog/remainingLengthMm には一切触れない。残量は減らさない（O3 以降・確認後）。
+ * 【read-only 境界】書き込みは hostObservationWatermark / hostObservationCurrent のみ。
+ *   安全基盤（completionObservationId/pendingUnattributedUsage/mountHistory/intervalId/
+ *   usedLengthLog/remainingLengthMm 等）には一切触れない。残量は減らさない。
  *
  * @version 2.3.0
  * @since   2.3.0
@@ -36,18 +34,10 @@ import { monitorData } from "./dashboard_data.js";
 import { wallNowMs } from "./dashboard_time.js";
 import { completedJobObservations, historyGenerationFingerprint } from "./dashboard_history_identity.js";
 
-/** 観測キーの保持上限（#411-P1-4。completion 時系列で最新のみ保持）。 */
+/** 観測キーの保持上限（completion 時系列で最新のみ保持）。 */
 const SEEN_CAP = 5000;
-/** 「識別材料不足」とみなす割合しきい（未識別が半数超なら bounded=false）。 */
-const INSUFFICIENT_RATIO = 0.5;
 
-/** per-host session observation counter（メモリ。再起動後は baseline/current から継続採番）。 */
-const _sessionObsSeq = new Map();
-
-/**
- * プリンタ同一性シグネチャ（read-only・取得できる範囲）。
- * @private @param {string} host @returns {string}
- */
+/** @private */
 function _identity(host) {
   const sd = monitorData.machines?.[host]?.storedData || {};
   const model = sd.model?.rawValue ?? "";
@@ -55,165 +45,207 @@ function _identity(host) {
   return `${host}|${type}|${model}`;
 }
 
-/**
- * 観測 sequence を継続採番する（#411-P1-3。再起動で 1 へ戻さない）。
- * @private @param {string} host @returns {number}
- */
+/** @private 継続採番（再起動で 1 へ戻さない）。current/baseline から常に単調増加。 */
 function _nextSeq(host) {
   const base = Number(monitorData.hostObservationWatermark?.[host]?.observationSequence) || 0;
   const cur = Number(monitorData.hostObservationCurrent?.[host]?.observationSequence) || 0;
-  const mem = _sessionObsSeq.get(host) || 0;
-  const next = Math.max(base, cur, mem) + 1;
-  _sessionObsSeq.set(host, next);
-  return next;
+  return Math.max(base, cur) + 1;
 }
 
-/**
- * 現在の観測スナップショットを構築する（read-only）。
- * @private
- */
-function _buildObservation(host, { mountIntervalId = null, mountIntervalStatus = "unknown" } = {}) {
+/** @private 現在履歴から観測スナップショットを構築（read-only）。 */
+function _buildObservation(host, { mountIntervalId = null, mountIntervalStatus = "none" } = {}) {
   const hist = monitorData.machines?.[host]?.printStore?.history;
-  const obsAll = completedJobObservations(hist);          // completion 時系列・重複排除済み
+  const obsAll = completedJobObservations(hist); // completion 時系列・重複排除
   const totalCompletedCount = obsAll.length;
-  // ★ P1-4: 文字列順ではなく completion 時系列の「最新 SEEN_CAP 件」を保持。
   const retained = obsAll.length > SEEN_CAP ? obsAll.slice(obsAll.length - SEEN_CAP) : obsAll;
+  const truncated = totalCompletedCount > retained.length;
   const spoolId = monitorData.hostSpoolMap?.[host] ?? null;
+  const first = retained[0] || null;
+  const last = retained[retained.length - 1] || null;
   return {
     observedAtEpochMs: wallNowMs(),
     persistedAt: null,
     observationSequence: _nextSeq(host),
     mountedSpoolId: spoolId,
     mountIntervalId: mountIntervalId ?? null,
-    mountIntervalStatus,                                   // ok/none/ambiguous/corrupt/unknown
+    mountIntervalStatus,
     observationState: spoolId ? "mounted" : "unmounted",
     printerIdentity: _identity(host),
-    generation: historyGenerationFingerprint(hist),       // 時系列ベース fingerprint
-    seenObservationKeys: retained.map(o => o.key),         // 複合キー（diff 基準）
-    undistinguishedCount: retained.filter(o => !o.hasDistinguishing).length,
+    generation: historyGenerationFingerprint(hist),
+    seenObservationKeys: retained.map(o => o.key),
+    // ★ retainedRange: 比較を境界内に限定するための時系列境界（5000件問題対策）。
+    retainedRange: {
+      firstKey: first ? first.key : null,
+      lastKey: last ? last.key : null,
+      firstCompletedAt: first ? (first.finishAt || 0) : 0,
+      lastCompletedAt: last ? (last.finishAt || 0) : 0,
+      truncated
+    },
     retainedObservationCount: retained.length,
     totalCompletedCount,
-    truncated: totalCompletedCount > retained.length
+    truncated
   };
 }
 
 /**
- * アプリ稼働中の観測を per-host に記録する（#411-O1・read-only）。current を更新し baseline は不変。
- * @function recordHostObservation
+ * 稼働中の観測を current へ記録する（baseline 非上書き。未設定初回のみ bootstrap）。
+ * @function recordObservation
  * @param {string} host
  * @param {{mountIntervalId?:?string, mountIntervalStatus?:string}} [opts]
- * @returns {?Object}
+ * @returns {?Object} current スナップショット
  */
-export function recordHostObservation(host, opts = {}) {
+export function recordObservation(host, opts = {}) {
   if (!host) return null;
   if (!monitorData.hostObservationWatermark || typeof monitorData.hostObservationWatermark !== "object") monitorData.hostObservationWatermark = {};
   if (!monitorData.hostObservationCurrent || typeof monitorData.hostObservationCurrent !== "object") monitorData.hostObservationCurrent = {};
   const snap = _buildObservation(host, opts);
   monitorData.hostObservationCurrent[host] = snap;
-  // ★ P0-1: 既存 baseline は評価前に上書きしない。無い初回のみ bootstrap（新規導入＝offline無し）。
   if (!monitorData.hostObservationWatermark[host]) {
     monitorData.hostObservationWatermark[host] = {
-      ...snap, committedReason: "bootstrap", persistedAt: wallNowMs(),
-      baselineObservationSequence: snap.observationSequence, lastCommittedWindowId: "bootstrap"
+      ...snap, committedReason: "bootstrap", persistedAt: wallNowMs(), lastCommittedWindowId: "bootstrap"
     };
   }
   return snap;
 }
 
 /**
- * オフライン窓「評価後」に current を baseline へ昇格する（#411-O1/P1-2）。
+ * オフライン観測窓を計算する（純関数。O2 はこの ObservationWindow を分類する）。
  *
- * ★ commit 順序契約（O2 が守る）: ①window 評価 → ②candidate/report を永続化 →
- *   ③同一 windowId で本関数を呼び baseline 昇格 → ④durable flush。baseline を先に進めない。
- * 同一 windowId の再処理は冪等（既昇格なら no-op）＝クラッシュ後の再実行で二重昇格しない。
- *
- * @function commitObservationBaseline
+ * @function computeObservationWindow
  * @param {string} host
- * @param {{reason?:string, windowId?:?string, candidatePersistedAt?:?number}} [opts]
- * @returns {?Object} 新しい baseline（未昇格 or current 無しなら null）
+ * @returns {{windowId:string, bounded:boolean, truncated:boolean, generationChanged:boolean,
+ *   reason:string, offlineObservationKeys:string[], unresolvedJobIds:string[],
+ *   baselineFingerprint:?Object, currentFingerprint:Object,
+ *   baselineSequence:number, currentSequence:number, stalenessMs:?number, watermark:?Object}}
  */
-export function commitObservationBaseline(host, { reason = "committed", windowId = null, candidatePersistedAt = null } = {}) {
-  if (!host) return null;
-  const cur = monitorData.hostObservationCurrent?.[host];
-  if (!cur) return null;
-  if (!monitorData.hostObservationWatermark || typeof monitorData.hostObservationWatermark !== "object") monitorData.hostObservationWatermark = {};
-  const prev = monitorData.hostObservationWatermark[host];
-  // 冪等: 同一 windowId で既に昇格済みなら何もしない。
-  if (windowId != null && prev && prev.lastCommittedWindowId === windowId) return prev;
-  monitorData.hostObservationWatermark[host] = {
-    ...cur,
-    committedReason: reason,
-    persistedAt: wallNowMs(),
-    baselineCommittedAt: wallNowMs(),
-    baselineObservationSequence: cur.observationSequence,
-    currentObservationSequence: cur.observationSequence,
-    candidatePersistedAt: candidatePersistedAt ?? (prev?.candidatePersistedAt ?? null),
-    lastCommittedWindowId: windowId ?? (prev?.lastCommittedWindowId ?? null)
-  };
-  return monitorData.hostObservationWatermark[host];
-}
-
-/**
- * 「アプリ停止中に新たに現れた完了ジョブ」を複合観測キーの集合差分で求める純関数（#411-O1/O2 基盤）。
- *
- * @function computeOfflineWindow
- * @param {string} host
- * @returns {{bounded:boolean, offlineJobKeys:string[], reason:string, identityChanged:boolean,
- *            generationChanged:boolean, stalenessMs:?number, watermark:?Object}}
- */
-export function computeOfflineWindow(host) {
+export function computeObservationWindow(host) {
   const wm = monitorData.hostObservationWatermark?.[host] || null;
+  const curSnap = monitorData.hostObservationCurrent?.[host] || null;
   const hist = monitorData.machines?.[host]?.printStore?.history;
   const currentObs = completedJobObservations(hist);
-  const currentGen = historyGenerationFingerprint(hist);
+  const currentFingerprint = historyGenerationFingerprint(hist);
+  const baselineSequence = Number(wm?.observationSequence) || 0;
+  const currentSequence = Number(curSnap?.observationSequence) || 0;
+  const windowId = `${host}|b${baselineSequence}|c${currentSequence}`;
+
+  const base = {
+    windowId, truncated: !!wm?.retainedRange?.truncated,
+    baselineFingerprint: wm?.generation || null, currentFingerprint,
+    baselineSequence, currentSequence, watermark: wm
+  };
 
   if (!wm || !Array.isArray(wm.seenObservationKeys)) {
-    return { bounded: false, offlineJobKeys: [], reason: "no-prior-observation",
-      identityChanged: false, generationChanged: false, stalenessMs: null, watermark: wm };
+    return { ...base, bounded: false, generationChanged: false, reason: "no-prior-observation",
+      offlineObservationKeys: [], unresolvedJobIds: [], stalenessMs: null };
   }
 
   const identityChanged = wm.printerIdentity !== _identity(host);
   const seen = new Set(wm.seenObservationKeys);
-  const currentKeys = currentObs.map(o => o.key);
-  const currentSet = new Set(currentKeys);
+  const baselineIds = new Set(wm.seenObservationKeys.map(_idOf));
+  const firstAt = Number(wm.retainedRange?.firstCompletedAt) || 0;
 
-  // #411-P0-2: 世代反証（baseline/current fingerprint を実際に比較）。
+  // ★ P0-2(世代反証): baseline/current fingerprint を実比較。current キー集合は一度だけ構築（O(n)）。
+  const currentKeySet = new Set(currentObs.map(o => o.key));
   const priorCount = wm.seenObservationKeys.length;
-  const missing = priorCount ? wm.seenObservationKeys.filter(k => !currentSet.has(k)).length : 0;
+  let missing = 0;
+  if (priorCount) for (const k of wm.seenObservationKeys) if (!currentKeySet.has(k)) missing++;
   const mostMissing = priorCount > 0 && missing > Math.floor(priorCount * 0.5);
   const shrunk = currentObs.length < Math.floor((Number(wm.retainedObservationCount) || 0) * 0.5);
-  const baseLatest = Number(wm.generation?.latestAt) || 0;
-  const curLatest = Number(currentGen.latestAt) || 0;
+  const baseLatest = Number(wm.generation?.latestCompletedAt) || 0;
+  const curLatest = Number(currentFingerprint.latestCompletedAt) || 0;
   const timeRollback = baseLatest > 0 && curLatest > 0 && curLatest < baseLatest;
-
-  // #411-P0-1: 識別材料不足（id 以外の distinguishing が半数超で無い）→ 複合キーを信頼できない。
-  const undist = currentObs.filter(o => !o.hasDistinguishing).length;
-  const identityInsufficient = currentObs.length > 0 && undist > Math.floor(currentObs.length * INSUFFICIENT_RATIO);
-
   const generationChanged = identityChanged || mostMissing || shrunk || timeRollback;
-  const offlineJobKeys = currentKeys.filter(k => !seen.has(k));
+
+  // ★ P0-1(retainedRange 境界): baseline に無く、かつ retained 境界「以降」の完了のみ offline 候補。
+  //   境界より古い履歴（切詰めで捨てた分）は offline にしない。finishAt 不明は候補単位で unresolved。
+  const offlineObservationKeys = [];
+  const unresolvedJobIds = [];
+  let hasIdReuse = false, hasInsufficient = false;
+  for (const o of currentObs) {
+    if (seen.has(o.key)) continue;                 // 既観測
+    if (o.finishAt && firstAt && o.finishAt < firstAt) continue; // 境界より古い＝offline 対象外
+    const idReused = baselineIds.has(o.canonicalJobId);
+    // ★ P0-2(候補単位判定): 識別材料が無い候補は unresolved。canonicalJobId が baseline と
+    //   衝突（再利用）で検証できない場合と、単なる識別不足を分けて理由を立てる。
+    if (!o.hasDistinguishing) {
+      if (idReused) hasIdReuse = true; else hasInsufficient = true;
+      unresolvedJobIds.push(o.canonicalJobId);
+      continue;
+    }
+    if (idReused && o.finishAt === 0) {            // 再利用IDで時刻検証もできない
+      hasIdReuse = true;
+      unresolvedJobIds.push(o.canonicalJobId);
+      continue;
+    }
+    offlineObservationKeys.push(o.key);            // 識別十分＝offline 確定候補（再利用IDでも別実行として保持）
+  }
 
   let reason;
   if (identityChanged) reason = "printer-identity-changed";
   else if (timeRollback) reason = "history-time-rollback";
   else if (mostMissing) reason = "history-generation-changed";
   else if (shrunk) reason = "history-shrunk";
-  else if (identityInsufficient) reason = "job-identity-insufficient";
+  else if (hasIdReuse) reason = "reused-job-id-unverifiable";
+  else if (hasInsufficient) reason = "job-identity-insufficient";
   else reason = "diff-ok";
 
   const persistedAt = Number(wm.persistedAt) || Number(wm.observedAtEpochMs) || 0;
   const stalenessMs = persistedAt > 0 ? Math.max(0, wallNowMs() - persistedAt) : null;
 
   return {
-    bounded: !generationChanged && !identityInsufficient,
-    offlineJobKeys, reason, identityChanged, generationChanged, stalenessMs, watermark: wm
+    ...base,
+    bounded: !generationChanged && unresolvedJobIds.length === 0,
+    generationChanged, reason, offlineObservationKeys, unresolvedJobIds, stalenessMs
   };
 }
 
+/** @private 複合キー(JSON tuple)から canonicalJobId を取り出す。 */
+function _idOf(key) {
+  try { const a = JSON.parse(key); return Array.isArray(a) ? String(a[0]) : ""; } catch { return ""; }
+}
+
 /**
- * confidence（推定確度）を reasons 付きで組み立てる純関数（#411 で schema 先行導入）。
- * remaining には一切影響しない（表示・監査用の宣言のみ）。
+ * 観測窓評価後に baseline を昇格する（fail-closed transaction。#411-P0-3）。
  *
+ * 必須: windowId（非空）・candidatePersistedAt・expectedSequence（評価時の currentSequence）。
+ * 不一致は昇格せず理由を返す。同一 windowId は冪等（二重昇格しない）。
+ *
+ * @function commitObservationWindow
+ * @param {string} host
+ * @param {{windowId:string, expectedSequence:number, candidatePersistedAt:number, candidateHash?:string}} opts
+ * @returns {{ok:boolean, reason:string, baseline?:Object, idempotent?:boolean}}
+ */
+export function commitObservationWindow(host, { windowId, expectedSequence, candidatePersistedAt, candidateHash = null } = {}) {
+  if (!host) return { ok: false, reason: "host_required" };
+  if (windowId == null || String(windowId) === "") return { ok: false, reason: "window_id_required" };
+  if (!monitorData.hostObservationWatermark || typeof monitorData.hostObservationWatermark !== "object") monitorData.hostObservationWatermark = {};
+  const prev = monitorData.hostObservationWatermark[host];
+  // ★ 冪等: 既に同一 windowId を昇格済みなら、以後の観測変化に関わらず no-op（二重適用防止）。
+  if (prev && prev.lastCommittedWindowId === windowId) {
+    return { ok: true, reason: "idempotent", baseline: prev, idempotent: true };
+  }
+  // ★ fail-closed 契約: 新規窓は candidate 永続証跡＋評価時 sequence 一致が必須。
+  if (!(Number(candidatePersistedAt) > 0)) return { ok: false, reason: "candidate_not_persisted" };
+  const cur = monitorData.hostObservationCurrent?.[host];
+  if (!cur) return { ok: false, reason: "no_current_observation" };
+  if (Number(expectedSequence) !== Number(cur.observationSequence)) {
+    return { ok: false, reason: "observation_changed_since_evaluation" };
+  }
+  const baseline = {
+    ...cur,
+    committedReason: "window-evaluated",
+    persistedAt: wallNowMs(),
+    baselineCommittedAt: wallNowMs(),
+    candidatePersistedAt: Number(candidatePersistedAt),
+    candidateHash,
+    lastCommittedWindowId: windowId
+  };
+  monitorData.hostObservationWatermark[host] = baseline;
+  return { ok: true, reason: "committed", baseline };
+}
+
+/**
+ * confidence（推定確度）を reasons 付きで組み立てる純関数。remaining には影響しない。
  * @function buildConfidence
  * @param {"high"|"medium"|"low"|"none"} level
  * @param {string[]} [reasons]

--- a/3dp_lib/dashboard_offline_observation.js
+++ b/3dp_lib/dashboard_offline_observation.js
@@ -23,9 +23,9 @@
  *   安全基盤（completionObservationId/pendingUnattributedUsage/mountHistory/intervalId/
  *   usedLengthLog/remainingLengthMm 等）には一切触れない。残量は減らさない。
  *
- * @version 1.390.1246 (PR #411)
+ * @version 1.390.1247 (PR #411)
  * @since   2.3.0
- * @lastModified 2026-07-23 09:57:05
+ * @lastModified 2026-07-23 15:21:14
  * -----------------------------------------------------------
  */
 
@@ -294,7 +294,11 @@ export function computeOfflineWindow(previous, current, opts = {}) {
   const seen = new Set(previous.seenObservationKeys);
   const baselineIds = new Set(previous.seenObservationKeys.map(_idOf));
   const firstAt = Number(previous.retainedRange?.firstCompletedAt) || 0;
+  const lastAt = Number(previous.retainedRange?.lastCompletedAt) || 0;
   const truncatedBaseline = !!previous.retainedRange?.truncated;
+  const previousTotalCompleted = Number(previous.totalCompletedCount) || 0;
+  const currentTotalCompleted = Number(current.totalCompletedCount) || 0;
+  const completedCountGrew = previousTotalCompleted > 0 && currentTotalCompleted > previousTotalCompleted;
 
   // ★ P0-2(世代反証): baseline/current を実比較。current キー集合は一度だけ構築（O(n)）。
   const currentKeySet = new Set(currentObs.map(o => o.key));
@@ -315,11 +319,11 @@ export function computeOfflineWindow(previous, current, opts = {}) {
   for (const o of currentObs) {
     if (seen.has(o.key)) continue;                 // 既観測
     if (o.finishAt && firstAt && o.finishAt < firstAt) continue; // 境界より古い＝offline 対象外
-    // ★ codex-P1: baseline が truncated のとき、retained 時系列境界で「窓の内側」だと確認できない
-    //   （候補の finishAt 不明 or 境界時刻 firstAt 不明）ものは offline 確定しない。切詰めで落ちた
-    //   古い履歴や、履歴再取得で finishTime/複合キーが変わった古い完了を誤って offline 化しないための
-    //   fail-closed（unresolved 扱い＝bounded=false）。
-    if (truncatedBaseline && !(o.finishAt > 0 && firstAt > 0)) {
+    // ★ codex-P1: baseline が truncated のときは、retained 末尾より後に増えた完了だけを
+    //   offline 候補にする。firstAt 以降という条件だけでは、切詰めで落ちた古い履歴へ
+    //   後から finishTime が補完され、複合キーが変わった場合に再流入し得るため、
+    //   「履歴総数が増えた」かつ「baseline の lastCompletedAt より後」を必須にする。
+    if (truncatedBaseline && !(o.finishAt > 0 && lastAt > 0 && o.finishAt > lastAt && completedCountGrew)) {
       hasTruncatedUnverifiable = true;
       unresolvedJobIds.push(o.canonicalJobId);
       continue;

--- a/3dp_lib/dashboard_offline_observation.js
+++ b/3dp_lib/dashboard_offline_observation.js
@@ -52,6 +52,22 @@ function _nextSeq(host) {
   return Math.max(base, cur) + 1;
 }
 
+/**
+ * @private 観測スナップショットから装着「事実」だけを投影する（解釈しない）。
+ * O2 が baseline/current の装着状態を比較できるよう ObservationWindow へ載せる。
+ * @param {?Object} snap 観測スナップショット（watermark or current）
+ * @returns {{spoolId:?string, intervalId:?string, intervalStatus:string, observationState:string}}
+ */
+function _mountFacts(snap) {
+  if (!snap) return { spoolId: null, intervalId: null, intervalStatus: "unknown", observationState: "unknown" };
+  return {
+    spoolId: snap.mountedSpoolId ?? null,
+    intervalId: snap.mountIntervalId ?? null,
+    intervalStatus: snap.mountIntervalStatus || "unknown",
+    observationState: snap.observationState || (snap.mountedSpoolId != null ? "mounted" : "unmounted")
+  };
+}
+
 /** @private 現在履歴から観測スナップショットを構築（read-only）。 */
 function _buildObservation(host, { mountIntervalId = null, mountIntervalStatus = "none" } = {}) {
   const hist = monitorData.machines?.[host]?.printStore?.history;
@@ -113,8 +129,9 @@ export function recordObservation(host, opts = {}) {
  *
  * @function computeObservationWindow
  * @param {string} host
- * @returns {{windowId:string, bounded:boolean, truncated:boolean, generationChanged:boolean,
- *   reason:string, offlineObservationKeys:string[], unresolvedJobIds:string[],
+ * @returns {{windowId:string, windowKind:string, bounded:boolean, truncated:boolean,
+ *   generationChanged:boolean, reason:string, offlineObservationKeys:string[], unresolvedJobIds:string[],
+ *   hasCurrentObservation:boolean, baselineMount:Object, currentMount:Object,
  *   baselineFingerprint:?Object, currentFingerprint:Object,
  *   baselineSequence:number, currentSequence:number, stalenessMs:?number, watermark:?Object}}
  */
@@ -128,15 +145,28 @@ export function computeObservationWindow(host) {
   const currentSequence = Number(curSnap?.observationSequence) || 0;
   const windowId = `${host}|b${baselineSequence}|c${currentSequence}`;
 
+  // ★ O2-P0: 解釈しない観測事実を ObservationWindow へ載せる（O1 責務は不変・戻り値拡張のみ）。
+  //   O2 は baseline/current の装着一致を candidate 必須条件に使う。
+  const hasCurrentObservation = !!curSnap;
+  const baselineMount = _mountFacts(wm);
+  const currentMount = _mountFacts(curSnap);
   const base = {
     windowId, truncated: !!wm?.retainedRange?.truncated,
     baselineFingerprint: wm?.generation || null, currentFingerprint,
-    baselineSequence, currentSequence, watermark: wm
+    baselineSequence, currentSequence, watermark: wm,
+    hasCurrentObservation, baselineMount, currentMount
   };
 
   if (!wm || !Array.isArray(wm.seenObservationKeys)) {
-    return { ...base, bounded: false, generationChanged: false, reason: "no-prior-observation",
-      offlineObservationKeys: [], unresolvedJobIds: [], stalenessMs: null };
+    return { ...base, windowKind: "no-prior", bounded: false, generationChanged: false,
+      reason: "no-prior-observation", offlineObservationKeys: [], unresolvedJobIds: [], stalenessMs: null };
+  }
+
+  // ★ O2-P0-2: baseline はあるが復帰後の current 観測がまだ無い＝装着状態未確認。
+  //   O2 が装着一致を検証できないため、この段階では窓を不完全として扱う。
+  if (!hasCurrentObservation) {
+    return { ...base, windowKind: "incomplete", bounded: false, generationChanged: false,
+      reason: "current-observation-missing", offlineObservationKeys: [], unresolvedJobIds: [], stalenessMs: null };
   }
 
   const identityChanged = wm.printerIdentity !== _identity(host);
@@ -191,10 +221,17 @@ export function computeObservationWindow(host) {
 
   const persistedAt = Number(wm.persistedAt) || Number(wm.observedAtEpochMs) || 0;
   const stalenessMs = persistedAt > 0 ? Math.max(0, wallNowMs() - persistedAt) : null;
+  const bounded = !generationChanged && unresolvedJobIds.length === 0;
+
+  // ★ O2-P1-1: 構造化した windowKind を提供し、O2 が reason 文字列に依存しないようにする。
+  //   reason は説明表示用に残す。
+  let windowKind;
+  if (hasIdReuse || hasInsufficient) windowKind = "insufficient";
+  else if (!bounded) windowKind = "unbounded";
+  else windowKind = "bounded";
 
   return {
-    ...base,
-    bounded: !generationChanged && unresolvedJobIds.length === 0,
+    ...base, windowKind, bounded,
     generationChanged, reason, offlineObservationKeys, unresolvedJobIds, stalenessMs
   };
 }

--- a/3dp_lib/dashboard_offline_projection.js
+++ b/3dp_lib/dashboard_offline_projection.js
@@ -1,0 +1,311 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用オフライン継続推定残量 projection モジュール
+ * @file dashboard_offline_projection.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * @author pumpCurry
+ * -----------------------------------------------------------
+ * @module dashboard_offline_projection
+ *
+ * 【機能内容サマリ】
+ * - #411-O3 の純粋 projection として、O2 の continuity candidate を確定残量へ直接混ぜず、
+ *   未帰属のオフライン完了分だけを推定 debit として集計する。
+ * - 確定済み履歴と observation key を照合し、同一スプール確定済み・別スプール確定済み・
+ *   履歴消失・未帰属を分離することで、二重減算と誤帰属を防ぐ。
+ * - spool.remainingLengthMm、mountHistory、usedLengthLog、filamentInfo などの確定台帳には
+ *   一切書き込まない。UI・ライブ残量・不可逆操作への接続は O4/O5 以降で行う。
+ *
+ * 【公開関数一覧】
+ * - {@link estimateHistoryEntryUsedMm}：履歴行から projection 用の消費量を抽出する。
+ * - {@link evaluateCandidateObservationKey}：candidate の observation key 1件を履歴へ照合する。
+ * - {@link buildInferredContinuityProjection}：candidate 全体から推定残量 projection を作る。
+ *
+ * @version 1.390.1244 (PR #411)
+ * @since   1.390.1244 (PR #411)
+ * @lastModified  2026-07-19 18:21:09
+ * -----------------------------------------------------------
+ * @todo
+ * - O4 で candidate 永続化・状態遷移・親子同期へ接続する。
+ * - O5 で確認・否認・再割当て UI と不可逆操作ゲートへ接続する。
+ */
+
+"use strict";
+
+import { jobObservationIdentity } from "./dashboard_history_identity.js";
+
+/** O2 continuity candidate の分類ラベル。classifier import による dashboard_data 依存を避けるため文字列を局所保持する。 */
+const CONTINUITY_CANDIDATE = "continuity-candidate";
+
+/**
+ * projection で扱う observation key 1件の照合状態。
+ *
+ * @typedef {Object} CandidateDebitEvaluation
+ * @property {string} observationKey - O1/O2 が生成した完了ジョブの複合 observation key。
+ * @property {string} status - 照合結果。`inferred-debit` / `confirmed-same-spool` /
+ *   `confirmed-other-spool` / `unresolved` / `no-usage` のいずれか。
+ * @property {number} usedMm - この key に紐づく消費量 mm。推定 debit 対象外でも監査用に保持する。
+ * @property {?string} candidateSpoolId - O2 が推定候補として提示したスプール ID。
+ * @property {?Array<string>} confirmedSpoolIds - 履歴上で既に確定帰属しているスプール ID 一覧。
+ * @property {?Object} entry - 照合した履歴行。見つからない場合は null。
+ * @property {string} reason - status の理由を UI/監査へ渡すための短い識別子。
+ */
+
+/**
+ * projection 全体の戻り値。
+ *
+ * @typedef {Object} InferredContinuityProjection
+ * @property {?string} host - 対象ホスト名。
+ * @property {?string} spoolId - projection 対象スプール ID。
+ * @property {?string} windowId - O1/O2 の ObservationWindow ID。
+ * @property {?string} classification - O2 分類ラベル。
+ * @property {number} confirmedRemainingMm - 確定台帳だけから見た残量 mm。
+ * @property {number} inferredContinuityUsedMm - 未帰属かつ継続候補として推定 debit する消費量 mm。
+ * @property {number} projectedRemainingMm - `confirmedRemainingMm - inferredContinuityUsedMm` の表示用推定残量 mm。
+ * @property {Array<CandidateDebitEvaluation>} candidateDebits - candidate key ごとの照合結果。
+ * @property {Array<CandidateDebitEvaluation>} contradictions - 別スプール確定済みなど、推定と矛盾する key。
+ * @property {Array<CandidateDebitEvaluation>} unresolved - 履歴消失・消費量不明など projection へ入れられない key。
+ * @property {boolean} readOnly - この関数群が確定台帳へ書き込まないことを示す固定フラグ。
+ */
+
+/**
+ * 数値を非負の mm 値へ正規化する。
+ *
+ * 【詳細説明】
+ * - 履歴や spool に文字列値が混ざっても projection の合計値が NaN へ崩れないようにする。
+ * - 負値や非数は「消費なし」として 0 に丸める。確定台帳の値自体は変更しない。
+ *
+ * @private
+ * @function _nonNegativeMm
+ * @param {*} value - mm として解釈したい任意値。
+ * @returns {number} 0 以上の有限数。
+ */
+function _nonNegativeMm(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/**
+ * observation key から lookup 用 Map を構築する。
+ *
+ * 【詳細説明】
+ * - O1/O2 と同じ `jobObservationIdentity()` を使い、ID だけでなく開始/完了時刻・ファイル署名を
+ *   含む複合 key で履歴行を検索できるようにする。
+ * - 同一 key が複数ある場合は、最初に見つけた履歴行を保持する。重複がある時点で履歴側が
+ *   既に曖昧なので、projection は台帳を書き換えず監査情報だけを返す。
+ *
+ * @private
+ * @function _historyByObservationKey
+ * @param {Array<Object>} history - printStore.history 相当の履歴配列。
+ * @returns {Map<string,Object>} observation key から履歴行への Map。
+ */
+function _historyByObservationKey(history) {
+  const map = new Map();
+  if (!Array.isArray(history)) return map;
+  for (const entry of history) {
+    const identity = jobObservationIdentity(entry);
+    if (!identity || !identity.key || map.has(identity.key)) continue;
+    map.set(identity.key, entry);
+  }
+  return map;
+}
+
+/**
+ * 履歴行の確定帰属スプール ID 一覧を返す。
+ *
+ * 【詳細説明】
+ * - `filamentInfo[].spoolId` を最優先にし、配列にスプール情報が無い場合だけ `filamentId` を見る。
+ * - `filamentId="none"` や空文字は確定スプールではないため除外する。
+ * - 重複は Set で畳み、projection 側の二重判定を防ぐ。
+ *
+ * @private
+ * @function _confirmedSpoolIds
+ * @param {Object} entry - 履歴行。
+ * @returns {Array<string>} 確定帰属済みのスプール ID 一覧。
+ */
+function _confirmedSpoolIds(entry) {
+  const ids = new Set();
+  const info = Array.isArray(entry?.filamentInfo) ? entry.filamentInfo : [];
+  for (const item of info) {
+    const id = item?.spoolId == null ? "" : String(item.spoolId).trim();
+    if (id && id !== "none") ids.add(id);
+  }
+  if (ids.size === 0) {
+    const id = entry?.filamentId == null ? "" : String(entry.filamentId).trim();
+    if (id && id !== "none") ids.add(id);
+  }
+  return [...ids];
+}
+
+/**
+ * 履歴行から projection 用の消費量を抽出する。
+ *
+ * 【詳細説明】
+ * - `materialUsedMm` が正であればジョブ総消費として採用する。
+ * - `materialUsedMm` が無い旧データでは `filamentInfo[].usedMm` の合計を fallback にする。
+ * - ここで得た値は「推定 debit の素材量」であり、確定台帳へは書き戻さない。
+ *
+ * @function estimateHistoryEntryUsedMm
+ * @param {Object} entry - printStore.history の履歴行。
+ * @returns {number} projection に使える消費量 mm。判定不能や 0 以下は 0。
+ * @example
+ * const usedMm = estimateHistoryEntryUsedMm({ materialUsedMm: 1200 });
+ */
+export function estimateHistoryEntryUsedMm(entry) {
+  const materialUsed = _nonNegativeMm(entry?.materialUsedMm);
+  if (materialUsed > 0) return materialUsed;
+  const info = Array.isArray(entry?.filamentInfo) ? entry.filamentInfo : [];
+  let total = 0;
+  for (const item of info) total += _nonNegativeMm(item?.usedMm);
+  return total;
+}
+
+/**
+ * candidate の observation key 1件を履歴へ照合し、推定 debit 対象か分類する。
+ *
+ * 【詳細説明】
+ * - 履歴に存在しない key は `unresolved` とし、推定残量へ入れない。履歴切詰めや削除を
+ *   「使ったはず」と決め打ちしないため。
+ * - 候補スプールへ既に確定帰属済みなら `confirmed-same-spool` とし、二重減算を防ぐ。
+ * - 別スプールへ確定帰属済みなら `confirmed-other-spool` とし、矛盾として返す。
+ * - 未帰属で消費量がある場合だけ `inferred-debit` として projectedRemainingMm に反映する。
+ *
+ * @function evaluateCandidateObservationKey
+ * @param {string} observationKey - O2 candidate の observation key。
+ * @param {?Object} entry - observation key に一致した履歴行。見つからない場合は null。
+ * @param {string} candidateSpoolId - O2 が提示した候補スプール ID。
+ * @returns {CandidateDebitEvaluation} key 1件の projection 判定。
+ * @example
+ * const evaluation = evaluateCandidateObservationKey(key, historyEntry, "spool-1");
+ */
+export function evaluateCandidateObservationKey(observationKey, entry, candidateSpoolId) {
+  const candidateId = candidateSpoolId == null ? null : String(candidateSpoolId);
+  if (!entry) {
+    return {
+      observationKey,
+      status: "unresolved",
+      usedMm: 0,
+      candidateSpoolId: candidateId,
+      confirmedSpoolIds: [],
+      entry: null,
+      reason: "history-entry-missing"
+    };
+  }
+
+  const usedMm = estimateHistoryEntryUsedMm(entry);
+  const confirmedSpoolIds = _confirmedSpoolIds(entry);
+  if (confirmedSpoolIds.includes(candidateId)) {
+    return {
+      observationKey,
+      status: "confirmed-same-spool",
+      usedMm,
+      candidateSpoolId: candidateId,
+      confirmedSpoolIds,
+      entry,
+      reason: "already-confirmed-on-candidate-spool"
+    };
+  }
+  if (confirmedSpoolIds.length > 0) {
+    return {
+      observationKey,
+      status: "confirmed-other-spool",
+      usedMm,
+      candidateSpoolId: candidateId,
+      confirmedSpoolIds,
+      entry,
+      reason: "already-confirmed-on-other-spool"
+    };
+  }
+  if (usedMm <= 0) {
+    return {
+      observationKey,
+      status: "no-usage",
+      usedMm: 0,
+      candidateSpoolId: candidateId,
+      confirmedSpoolIds,
+      entry,
+      reason: "usage-missing-or-zero"
+    };
+  }
+  return {
+    observationKey,
+    status: "inferred-debit",
+    usedMm,
+    candidateSpoolId: candidateId,
+    confirmedSpoolIds,
+    entry,
+    reason: "unattributed-usage"
+  };
+}
+
+/**
+ * O2 continuity candidate から O3 の純粋 projection を構築する。
+ *
+ * 【詳細説明】
+ * - `classificationResult.classification` が `continuity-candidate` でない場合は推定 debit しない。
+ * - `spool.remainingLengthMm` を `confirmedRemainingMm` として読み、未帰属 candidate の消費量だけを
+ *   `inferredContinuityUsedMm` に集計する。
+ * - `projectedRemainingMm` は表示・計画用の推定値であり、spool オブジェクトへは書き戻さない。
+ * - 入力履歴に同一 observation key が既に候補スプールへ確定帰属している場合は対象外にし、
+ *   別スプール確定済みなら contradictions に分離する。
+ *
+ * @function buildInferredContinuityProjection
+ * @param {{classification:string, host?:?string, windowId?:?string, candidate?:?Object}} classificationResult -
+ *   `classifyObservationWindow()` の戻り値。
+ * @param {Object} spool - projection 対象スプール。`id` と `remainingLengthMm` を読む。
+ * @param {Array<Object>} history - printStore.history 相当の履歴配列。
+ * @returns {InferredContinuityProjection} O3 projection 結果。
+ * @example
+ * const projection = buildInferredContinuityProjection(classification, spool, history);
+ */
+export function buildInferredContinuityProjection(classificationResult, spool, history) {
+  const confirmedRemainingMm = _nonNegativeMm(spool?.remainingLengthMm);
+  const candidate = classificationResult?.candidate || null;
+  const candidateSpoolId = candidate?.candidateSpoolId == null ? null : String(candidate.candidateSpoolId);
+  const base = {
+    host: classificationResult?.host ?? null,
+    spoolId: spool?.id == null ? candidateSpoolId : String(spool.id),
+    windowId: classificationResult?.windowId ?? candidate?.windowId ?? null,
+    classification: classificationResult?.classification ?? null,
+    confirmedRemainingMm,
+    inferredContinuityUsedMm: 0,
+    projectedRemainingMm: confirmedRemainingMm,
+    candidateDebits: [],
+    contradictions: [],
+    unresolved: [],
+    readOnly: true
+  };
+
+  // O2 が継続候補を出していない、または対象スプールが一致しない場合は debit しない。
+  if (classificationResult?.classification !== CONTINUITY_CANDIDATE || !candidateSpoolId) {
+    return base;
+  }
+  if (spool?.id != null && String(spool.id) !== candidateSpoolId) {
+    return { ...base, contradictions: [{
+      observationKey: "",
+      status: "confirmed-other-spool",
+      usedMm: 0,
+      candidateSpoolId,
+      confirmedSpoolIds: [String(spool.id)],
+      entry: null,
+      reason: "projection-spool-mismatch"
+    }] };
+  }
+
+  const byKey = _historyByObservationKey(history);
+  const keys = Array.isArray(candidate.offlineObservationKeys) ? candidate.offlineObservationKeys : [];
+  const candidateDebits = keys.map(key => evaluateCandidateObservationKey(key, byKey.get(key) || null, candidateSpoolId));
+  const contradictions = candidateDebits.filter(item => item.status === "confirmed-other-spool");
+  const unresolved = candidateDebits.filter(item => item.status === "unresolved" || item.status === "no-usage");
+  const inferredContinuityUsedMm = candidateDebits
+    .filter(item => item.status === "inferred-debit")
+    .reduce((sum, item) => sum + _nonNegativeMm(item.usedMm), 0);
+
+  return {
+    ...base,
+    inferredContinuityUsedMm,
+    projectedRemainingMm: Math.max(0, confirmedRemainingMm - inferredContinuityUsedMm),
+    candidateDebits,
+    contradictions,
+    unresolved
+  };
+}

--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -62,6 +62,7 @@ import { getDisplayBaseUrl } from "./dashboard_connection.js";
 import { sendRelayFilament } from "./dashboard_client_sync.js";
 import { normalizeJobId } from "./dashboard_utils.js";
 import { wallNowMs, randomEventId } from "./dashboard_time.js";
+import { isCompletedHistoryEntry } from "./dashboard_history_identity.js";
 
 /**
  * リレー子クライアント（satellite/readonly）として動作中かを判定する。
@@ -2091,24 +2092,9 @@ export function shouldLinkOfflineJob(job) {
  * @param {Object} entry - 履歴ジョブ（printStore.history / historyData のエントリ）
  * @returns {boolean} 帰属未確認なら true
  */
-/**
- * 履歴エントリが「完了」しているかの共通判定（Phase5 P1-5 / #410-8）。
- * printfinish が正のシグナル。旧保存データは printfinish 欠落でも finishTime/finishTimeSec/
- * endtime/usagetime による完了証拠があれば完了扱いにする（古いログを未完了と誤判定しない）。
- *
- * @function isCompletedHistoryEntry
- * @param {Object} entry - 履歴ジョブ
- * @returns {boolean} 完了なら true
- */
-export function isCompletedHistoryEntry(entry) {
-  if (!entry) return false;
-  if (entry.printfinish != null) return true;
-  if (Number(entry.finishTime) > 0) return true;
-  if (Number(entry.finishTimeSec) > 0) return true;
-  if (Number(entry.endtime) > 0) return true;
-  if (Number(entry.usagetime) > 0) return true;
-  return false;
-}
+// ★ #410-8/#411-P1-4: 完了判定は下位の共通 pure utility へ一本化（判定ロジックの二重化を排す）。
+//   import は先頭で行い（ローカル束縛）、ここで再エクスポートする。
+export { isCompletedHistoryEntry };
 
 export function isAttributionPending(entry) {
   if (!entry) return false;

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -656,8 +656,8 @@ const LS_GLOBAL_FIELDS = [
   "mountHistory", "mountHistorySeq",
   // ★ #410-9: 参照不整合で隔離した mount イベント（元データを失わない）
   "mountHistoryRejectedEvents",
-  // ★ #411-O1: オフライン推定の観測 watermark（再起動後の差分基準）
-  "hostObservationWatermark",
+  // ★ #411-O1: オフライン推定の観測 watermark（baseline＝再起動後の差分基準）＋現セッション観測
+  "hostObservationWatermark", "hostObservationCurrent",
   // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない）
   "pendingUnattributedUsage", "pendingUnattributedUsageArchive",
   // ★ RR-2: 台帳修復要求フラグ（破損時に暗黙クローズせず可視化）
@@ -881,6 +881,7 @@ function _flushStorage() {
       queueSharedWrite("mountHistorySeq",    monitorData.mountHistorySeq);
       queueSharedWrite("mountHistoryRejectedEvents", monitorData.mountHistoryRejectedEvents);
       queueSharedWrite("hostObservationWatermark", monitorData.hostObservationWatermark);
+      queueSharedWrite("hostObservationCurrent",   monitorData.hostObservationCurrent);
       // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない・子へも配信）
       queueSharedWrite("pendingUnattributedUsage",        monitorData.pendingUnattributedUsage);
       queueSharedWrite("pendingUnattributedUsageArchive", monitorData.pendingUnattributedUsageArchive);
@@ -1239,14 +1240,23 @@ function _restoreFromData(shared, machines) {
     }
   }
 
-  // ★ #411-O1: オフライン推定の観測 watermark（per-host）は未保持ホストのみ取り込む
-  //   （再起動後の差分基準＝停止直前の観測状態を復元する）。
+  // ★ #411-O1: オフライン推定の観測 watermark（baseline・per-host）は未保持ホストのみ取り込む
+  //   （再起動後の差分基準＝停止直前の観測状態を復元。起動直後の record は baseline を上書きしない）。
   if (shared?.hostObservationWatermark && typeof shared.hostObservationWatermark === "object") {
     if (!monitorData.hostObservationWatermark || typeof monitorData.hostObservationWatermark !== "object") {
       monitorData.hostObservationWatermark = {};
     }
     for (const [h, v] of Object.entries(shared.hostObservationWatermark)) {
       if (v && !monitorData.hostObservationWatermark[h]) monitorData.hostObservationWatermark[h] = { ...v };
+    }
+  }
+  // ★ #411-O1: 現セッション観測（crash 耐性用）。record が上書きするため未保持のみ取り込む。
+  if (shared?.hostObservationCurrent && typeof shared.hostObservationCurrent === "object") {
+    if (!monitorData.hostObservationCurrent || typeof monitorData.hostObservationCurrent !== "object") {
+      monitorData.hostObservationCurrent = {};
+    }
+    for (const [h, v] of Object.entries(shared.hostObservationCurrent)) {
+      if (v && !monitorData.hostObservationCurrent[h]) monitorData.hostObservationCurrent[h] = { ...v };
     }
   }
 

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -656,6 +656,8 @@ const LS_GLOBAL_FIELDS = [
   "mountHistory", "mountHistorySeq",
   // ★ #410-9: 参照不整合で隔離した mount イベント（元データを失わない）
   "mountHistoryRejectedEvents",
+  // ★ #411-O1: オフライン推定の観測 watermark（再起動後の差分基準）
+  "hostObservationWatermark",
   // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない）
   "pendingUnattributedUsage", "pendingUnattributedUsageArchive",
   // ★ RR-2: 台帳修復要求フラグ（破損時に暗黙クローズせず可視化）
@@ -878,6 +880,7 @@ function _flushStorage() {
       queueSharedWrite("mountHistory",       monitorData.mountHistory);
       queueSharedWrite("mountHistorySeq",    monitorData.mountHistorySeq);
       queueSharedWrite("mountHistoryRejectedEvents", monitorData.mountHistoryRejectedEvents);
+      queueSharedWrite("hostObservationWatermark", monitorData.hostObservationWatermark);
       // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない・子へも配信）
       queueSharedWrite("pendingUnattributedUsage",        monitorData.pendingUnattributedUsage);
       queueSharedWrite("pendingUnattributedUsageArchive", monitorData.pendingUnattributedUsageArchive);
@@ -1233,6 +1236,17 @@ function _restoreFromData(shared, machines) {
     }
     for (const [h, v] of Object.entries(shared.ledgerRepairRequired)) {
       if (v && !monitorData.ledgerRepairRequired[h]) monitorData.ledgerRepairRequired[h] = { ...v };
+    }
+  }
+
+  // ★ #411-O1: オフライン推定の観測 watermark（per-host）は未保持ホストのみ取り込む
+  //   （再起動後の差分基準＝停止直前の観測状態を復元する）。
+  if (shared?.hostObservationWatermark && typeof shared.hostObservationWatermark === "object") {
+    if (!monitorData.hostObservationWatermark || typeof monitorData.hostObservationWatermark !== "object") {
+      monitorData.hostObservationWatermark = {};
+    }
+    for (const [h, v] of Object.entries(shared.hostObservationWatermark)) {
+      if (v && !monitorData.hostObservationWatermark[h]) monitorData.hostObservationWatermark[h] = { ...v };
     }
   }
 

--- a/3dp_lib/dashboard_storage_idb.js
+++ b/3dp_lib/dashboard_storage_idb.js
@@ -103,8 +103,9 @@ const SHARED_KEYS = [
   "mountHistorySeq",
   // ★ #410-9: 参照不整合で隔離した mount イベント
   "mountHistoryRejectedEvents",
-  // ★ #411-O1: オフライン推定の観測 watermark
+  // ★ #411-O1: オフライン推定の観測 watermark（baseline）＋現セッション観測
   "hostObservationWatermark",
+  "hostObservationCurrent",
   // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない）
   "pendingUnattributedUsage",
   "pendingUnattributedUsageArchive",

--- a/3dp_lib/dashboard_storage_idb.js
+++ b/3dp_lib/dashboard_storage_idb.js
@@ -103,6 +103,8 @@ const SHARED_KEYS = [
   "mountHistorySeq",
   // ★ #410-9: 参照不整合で隔離した mount イベント
   "mountHistoryRejectedEvents",
+  // ★ #411-O1: オフライン推定の観測 watermark
+  "hostObservationWatermark",
   // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない）
   "pendingUnattributedUsage",
   "pendingUnattributedUsageArchive",

--- a/tests/unit/dashboard_history_identity.test.js
+++ b/tests/unit/dashboard_history_identity.test.js
@@ -21,6 +21,11 @@ describe("isCompletedHistoryEntry", () => {
     expect(isCompletedHistoryEntry({})).toBe(false);
     expect(isCompletedHistoryEntry(null)).toBe(false);
   });
+  it("★ P1-2: ISO 8601（Z/offset）の finishTime も完了証拠として受理する", () => {
+    expect(isCompletedHistoryEntry({ finishTime: "2026-07-16T10:20:30.000Z" })).toBe(true);
+    expect(isCompletedHistoryEntry({ endtime: "2026-07-16T19:20:30+09:00" })).toBe(true);
+    expect(isCompletedHistoryEntry({ finishTime: "not-a-date" })).toBe(false); // 曖昧/不正は不採用
+  });
 });
 
 describe("canonicalJobKey（Number化しない・偽ID除外）", () => {
@@ -57,6 +62,11 @@ describe("jobTemporal（P1-1: id を時刻 fallback にしない / P1-3: 単位�
   });
   it("単位不明な小さい値は 0（誤って秒/ms 化しない）", () => {
     expect(jobTemporal({ finishTime: 500 }).finishAt).toBe(0);
+  });
+  it("★ P1-2: ISO finishTime を epoch ms へ正規化", () => {
+    const t = jobTemporal({ finishTime: "2026-07-16T10:20:30.000Z" });
+    expect(t.finishAt).toBe(Date.parse("2026-07-16T10:20:30.000Z"));
+    expect(t.timeSource).toBe("finishTime");
   });
 });
 

--- a/tests/unit/dashboard_history_identity.test.js
+++ b/tests/unit/dashboard_history_identity.test.js
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview dashboard_history_identity.js（#411 完了判定・複合キー・世代fingerprint）単体テスト
+ */
+import { describe, it, expect } from "vitest";
+import {
+  isCompletedHistoryEntry, canonicalJobKey, jobObservationKey,
+  completedJobObservations, historyGenerationFingerprint, completedJobKeySet
+} from "../../3dp_lib/dashboard_history_identity.js";
+
+describe("isCompletedHistoryEntry", () => {
+  it("printfinish/ finishTime/endtime/usagetime で完了判定、無ければ未完了", () => {
+    expect(isCompletedHistoryEntry({ printfinish: 1 })).toBe(true);
+    expect(isCompletedHistoryEntry({ printfinish: 0 })).toBe(true);
+    expect(isCompletedHistoryEntry({ endtime: 123 })).toBe(true);
+    expect(isCompletedHistoryEntry({ usagetime: 60 })).toBe(true);
+    expect(isCompletedHistoryEntry({ printfinish: null })).toBe(false);
+    expect(isCompletedHistoryEntry({})).toBe(false);
+    expect(isCompletedHistoryEntry(null)).toBe(false);
+  });
+});
+
+describe("canonicalJobKey（Number化しない・偽ID除外）", () => {
+  it("有効IDは文字列のまま、0/空/全ゼロは null", () => {
+    expect(canonicalJobKey({ id: "1749700000" })).toBe("1749700000");
+    expect(canonicalJobKey("00123")).toBe("00123"); // leading zero 保持
+    expect(canonicalJobKey(12345)).toBe("12345");
+    expect(canonicalJobKey("0")).toBeNull();
+    expect(canonicalJobKey("00")).toBeNull();
+    expect(canonicalJobKey("")).toBeNull();
+    expect(canonicalJobKey(null)).toBeNull();
+  });
+  it("2^53 超の巨大IDでも精度を失わない（文字列保持）", () => {
+    const big = "900719925474099300001";
+    expect(canonicalJobKey(big)).toBe(big);
+  });
+});
+
+describe("jobObservationKey（複合観測キー）", () => {
+  it("id＋開始/完了時刻＋ファイルで同一実行を識別、識別材料の有無を返す", () => {
+    const o = jobObservationKey({ id: "1", finishTime: 500, filename: "a.gcode" });
+    expect(o.id).toBe("1");
+    expect(o.hasDistinguishing).toBe(true);
+    expect(o.finishAt).toBe(500);
+    // id 同じでも finishTime が違えば別キー（= ID 再利用を区別できる）
+    const o2 = jobObservationKey({ id: "1", finishTime: 900, filename: "a.gcode" });
+    expect(o2.key).not.toBe(o.key);
+  });
+  it("id のみ（start=id）は hasDistinguishing=false", () => {
+    const o = jobObservationKey({ id: "1000", printfinish: 1 });
+    expect(o.hasDistinguishing).toBe(false);
+  });
+});
+
+describe("completedJobObservations / historyGenerationFingerprint", () => {
+  it("completion 時系列で安定ソート・重複排除", () => {
+    const hist = [job("3", 300), job("1", 100), job("1", 100), job("2", 200)];
+    const obs = completedJobObservations(hist);
+    expect(obs.map(o => o.finishAt)).toEqual([100, 200, 300]); // finishAt 昇順・重複排除
+  });
+  it("fingerprint は時系列（earliest/latest）＋ hash", () => {
+    const fp = historyGenerationFingerprint([job("1", 100), job("2", 300)]);
+    expect(fp.count).toBe(2);
+    expect(fp.earliestAt).toBe(100);
+    expect(fp.latestAt).toBe(300);
+    expect(typeof fp.hash).toBe("string");
+    // 内容が変われば hash も変わる
+    const fp2 = historyGenerationFingerprint([job("1", 100), job("2", 999)]);
+    expect(fp2.hash).not.toBe(fp.hash);
+  });
+});
+
+describe("completedJobKeySet（表示用 id 集合）", () => {
+  it("重複排除した canonical id 集合", () => {
+    expect(completedJobKeySet([job("2", 2), job("1", 1), job("1", 1)])).toEqual(["1", "2"]);
+  });
+});
+
+/** helper */
+function job(id, finishAt) {
+  return { id, materialUsedMm: 5000, printfinish: 1, finishTime: finishAt, filename: `f${id}.gcode` };
+}

--- a/tests/unit/dashboard_history_identity.test.js
+++ b/tests/unit/dashboard_history_identity.test.js
@@ -1,19 +1,23 @@
 /**
- * @fileoverview dashboard_history_identity.js（#411 完了判定・複合キー・世代fingerprint）単体テスト
+ * @fileoverview dashboard_history_identity.js（#411 完了判定・複合 identity・世代fingerprint）単体テスト
  */
 import { describe, it, expect } from "vitest";
 import {
-  isCompletedHistoryEntry, canonicalJobKey, jobObservationKey,
+  isCompletedHistoryEntry, canonicalJobKey, jobTemporal, jobObservationIdentity,
   completedJobObservations, historyGenerationFingerprint, completedJobKeySet
 } from "../../3dp_lib/dashboard_history_identity.js";
 
+const BASE = 1_700_000_000_000; // epoch ms
+
 describe("isCompletedHistoryEntry", () => {
-  it("printfinish/ finishTime/endtime/usagetime で完了判定、無ければ未完了", () => {
+  it("printfinish 数値/真偽・finishTime/endtime/usagetime で完了判定", () => {
     expect(isCompletedHistoryEntry({ printfinish: 1 })).toBe(true);
-    expect(isCompletedHistoryEntry({ printfinish: 0 })).toBe(true);
-    expect(isCompletedHistoryEntry({ endtime: 123 })).toBe(true);
+    expect(isCompletedHistoryEntry({ printfinish: 0 })).toBe(true);   // 失敗も「完了」
+    expect(isCompletedHistoryEntry({ printfinish: false })).toBe(true);
+    expect(isCompletedHistoryEntry({ endtime: BASE })).toBe(true);
     expect(isCompletedHistoryEntry({ usagetime: 60 })).toBe(true);
-    expect(isCompletedHistoryEntry({ printfinish: null })).toBe(false);
+    expect(isCompletedHistoryEntry({ printfinish: null })).toBe(false); // 未完了
+    expect(isCompletedHistoryEntry({ printfinish: "" })).toBe(false);   // 曖昧値は完了証拠にしない
     expect(isCompletedHistoryEntry({})).toBe(false);
     expect(isCompletedHistoryEntry(null)).toBe(false);
   });
@@ -35,18 +39,49 @@ describe("canonicalJobKey（Number化しない・偽ID除外）", () => {
   });
 });
 
-describe("jobObservationKey（複合観測キー）", () => {
-  it("id＋開始/完了時刻＋ファイルで同一実行を識別、識別材料の有無を返す", () => {
-    const o = jobObservationKey({ id: "1", finishTime: 500, filename: "a.gcode" });
-    expect(o.id).toBe("1");
-    expect(o.hasDistinguishing).toBe(true);
-    expect(o.finishAt).toBe(500);
-    // id 同じでも finishTime が違えば別キー（= ID 再利用を区別できる）
-    const o2 = jobObservationKey({ id: "1", finishTime: 900, filename: "a.gcode" });
-    expect(o2.key).not.toBe(o.key);
+describe("jobTemporal（P1-1: id を時刻 fallback にしない / P1-3: 単位正規化）", () => {
+  it("finishTime(ms)・finishTimeSec(秒→ms)・endtime を epoch ms へ正規化し timeSource を返す", () => {
+    expect(jobTemporal({ finishTime: BASE }).finishAt).toBe(BASE);
+    expect(jobTemporal({ finishTime: BASE }).timeSource).toBe("finishTime");
+    // 秒指定は *1000
+    expect(jobTemporal({ finishTimeSec: 1_700_000_000 }).finishAt).toBe(1_700_000_000_000);
+    expect(jobTemporal({ finishTimeSec: 1_700_000_000 }).timeSource).toBe("finishTimeSec");
+    // 秒レンジの finishTime も自動で ms 化
+    expect(jobTemporal({ endtime: 1_700_000_000 }).finishAt).toBe(1_700_000_000_000);
   });
-  it("id のみ（start=id）は hasDistinguishing=false", () => {
-    const o = jobObservationKey({ id: "1000", printfinish: 1 });
+  it("★ id を時刻 fallback にしない（巨大 id でも finishAt は 0/unknown）", () => {
+    const t = jobTemporal({ id: "900719925474099300001" });
+    expect(t.finishAt).toBe(0);
+    expect(t.startAt).toBe(0);
+    expect(t.timeSource).toBe("unknown");
+  });
+  it("単位不明な小さい値は 0（誤って秒/ms 化しない）", () => {
+    expect(jobTemporal({ finishTime: 500 }).finishAt).toBe(0);
+  });
+});
+
+describe("jobObservationIdentity（複合 identity・安全 encode）", () => {
+  it("id＋開始/完了時刻＋ファイルで同一実行を識別、id 再利用（別完了時刻）は別キー", () => {
+    const o = jobObservationIdentity({ id: "1", finishTime: BASE + 500, filename: "a.gcode" });
+    expect(o.canonicalJobId).toBe("1");
+    expect(o.hasDistinguishing).toBe(true);
+    expect(o.finishAt).toBe(BASE + 500);
+    const o2 = jobObservationIdentity({ id: "1", finishTime: BASE + 900, filename: "a.gcode" });
+    expect(o2.key).not.toBe(o.key); // 同 id・別完了時刻＝別キー（ID 再利用を区別）
+  });
+  it("★ P1-2: 区切り文字を含む値でもキー衝突しない（JSON tuple encode）", () => {
+    // id や file に '|' を仕込んでも別 identity は別キーのまま
+    const a = jobObservationIdentity({ id: "1|2", finishTime: BASE, filename: "3.gcode" });
+    const b = jobObservationIdentity({ id: "1", finishTime: BASE, filename: "2|3.gcode" });
+    expect(a.key).not.toBe(b.key);
+  });
+  it("ファイル同一性を正規化（大小・バックスラッシュ・URLエンコード）", () => {
+    const a = jobObservationIdentity({ id: "1", finishTime: BASE, filename: "A\\Dir\\File.GCODE" });
+    const b = jobObservationIdentity({ id: "1", finishTime: BASE, filename: "a/dir/file.gcode" });
+    expect(a.key).toBe(b.key);
+  });
+  it("識別材料が無い（id のみ）は hasDistinguishing=false", () => {
+    const o = jobObservationIdentity({ id: "1000", printfinish: 1 });
     expect(o.hasDistinguishing).toBe(false);
   });
 });
@@ -55,17 +90,16 @@ describe("completedJobObservations / historyGenerationFingerprint", () => {
   it("completion 時系列で安定ソート・重複排除", () => {
     const hist = [job("3", 300), job("1", 100), job("1", 100), job("2", 200)];
     const obs = completedJobObservations(hist);
-    expect(obs.map(o => o.finishAt)).toEqual([100, 200, 300]); // finishAt 昇順・重複排除
+    expect(obs.map(o => o.finishAt)).toEqual([BASE + 100000, BASE + 200000, BASE + 300000]);
   });
-  it("fingerprint は時系列（earliest/latest）＋ hash", () => {
+  it("fingerprint は completion 時系列（earliest/latest）＋順序 hash", () => {
     const fp = historyGenerationFingerprint([job("1", 100), job("2", 300)]);
-    expect(fp.count).toBe(2);
-    expect(fp.earliestAt).toBe(100);
-    expect(fp.latestAt).toBe(300);
-    expect(typeof fp.hash).toBe("string");
-    // 内容が変われば hash も変わる
+    expect(fp.completedCount).toBe(2);
+    expect(fp.earliestCompletedAt).toBe(BASE + 100000);
+    expect(fp.latestCompletedAt).toBe(BASE + 300000);
+    expect(typeof fp.retainedHash).toBe("string");
     const fp2 = historyGenerationFingerprint([job("1", 100), job("2", 999)]);
-    expect(fp2.hash).not.toBe(fp.hash);
+    expect(fp2.retainedHash).not.toBe(fp.retainedHash);
   });
 });
 
@@ -75,7 +109,7 @@ describe("completedJobKeySet（表示用 id 集合）", () => {
   });
 });
 
-/** helper */
-function job(id, finishAt) {
-  return { id, materialUsedMm: 5000, printfinish: 1, finishTime: finishAt, filename: `f${id}.gcode` };
+/** helper: t は基準からの相対秒 */
+function job(id, t) {
+  return { id, materialUsedMm: 5000, printfinish: 1, finishTime: BASE + t * 1000, filename: `f${id}.gcode` };
 }

--- a/tests/unit/dashboard_offline_classifier.test.js
+++ b/tests/unit/dashboard_offline_classifier.test.js
@@ -1,7 +1,8 @@
 /**
  * @fileoverview dashboard_offline_classifier.js（#411-O2 分類レイヤ）の単体テスト
  * ObservationWindow → 分類 → candidate → confidence の純関数を検証する。
- * O2 は Observation 層を変更せず利用のみ・remaining/安全基盤に触れないことも確認。
+ * 継続候補は「停止前後で同一スプールが装着継続」を観測できた場合のみ成立すること、
+ * O2 が Observation 層を変更せず利用のみ・remaining/安全基盤に触れないことを確認。
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
@@ -18,92 +19,144 @@ const { ATTR_CLASS, classifyObservationWindow, classifyHostAttribution } =
 const { recordObservation, computeObservationWindow, commitObservationWindow } =
   await import("../../3dp_lib/dashboard_offline_observation.js");
 
-/** 既定 bounded・継続候補になる ObservationWindow を組み立てる。 */
+const M = (over = {}) => ({ spoolId: "S1", intervalId: "iv1", intervalStatus: "ok", observationState: "mounted", ...over });
+
+/** 既定 bounded・同一スプール継続の ObservationWindow を組み立てる。 */
 function win(over = {}) {
+  const baselineMount = M(over.baselineMount || {});
+  const currentMount = M(over.currentMount || {});
   return {
-    windowId: "h|b1|c2", bounded: true, truncated: false, generationChanged: false,
-    reason: "diff-ok", offlineObservationKeys: [], unresolvedJobIds: [],
-    baselineFingerprint: {}, currentFingerprint: {}, baselineSequence: 1, currentSequence: 2,
-    stalenessMs: 0,
-    watermark: { mountedSpoolId: "S1", mountIntervalId: "iv1", mountIntervalStatus: "ok" },
-    ...over
+    windowId: "h|b1|c2", windowKind: "bounded", bounded: true, truncated: false, generationChanged: false,
+    reason: "diff-ok", offlineObservationKeys: [], unresolvedJobIds: [], hasCurrentObservation: true,
+    baselineFingerprint: {}, currentFingerprint: {}, baselineSequence: 1, currentSequence: 2, stalenessMs: 0,
+    watermark: {},
+    ...over,
+    baselineMount, currentMount
   };
 }
 
-describe("classifyObservationWindow（純関数）", () => {
-  it("bounded＋offline完了＋装着スプール＋interval ok → continuity-candidate/high", () => {
+describe("continuity 成立条件（O2-P0-1: 停止前後で同一スプール装着継続の観測が必須）", () => {
+  it("baseline A / current A / offline あり → continuity-candidate（interval一致で high）", () => {
     const r = classifyObservationWindow(win({ offlineObservationKeys: ["k1", "k2"] }));
     expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CANDIDATE);
     expect(r.candidate.candidateSpoolId).toBe("S1");
-    expect(r.candidate.candidateIntervalId).toBe("iv1");
+    expect(r.candidate.candidateBaselineIntervalId).toBe("iv1");
+    expect(r.candidate.candidateCurrentIntervalId).toBe("iv1");
     expect(r.candidate.offlineObservationKeys).toEqual(["k1", "k2"]);
     expect(r.confidence.level).toBe("high");
-    expect(r.confidence.reasons).toEqual(expect.arrayContaining(["bounded", "same-mounted-spool", "mount-interval-ok"]));
+    expect(r.confidence.reasons).toEqual(expect.arrayContaining(["same-mounted-spool", "current-interval-ok", "same-mount-interval"]));
   });
 
-  it("interval が ok でない（ambiguous）と confidence を1段下げる", () => {
+  it("baseline A / current B → continuity-contradicted（candidate なし）", () => {
     const r = classifyObservationWindow(win({
-      offlineObservationKeys: ["k1"], watermark: { mountedSpoolId: "S1", mountIntervalStatus: "ambiguous" }
+      offlineObservationKeys: ["k1"], currentMount: { spoolId: "S2" }
+    }));
+    expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CONTRADICTED);
+    expect(r.candidate).toBeNull();
+    expect(r.confidence.reasons).toContain("mounted-spool-changed");
+  });
+
+  it("baseline A / current 未装着 → continuity-contradicted（candidate なし）", () => {
+    const r = classifyObservationWindow(win({
+      offlineObservationKeys: ["k1"], currentMount: { spoolId: null, observationState: "unmounted", intervalStatus: "none" }
+    }));
+    expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CONTRADICTED);
+    expect(r.candidate).toBeNull();
+    expect(r.confidence.reasons).toContain("current-unmounted");
+  });
+
+  it("current の mount interval が corrupt → continuity-contradicted（candidate なし）", () => {
+    const r = classifyObservationWindow(win({
+      offlineObservationKeys: ["k1"], currentMount: { intervalStatus: "corrupt" }
+    }));
+    expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CONTRADICTED);
+    expect(r.candidate).toBeNull();
+  });
+
+  it("current の mount interval が ambiguous → continuity-contradicted", () => {
+    const r = classifyObservationWindow(win({
+      offlineObservationKeys: ["k1"], currentMount: { intervalStatus: "ambiguous" }
+    }));
+    expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CONTRADICTED);
+  });
+
+  it("baseline 未装着 → no-mounted-spool（candidate なし）", () => {
+    const r = classifyObservationWindow(win({
+      offlineObservationKeys: ["k1"], baselineMount: { spoolId: null, observationState: "unmounted", intervalStatus: "none" }
+    }));
+    expect(r.classification).toBe(ATTR_CLASS.NO_MOUNTED_SPOOL);
+    expect(r.candidate).toBeNull();
+  });
+});
+
+describe("O2-P0-2: current 観測が無ければ candidate を作らない", () => {
+  it("hasCurrentObservation=false → observation-incomplete（NO_PRIOR とは別）", () => {
+    const r = classifyObservationWindow(win({ windowKind: "incomplete", bounded: false, hasCurrentObservation: false, offlineObservationKeys: ["k1"] }));
+    expect(r.classification).toBe(ATTR_CLASS.OBSERVATION_INCOMPLETE);
+    expect(r.candidate).toBeNull();
+    expect(r.confidence.level).toBe("none");
+  });
+});
+
+describe("confidence 段階（interval / truncated）", () => {
+  it("same spool / same interval → high", () => {
+    expect(classifyObservationWindow(win({ offlineObservationKeys: ["k1"] })).confidence.level).toBe("high");
+  });
+
+  it("same spool / different interval → high にしない（途中 detach/reattach 疑い）", () => {
+    const r = classifyObservationWindow(win({ offlineObservationKeys: ["k1"], currentMount: { intervalId: "iv2" } }));
+    expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CANDIDATE);
+    expect(r.confidence.level).not.toBe("high");
+    expect(r.confidence.reasons).toContain("mount-interval-changed");
+  });
+
+  it("current interval none（同一スプール・mounted）→ candidate は出すが low", () => {
+    const r = classifyObservationWindow(win({
+      offlineObservationKeys: ["k1"], currentMount: { intervalStatus: "none", intervalId: null }
     }));
     expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CANDIDATE);
-    expect(r.confidence.level).toBe("medium");
-    expect(r.confidence.reasons).toContain("mount-interval-ambiguous");
+    expect(r.confidence.level).toBe("low");
   });
 
-  it("truncated は confidence を1段下げる", () => {
+  it("truncated は candidate の confidence を1段下げる（下限 low）", () => {
     const r = classifyObservationWindow(win({ offlineObservationKeys: ["k1"], truncated: true }));
     expect(r.confidence.level).toBe("medium");
     expect(r.confidence.reasons).toContain("history-truncated");
   });
+});
 
-  it("弱い証拠が重なっても candidate の confidence は low で下げ止まる", () => {
-    const r = classifyObservationWindow(win({
-      offlineObservationKeys: ["k1"], truncated: true, unresolvedJobIds: ["9"], stalenessMs: 40 * 24 * 3600 * 1000,
-      watermark: { mountedSpoolId: "S1", mountIntervalStatus: "none" }
-    }));
-    expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CANDIDATE);
-    expect(r.confidence.level).toBe("low"); // none まで落ちない
-  });
-
-  it("bounded だが offline 完了なし → no-offline-activity（candidate なし・high）", () => {
+describe("非 candidate 分類", () => {
+  it("bounded だが offline なし → no-offline-activity（high）", () => {
     const r = classifyObservationWindow(win({ offlineObservationKeys: [] }));
     expect(r.classification).toBe(ATTR_CLASS.NO_OFFLINE_ACTIVITY);
     expect(r.candidate).toBeNull();
     expect(r.confidence.level).toBe("high");
   });
 
-  it("bounded＋offline あるが baseline 未装着 → no-mounted-spool（candidate なし）", () => {
-    const r = classifyObservationWindow(win({
-      offlineObservationKeys: ["k1"], watermark: { mountedSpoolId: null, mountIntervalStatus: "none" }
-    }));
-    expect(r.classification).toBe(ATTR_CLASS.NO_MOUNTED_SPOOL);
-    expect(r.candidate).toBeNull();
+  it("offline なし＋truncated → no-offline-activity だが medium（監査用に理由を残す）", () => {
+    const r = classifyObservationWindow(win({ offlineObservationKeys: [], truncated: true }));
+    expect(r.classification).toBe(ATTR_CLASS.NO_OFFLINE_ACTIVITY);
+    expect(r.confidence.level).toBe("medium");
+    expect(r.confidence.reasons).toContain("history-truncated");
   });
 
-  it("bounded=false / identity 変化 → unbounded（candidate なし・none）", () => {
-    const r = classifyObservationWindow(win({ bounded: false, reason: "printer-identity-changed" }));
+  it("windowKind=unbounded → unbounded（candidate なし・none）", () => {
+    const r = classifyObservationWindow(win({ windowKind: "unbounded", bounded: false, reason: "printer-identity-changed" }));
     expect(r.classification).toBe(ATTR_CLASS.UNBOUNDED);
     expect(r.candidate).toBeNull();
-    expect(r.confidence.level).toBe("none");
     expect(r.confidence.reasons).toContain("printer-identity-changed");
   });
 
-  it("bounded=false / 識別不足 → insufficient（unresolvedJobIds を持ち越す）", () => {
-    const r = classifyObservationWindow(win({ bounded: false, reason: "job-identity-insufficient", unresolvedJobIds: ["3"] }));
+  it("windowKind=insufficient → insufficient（unresolvedJobIds を持ち越す）", () => {
+    const r = classifyObservationWindow(win({ windowKind: "insufficient", bounded: false, reason: "job-identity-insufficient", unresolvedJobIds: ["3"] }));
     expect(r.classification).toBe(ATTR_CLASS.INSUFFICIENT);
     expect(r.candidate).toBeNull();
     expect(r.unresolvedJobIds).toEqual(["3"]);
   });
 
-  it("再利用ID未検証も insufficient", () => {
-    const r = classifyObservationWindow(win({ bounded: false, reason: "reused-job-id-unverifiable", unresolvedJobIds: ["7"] }));
-    expect(r.classification).toBe(ATTR_CLASS.INSUFFICIENT);
-  });
-
-  it("前回観測なし → no-prior", () => {
-    const r = classifyObservationWindow(win({ bounded: false, reason: "no-prior-observation", watermark: null }));
+  it("windowKind=no-prior → no-prior", () => {
+    const r = classifyObservationWindow(win({ windowKind: "no-prior", bounded: false, reason: "no-prior-observation" }));
     expect(r.classification).toBe(ATTR_CLASS.NO_PRIOR);
-    expect(r.candidate).toBeNull();
   });
 
   it("window が無効でも落ちない（no-prior/none）", () => {
@@ -119,6 +172,13 @@ describe("classifyHostAttribution（Observation 層を利用のみ・read-only�
     if (!mockMonitorData.machines[host]) mockMonitorData.machines[host] = { printStore: {}, storedData: {} };
     mockMonitorData.machines[host].printStore = { history: entries };
   }
+  function establishBaseline(host, spool, entries) {
+    mockMonitorData.hostSpoolMap[host] = spool;
+    setHistory(host, entries);
+    recordObservation(host, { mountIntervalStatus: "ok", mountIntervalId: "iv1" });
+    const w = computeObservationWindow(host);
+    commitObservationWindow(host, { windowId: w.windowId, expectedSequence: w.currentSequence, candidatePersistedAt: 1 });
+  }
 
   beforeEach(() => {
     mockMonitorData.machines = {};
@@ -131,13 +191,8 @@ describe("classifyHostAttribution（Observation 層を利用のみ・read-only�
     mockMonitorData.remainingLengthMm = 12345;
   });
 
-  it("装着中に offline 完了が出れば continuity-candidate を返し、安全基盤は不変", () => {
-    mockMonitorData.hostSpoolMap.h = "S1";
-    setHistory("h", [job("1000", 100)]);
-    recordObservation("h", { mountIntervalStatus: "ok", mountIntervalId: "iv1" });
-    const w0 = computeObservationWindow("h");
-    commitObservationWindow("h", { windowId: w0.windowId, expectedSequence: w0.currentSequence, candidatePersistedAt: 1 });
-    // 再起動後: オフライン完了 1001 が出現
+  it("同一スプール継続で offline 完了が出れば continuity-candidate、安全基盤は不変", () => {
+    establishBaseline("h", "S1", [job("1000", 100)]);
     setHistory("h", [job("1000", 100), job("1001", 200)]);
     recordObservation("h", { mountIntervalStatus: "ok", mountIntervalId: "iv1" });
 
@@ -146,10 +201,33 @@ describe("classifyHostAttribution（Observation 層を利用のみ・read-only�
     expect(r.candidate.candidateSpoolId).toBe("S1");
     expect(r.candidate.offlineObservationKeys).toHaveLength(1);
     expect(r.confidence.level).toBe("high");
-    // read-only 境界: remaining / mountHistory / pendingUnattributedUsage 不変
+    // read-only 境界
     expect(mockMonitorData.remainingLengthMm).toBe(12345);
     expect(mockMonitorData.mountHistory).toEqual([{ evId: "keep" }]);
     expect(mockMonitorData.pendingUnattributedUsage).toEqual([{ pendingUsageId: "keep" }]);
+  });
+
+  it("復帰後に別スプールへ替わっていたら continuity-contradicted（誤帰属しない）", () => {
+    establishBaseline("h", "S1", [job("1000", 100)]);
+    // 復帰後: 物理的に S2 へ交換され、offline 完了 1001 が出現
+    mockMonitorData.hostSpoolMap.h = "S2";
+    setHistory("h", [job("1000", 100), job("1001", 200)]);
+    recordObservation("h", { mountIntervalStatus: "ok", mountIntervalId: "iv9" });
+
+    const r = classifyHostAttribution("h");
+    expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CONTRADICTED);
+    expect(r.candidate).toBeNull();
+  });
+
+  it("baseline はあるが復帰後 current 未観測なら observation-incomplete", () => {
+    establishBaseline("h", "S1", [job("1000", 100)]);
+    // 再起動直後: current 観測がまだ無い状態を模す
+    delete mockMonitorData.hostObservationCurrent.h;
+    setHistory("h", [job("1000", 100), job("1001", 200)]);
+
+    const r = classifyHostAttribution("h");
+    expect(r.classification).toBe(ATTR_CLASS.OBSERVATION_INCOMPLETE);
+    expect(r.candidate).toBeNull();
   });
 
   it("前回観測が無ければ no-prior", () => {

--- a/tests/unit/dashboard_offline_classifier.test.js
+++ b/tests/unit/dashboard_offline_classifier.test.js
@@ -20,6 +20,8 @@ const { recordObservation, computeObservationWindow, commitObservationWindow } =
   await import("../../3dp_lib/dashboard_offline_observation.js");
 
 const M = (over = {}) => ({ spoolId: "S1", intervalId: "iv1", intervalStatus: "ok", observationState: "mounted", ...over });
+const AJ = "J1";
+const AJKEY = JSON.stringify([AJ, 0, 1700000000000, "fJ1.gcode"]); // active job の offline 複合キー
 
 /** 既定 bounded・同一スプール継続の ObservationWindow を組み立てる。 */
 function win(over = {}) {
@@ -29,22 +31,26 @@ function win(over = {}) {
     windowId: "h|b1|c2", windowKind: "bounded", bounded: true, truncated: false, generationChanged: false,
     reason: "diff-ok", offlineObservationKeys: [], unresolvedJobIds: [], hasCurrentObservation: true,
     baselineFingerprint: {}, currentFingerprint: {}, baselineSequence: 1, currentSequence: 2, stalenessMs: 0,
-    watermark: {},
+    watermark: {}, printerIdentityMatch: { status: "same-descriptive", matchedBy: "model" },
     ...over,
     baselineMount, currentMount
   };
 }
+/** activeJobContinued=true（停止前ジョブの完了を観測＝high の前提）の継続窓。 */
+function contWin(over = {}) {
+  return win({ offlineObservationKeys: [AJKEY], watermark: { activeJobId: AJ }, ...over });
+}
 
 describe("continuity 成立条件（O2-P0-1: 停止前後で同一スプール装着継続の観測が必須）", () => {
-  it("baseline A / current A / offline あり → continuity-candidate（interval一致で high）", () => {
-    const r = classifyObservationWindow(win({ offlineObservationKeys: ["k1", "k2"] }));
+  it("baseline A / current A / activeJob継続 → continuity-candidate（interval一致で high）", () => {
+    const r = classifyObservationWindow(contWin());
     expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CANDIDATE);
     expect(r.candidate.candidateSpoolId).toBe("S1");
     expect(r.candidate.candidateBaselineIntervalId).toBe("iv1");
     expect(r.candidate.candidateCurrentIntervalId).toBe("iv1");
-    expect(r.candidate.offlineObservationKeys).toEqual(["k1", "k2"]);
+    expect(r.candidate.offlineObservationKeys).toEqual([AJKEY]);
     expect(r.confidence.level).toBe("high");
-    expect(r.confidence.reasons).toEqual(expect.arrayContaining(["same-mounted-spool", "current-interval-ok", "same-mount-interval"]));
+    expect(r.confidence.reasons).toEqual(expect.arrayContaining(["same-mounted-spool", "active-job-continued", "current-interval-ok", "baseline-interval-ok", "same-mount-interval"]));
   });
 
   it("baseline A / current B → continuity-contradicted（candidate なし）", () => {
@@ -87,6 +93,18 @@ describe("continuity 成立条件（O2-P0-1: 停止前後で同一スプール�
     expect(r.classification).toBe(ATTR_CLASS.NO_MOUNTED_SPOOL);
     expect(r.candidate).toBeNull();
   });
+
+  it("★P0-2: baseline interval が corrupt → continuity-contradicted（破損台帳を根拠にしない）", () => {
+    const r = classifyObservationWindow(win({ offlineObservationKeys: ["k1"], baselineMount: { intervalStatus: "corrupt" } }));
+    expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CONTRADICTED);
+    expect(r.candidate).toBeNull();
+    expect(r.confidence.contradictions).toContain("baseline-interval-corrupt");
+  });
+
+  it("★P0-2: baseline interval が ambiguous → continuity-contradicted", () => {
+    const r = classifyObservationWindow(win({ offlineObservationKeys: ["k1"], baselineMount: { intervalStatus: "ambiguous" } }));
+    expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CONTRADICTED);
+  });
 });
 
 describe("O2-P0-2: current 観測が無ければ candidate を作らない", () => {
@@ -98,29 +116,41 @@ describe("O2-P0-2: current 観測が無ければ candidate を作らない", () 
   });
 });
 
-describe("confidence 段階（interval / truncated）", () => {
-  it("same spool / same interval → high", () => {
-    expect(classifyObservationWindow(win({ offlineObservationKeys: ["k1"] })).confidence.level).toBe("high");
+describe("confidence 段階（P0-3: activeJobContinued / interval / truncated）", () => {
+  it("activeJob継続＋same spool＋same interval＋前後ok → high", () => {
+    expect(classifyObservationWindow(contWin()).confidence.level).toBe("high");
+  });
+
+  it("★P0-3: 完全オフライン（activeJobContinued=false）は high にしない＝medium 止まり", () => {
+    const r = classifyObservationWindow(win({ offlineObservationKeys: ["k1"] })); // watermark.activeJobId なし
+    expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CANDIDATE);
+    expect(r.confidence.level).toBe("medium");
+    expect(r.confidence.reasons).toContain("fully-offline");
   });
 
   it("same spool / different interval → high にしない（途中 detach/reattach 疑い）", () => {
-    const r = classifyObservationWindow(win({ offlineObservationKeys: ["k1"], currentMount: { intervalId: "iv2" } }));
+    const r = classifyObservationWindow(contWin({ currentMount: { intervalId: "iv2" } }));
     expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CANDIDATE);
     expect(r.confidence.level).not.toBe("high");
     expect(r.confidence.reasons).toContain("mount-interval-changed");
   });
 
   it("current interval none（同一スプール・mounted）→ candidate は出すが low", () => {
-    const r = classifyObservationWindow(win({
-      offlineObservationKeys: ["k1"], currentMount: { intervalStatus: "none", intervalId: null }
-    }));
+    const r = classifyObservationWindow(contWin({ currentMount: { intervalStatus: "none", intervalId: null } }));
     expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CANDIDATE);
     expect(r.confidence.level).toBe("low");
   });
 
-  it("truncated は candidate の confidence を1段下げる（下限 low）", () => {
-    const r = classifyObservationWindow(win({ offlineObservationKeys: ["k1"], truncated: true }));
-    expect(r.confidence.level).toBe("medium");
+  it("baseline interval が none/unknown → candidate は出すが low", () => {
+    const r = classifyObservationWindow(contWin({ baselineMount: { intervalStatus: "none" } }));
+    expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CANDIDATE);
+    expect(r.confidence.level).toBe("low");
+    expect(r.confidence.reasons).toContain("baseline-interval-none");
+  });
+
+  it("truncated は low tier（窓が欠けている可能性）", () => {
+    const r = classifyObservationWindow(contWin({ truncated: true }));
+    expect(r.confidence.level).toBe("low");
     expect(r.confidence.reasons).toContain("history-truncated");
   });
 });
@@ -172,6 +202,13 @@ describe("evidence / contradictions（O2 返却仕様）", () => {
     expect(r.evidence.sameMountInterval).toBe(true);
     expect(r.evidence.mountStatus).toBe("ok");
   });
+  it("★P1-1: sameStrongPrinterIdentity は serial/deviceId 一致(same-strong)のみ true。model一致(same-descriptive)では false", () => {
+    const desc = classifyObservationWindow(win({ offlineObservationKeys: ["k1"], printerIdentityMatch: { status: "same-descriptive", matchedBy: "model" } }));
+    expect(desc.evidence.sameStrongPrinterIdentity).toBe(false);
+    expect(desc.evidence.printerIdentityMatch.status).toBe("same-descriptive");
+    const strong = classifyObservationWindow(win({ offlineObservationKeys: ["k1"], printerIdentityMatch: { status: "same-strong", matchedBy: "serialNumber" } }));
+    expect(strong.evidence.sameStrongPrinterIdentity).toBe(true);
+  });
   it("activeJobContinued: baseline の activeJobId が offline 集合に現れる", () => {
     const key = JSON.stringify(["1000", 0, 1700000000000, "f.gcode"]);
     const r = classifyObservationWindow(win({ offlineObservationKeys: [key], watermark: { activeJobId: "1000" } }));
@@ -213,7 +250,7 @@ describe("classifyHostAttribution（Observation 層を利用のみ・read-only�
     mockMonitorData.remainingLengthMm = 12345;
   });
 
-  it("同一スプール継続で offline 完了が出れば continuity-candidate、安全基盤は不変", () => {
+  it("同一スプール継続で offline 完了が出れば continuity-candidate（完全オフラインは medium）、安全基盤は不変", () => {
     establishBaseline("h", "S1", [job("1000", 100)]);
     setHistory("h", [job("1000", 100), job("1001", 200)]);
     recordObservation("h", { mountIntervalStatus: "ok", mountIntervalId: "iv1" });
@@ -222,11 +259,24 @@ describe("classifyHostAttribution（Observation 層を利用のみ・read-only�
     expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CANDIDATE);
     expect(r.candidate.candidateSpoolId).toBe("S1");
     expect(r.candidate.offlineObservationKeys).toHaveLength(1);
-    expect(r.confidence.level).toBe("high");
+    expect(r.confidence.level).toBe("medium"); // 停止前 idle＝完全オフライン→high にしない
     // read-only 境界
     expect(mockMonitorData.remainingLengthMm).toBe(12345);
     expect(mockMonitorData.mountHistory).toEqual([{ evId: "keep" }]);
     expect(mockMonitorData.pendingUnattributedUsage).toEqual([{ pendingUsageId: "keep" }]);
+  });
+
+  it("★P1-2: 永続復元された旧 current だけでは observation-incomplete（現セッションの観測が要る）", () => {
+    establishBaseline("h", "S1", [job("1000", 100)]);
+    // 復帰後: current を「旧セッションの appSessionId」に差し替える（永続復元を模す）
+    mockMonitorData.hostObservationCurrent.h = { ...mockMonitorData.hostObservationCurrent.h, appSessionId: "stale-session" };
+    setHistory("h", [job("1000", 100), job("1001", 200)]);
+    const r = classifyHostAttribution("h");
+    expect(r.classification).toBe(ATTR_CLASS.OBSERVATION_INCOMPLETE);
+    expect(r.candidate).toBeNull();
+    // 現セッションで観測を取れば bounded 判定へ進める
+    recordObservation("h", { mountIntervalStatus: "ok", mountIntervalId: "iv1" });
+    expect(classifyHostAttribution("h").classification).toBe(ATTR_CLASS.CONTINUITY_CANDIDATE);
   });
 
   it("復帰後に別スプールへ替わっていたら continuity-contradicted（誤帰属しない）", () => {

--- a/tests/unit/dashboard_offline_classifier.test.js
+++ b/tests/unit/dashboard_offline_classifier.test.js
@@ -1,0 +1,159 @@
+/**
+ * @fileoverview dashboard_offline_classifier.js（#411-O2 分類レイヤ）の単体テスト
+ * ObservationWindow → 分類 → candidate → confidence の純関数を検証する。
+ * O2 は Observation 層を変更せず利用のみ・remaining/安全基盤に触れないことも確認。
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockMonitorData = {
+  machines: {}, hostSpoolMap: {}, hostObservationWatermark: {}, hostObservationCurrent: {},
+  appSettings: { connectionTargets: [] },
+  mountHistory: [{ evId: "keep" }], pendingUnattributedUsage: [{ pendingUsageId: "keep" }],
+  remainingLengthMm: 12345,
+};
+vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mockMonitorData }));
+
+const { ATTR_CLASS, classifyObservationWindow, classifyHostAttribution } =
+  await import("../../3dp_lib/dashboard_offline_classifier.js");
+const { recordObservation, computeObservationWindow, commitObservationWindow } =
+  await import("../../3dp_lib/dashboard_offline_observation.js");
+
+/** 既定 bounded・継続候補になる ObservationWindow を組み立てる。 */
+function win(over = {}) {
+  return {
+    windowId: "h|b1|c2", bounded: true, truncated: false, generationChanged: false,
+    reason: "diff-ok", offlineObservationKeys: [], unresolvedJobIds: [],
+    baselineFingerprint: {}, currentFingerprint: {}, baselineSequence: 1, currentSequence: 2,
+    stalenessMs: 0,
+    watermark: { mountedSpoolId: "S1", mountIntervalId: "iv1", mountIntervalStatus: "ok" },
+    ...over
+  };
+}
+
+describe("classifyObservationWindow（純関数）", () => {
+  it("bounded＋offline完了＋装着スプール＋interval ok → continuity-candidate/high", () => {
+    const r = classifyObservationWindow(win({ offlineObservationKeys: ["k1", "k2"] }));
+    expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CANDIDATE);
+    expect(r.candidate.candidateSpoolId).toBe("S1");
+    expect(r.candidate.candidateIntervalId).toBe("iv1");
+    expect(r.candidate.offlineObservationKeys).toEqual(["k1", "k2"]);
+    expect(r.confidence.level).toBe("high");
+    expect(r.confidence.reasons).toEqual(expect.arrayContaining(["bounded", "same-mounted-spool", "mount-interval-ok"]));
+  });
+
+  it("interval が ok でない（ambiguous）と confidence を1段下げる", () => {
+    const r = classifyObservationWindow(win({
+      offlineObservationKeys: ["k1"], watermark: { mountedSpoolId: "S1", mountIntervalStatus: "ambiguous" }
+    }));
+    expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CANDIDATE);
+    expect(r.confidence.level).toBe("medium");
+    expect(r.confidence.reasons).toContain("mount-interval-ambiguous");
+  });
+
+  it("truncated は confidence を1段下げる", () => {
+    const r = classifyObservationWindow(win({ offlineObservationKeys: ["k1"], truncated: true }));
+    expect(r.confidence.level).toBe("medium");
+    expect(r.confidence.reasons).toContain("history-truncated");
+  });
+
+  it("弱い証拠が重なっても candidate の confidence は low で下げ止まる", () => {
+    const r = classifyObservationWindow(win({
+      offlineObservationKeys: ["k1"], truncated: true, unresolvedJobIds: ["9"], stalenessMs: 40 * 24 * 3600 * 1000,
+      watermark: { mountedSpoolId: "S1", mountIntervalStatus: "none" }
+    }));
+    expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CANDIDATE);
+    expect(r.confidence.level).toBe("low"); // none まで落ちない
+  });
+
+  it("bounded だが offline 完了なし → no-offline-activity（candidate なし・high）", () => {
+    const r = classifyObservationWindow(win({ offlineObservationKeys: [] }));
+    expect(r.classification).toBe(ATTR_CLASS.NO_OFFLINE_ACTIVITY);
+    expect(r.candidate).toBeNull();
+    expect(r.confidence.level).toBe("high");
+  });
+
+  it("bounded＋offline あるが baseline 未装着 → no-mounted-spool（candidate なし）", () => {
+    const r = classifyObservationWindow(win({
+      offlineObservationKeys: ["k1"], watermark: { mountedSpoolId: null, mountIntervalStatus: "none" }
+    }));
+    expect(r.classification).toBe(ATTR_CLASS.NO_MOUNTED_SPOOL);
+    expect(r.candidate).toBeNull();
+  });
+
+  it("bounded=false / identity 変化 → unbounded（candidate なし・none）", () => {
+    const r = classifyObservationWindow(win({ bounded: false, reason: "printer-identity-changed" }));
+    expect(r.classification).toBe(ATTR_CLASS.UNBOUNDED);
+    expect(r.candidate).toBeNull();
+    expect(r.confidence.level).toBe("none");
+    expect(r.confidence.reasons).toContain("printer-identity-changed");
+  });
+
+  it("bounded=false / 識別不足 → insufficient（unresolvedJobIds を持ち越す）", () => {
+    const r = classifyObservationWindow(win({ bounded: false, reason: "job-identity-insufficient", unresolvedJobIds: ["3"] }));
+    expect(r.classification).toBe(ATTR_CLASS.INSUFFICIENT);
+    expect(r.candidate).toBeNull();
+    expect(r.unresolvedJobIds).toEqual(["3"]);
+  });
+
+  it("再利用ID未検証も insufficient", () => {
+    const r = classifyObservationWindow(win({ bounded: false, reason: "reused-job-id-unverifiable", unresolvedJobIds: ["7"] }));
+    expect(r.classification).toBe(ATTR_CLASS.INSUFFICIENT);
+  });
+
+  it("前回観測なし → no-prior", () => {
+    const r = classifyObservationWindow(win({ bounded: false, reason: "no-prior-observation", watermark: null }));
+    expect(r.classification).toBe(ATTR_CLASS.NO_PRIOR);
+    expect(r.candidate).toBeNull();
+  });
+
+  it("window が無効でも落ちない（no-prior/none）", () => {
+    expect(classifyObservationWindow(null).classification).toBe(ATTR_CLASS.NO_PRIOR);
+    expect(classifyObservationWindow(undefined).confidence.level).toBe("none");
+  });
+});
+
+describe("classifyHostAttribution（Observation 層を利用のみ・read-only）", () => {
+  const BASE = 1_700_000_000_000;
+  function job(id, t) { return { id, materialUsedMm: 5000, printfinish: 1, finishTime: BASE + t * 1000, filename: `f${id}.gcode` }; }
+  function setHistory(host, entries) {
+    if (!mockMonitorData.machines[host]) mockMonitorData.machines[host] = { printStore: {}, storedData: {} };
+    mockMonitorData.machines[host].printStore = { history: entries };
+  }
+
+  beforeEach(() => {
+    mockMonitorData.machines = {};
+    mockMonitorData.hostSpoolMap = {};
+    mockMonitorData.hostObservationWatermark = {};
+    mockMonitorData.hostObservationCurrent = {};
+    mockMonitorData.appSettings = { connectionTargets: [] };
+    mockMonitorData.mountHistory = [{ evId: "keep" }];
+    mockMonitorData.pendingUnattributedUsage = [{ pendingUsageId: "keep" }];
+    mockMonitorData.remainingLengthMm = 12345;
+  });
+
+  it("装着中に offline 完了が出れば continuity-candidate を返し、安全基盤は不変", () => {
+    mockMonitorData.hostSpoolMap.h = "S1";
+    setHistory("h", [job("1000", 100)]);
+    recordObservation("h", { mountIntervalStatus: "ok", mountIntervalId: "iv1" });
+    const w0 = computeObservationWindow("h");
+    commitObservationWindow("h", { windowId: w0.windowId, expectedSequence: w0.currentSequence, candidatePersistedAt: 1 });
+    // 再起動後: オフライン完了 1001 が出現
+    setHistory("h", [job("1000", 100), job("1001", 200)]);
+    recordObservation("h", { mountIntervalStatus: "ok", mountIntervalId: "iv1" });
+
+    const r = classifyHostAttribution("h");
+    expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CANDIDATE);
+    expect(r.candidate.candidateSpoolId).toBe("S1");
+    expect(r.candidate.offlineObservationKeys).toHaveLength(1);
+    expect(r.confidence.level).toBe("high");
+    // read-only 境界: remaining / mountHistory / pendingUnattributedUsage 不変
+    expect(mockMonitorData.remainingLengthMm).toBe(12345);
+    expect(mockMonitorData.mountHistory).toEqual([{ evId: "keep" }]);
+    expect(mockMonitorData.pendingUnattributedUsage).toEqual([{ pendingUsageId: "keep" }]);
+  });
+
+  it("前回観測が無ければ no-prior", () => {
+    setHistory("h", [job("1", 100)]);
+    expect(classifyHostAttribution("h").classification).toBe(ATTR_CLASS.NO_PRIOR);
+  });
+});

--- a/tests/unit/dashboard_offline_classifier.test.js
+++ b/tests/unit/dashboard_offline_classifier.test.js
@@ -165,6 +165,28 @@ describe("非 candidate 分類", () => {
   });
 });
 
+describe("evidence / contradictions（O2 返却仕様）", () => {
+  it("continuity-candidate は evidence を埋める（sameMountedSpool/sameMountInterval/mountStatus）", () => {
+    const r = classifyObservationWindow(win({ offlineObservationKeys: ["k1"] }));
+    expect(r.evidence.sameMountedSpool).toBe(true);
+    expect(r.evidence.sameMountInterval).toBe(true);
+    expect(r.evidence.mountStatus).toBe("ok");
+  });
+  it("activeJobContinued: baseline の activeJobId が offline 集合に現れる", () => {
+    const key = JSON.stringify(["1000", 0, 1700000000000, "f.gcode"]);
+    const r = classifyObservationWindow(win({ offlineObservationKeys: [key], watermark: { activeJobId: "1000" } }));
+    expect(r.evidence.activeJobContinued).toBe(true);
+  });
+  it("continuity-contradicted は confidence.contradictions を埋める", () => {
+    const r = classifyObservationWindow(win({ offlineObservationKeys: ["k1"], currentMount: { spoolId: "S2" } }));
+    expect(r.confidence.contradictions).toContain("mounted-spool-changed");
+  });
+  it("unbounded も contradictions を埋める", () => {
+    const r = classifyObservationWindow(win({ windowKind: "unbounded", bounded: false, reason: "printer-identity-changed" }));
+    expect(r.confidence.contradictions).toContain("printer-identity-changed");
+  });
+});
+
 describe("classifyHostAttribution（Observation 層を利用のみ・read-only）", () => {
   const BASE = 1_700_000_000_000;
   function job(id, t) { return { id, materialUsedMm: 5000, printfinish: 1, finishTime: BASE + t * 1000, filename: `f${id}.gcode` }; }

--- a/tests/unit/dashboard_offline_classifier.test.js
+++ b/tests/unit/dashboard_offline_classifier.test.js
@@ -21,7 +21,9 @@ const { recordObservation, computeObservationWindow, commitObservationWindow } =
 
 const M = (over = {}) => ({ spoolId: "S1", intervalId: "iv1", intervalStatus: "ok", observationState: "mounted", ...over });
 const AJ = "J1";
-const AJKEY = JSON.stringify([AJ, 0, 1700000000000, "fJ1.gcode"]); // active job の offline 複合キー
+const AJ_START = 1700000000000;
+const AJKEY = JSON.stringify([AJ, AJ_START, AJ_START + 5000, "fJ1.gcode"]); // active job の offline 複合キー
+const AJOBS = { canonicalJobId: AJ, startAt: AJ_START, fileSignature: "fJ1.gcode" }; // 印刷中に取得した複合 identity
 
 /** 既定 bounded・同一スプール継続の ObservationWindow を組み立てる。 */
 function win(over = {}) {
@@ -36,9 +38,9 @@ function win(over = {}) {
     baselineMount, currentMount
   };
 }
-/** activeJobContinued=true（停止前ジョブの完了を観測＝high の前提）の継続窓。 */
+/** activeJobContinued=true（停止前印刷中ジョブの完了を複合 identity で観測＝high の前提）の継続窓。 */
 function contWin(over = {}) {
-  return win({ offlineObservationKeys: [AJKEY], watermark: { activeJobId: AJ }, ...over });
+  return win({ offlineObservationKeys: [AJKEY], watermark: { activeJobObservation: AJOBS }, ...over });
 }
 
 describe("continuity 成立条件（O2-P0-1: 停止前後で同一スプール装着継続の観測が必須）", () => {
@@ -121,11 +123,27 @@ describe("confidence 段階（P0-3: activeJobContinued / interval / truncated）
     expect(classifyObservationWindow(contWin()).confidence.level).toBe("high");
   });
 
-  it("★P0-3: 完全オフライン（activeJobContinued=false）は high にしない＝medium 止まり", () => {
-    const r = classifyObservationWindow(win({ offlineObservationKeys: ["k1"] })); // watermark.activeJobId なし
+  it("★P0-3: 完全オフライン（activeJobObservation なし）は high にしない＝medium 止まり", () => {
+    const r = classifyObservationWindow(win({ offlineObservationKeys: ["k1"] })); // activeJobObservation なし
     expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CANDIDATE);
     expect(r.confidence.level).toBe("medium");
     expect(r.confidence.reasons).toContain("fully-offline");
+  });
+
+  it("★P1-B: active job の ID は一致でも複合 identity（開始時刻/file）が不一致なら high にしない", () => {
+    // offline key は同 id だが startAt/file が別＝別実行（ID 再利用など）
+    const otherKey = JSON.stringify([AJ, 999, 1000, "other.gcode"]);
+    const r = classifyObservationWindow(win({
+      offlineObservationKeys: [otherKey], watermark: { activeJobObservation: AJOBS }
+    }));
+    expect(r.classification).toBe(ATTR_CLASS.CONTINUITY_CANDIDATE);
+    expect(r.confidence.level).toBe("medium"); // activeJobContinued=false 扱い
+    expect(r.evidence.activeJobContinued).toBe(false);
+  });
+
+  it("★P1-B: baseline が idle（activeJobObservation なし）なら activeJobContinued=false", () => {
+    const r = classifyObservationWindow(win({ offlineObservationKeys: [AJKEY], watermark: {} }));
+    expect(r.evidence.activeJobContinued).toBe(false);
   });
 
   it("same spool / different interval → high にしない（途中 detach/reattach 疑い）", () => {
@@ -209,9 +227,8 @@ describe("evidence / contradictions（O2 返却仕様）", () => {
     const strong = classifyObservationWindow(win({ offlineObservationKeys: ["k1"], printerIdentityMatch: { status: "same-strong", matchedBy: "serialNumber" } }));
     expect(strong.evidence.sameStrongPrinterIdentity).toBe(true);
   });
-  it("activeJobContinued: baseline の activeJobId が offline 集合に現れる", () => {
-    const key = JSON.stringify(["1000", 0, 1700000000000, "f.gcode"]);
-    const r = classifyObservationWindow(win({ offlineObservationKeys: [key], watermark: { activeJobId: "1000" } }));
+  it("activeJobContinued: baseline の active job 複合 identity が offline 集合に現れる", () => {
+    const r = classifyObservationWindow(contWin());
     expect(r.evidence.activeJobContinued).toBe(true);
   });
   it("continuity-contradicted は confidence.contradictions を埋める", () => {

--- a/tests/unit/dashboard_offline_observation.test.js
+++ b/tests/unit/dashboard_offline_observation.test.js
@@ -12,7 +12,7 @@ const mockMonitorData = {
 };
 vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mockMonitorData }));
 
-const { recordObservation, commitObservationWindow, computeObservationWindow, buildConfidence } =
+const { recordObservation, commitObservationWindow, computeObservationWindow, computeOfflineWindow, buildConfidence } =
   await import("../../3dp_lib/dashboard_offline_observation.js");
 
 const BASE = 1_700_000_000_000; // epoch ms 基準（_epochMs が ms として扱える範囲）
@@ -266,9 +266,86 @@ describe("computeObservationWindow — 観測事実の投影（O2-P0 用・解�
   });
 });
 
+describe("computeOfflineWindow（P1-4 完全な純関数・2スナップショットのみ）", () => {
+  const BASE = 1_700_000_000_000;
+  const snap = (over = {}) => ({
+    observationSequence: 1, observedAtEpochMs: BASE, persistedAt: BASE,
+    mountedSpoolId: "S1", mountIntervalId: "iv1", mountIntervalStatus: "ok", observationState: "mounted",
+    printerIdentity: { host: "h", printerType: "k1", model: "K1 Max", completeness: "strong" },
+    generation: { completedCount: 1, earliestCompletedAt: BASE, latestCompletedAt: BASE, retainedHash: "x" },
+    seenObservationKeys: [JSON.stringify(["1000", 0, BASE, "f.gcode"])],
+    retainedRange: { firstCompletedAt: BASE, lastCompletedAt: BASE, truncated: false },
+    retainedObservationCount: 1, totalCompletedCount: 1, truncated: false,
+    ...over
+  });
+
+  it("グローバル状態を読まず、引数のみで決定論的に窓を返す", () => {
+    const prev = snap();
+    const curKeys = prev.seenObservationKeys.concat([JSON.stringify(["1001", 0, BASE + 1000, "g.gcode"])]);
+    const cur = snap({ observationSequence: 2, observedAtEpochMs: BASE + 5000, persistedAt: null,
+      seenObservationKeys: curKeys,
+      generation: { completedCount: 2, earliestCompletedAt: BASE, latestCompletedAt: BASE + 1000, retainedHash: "y" } });
+    const w = computeOfflineWindow(prev, cur, "h");
+    expect(w.bounded).toBe(true);
+    expect(w.offlineObservationKeys).toHaveLength(1);
+    expect(w.windowKind).toBe("bounded");
+    expect(w.stalenessMs).toBe(5000); // curAt - baseAt（wall clock 非依存）
+  });
+
+  it("previous なし＝no-prior / current なし＝incomplete", () => {
+    expect(computeOfflineWindow(null, snap()).windowKind).toBe("no-prior");
+    expect(computeOfflineWindow(snap(), null).windowKind).toBe("incomplete");
+  });
+});
+
+describe("printerIdentity（P1-1 構造化・weak→strong は交換扱いしない）", () => {
+  it("weak→strong の情報補完は identityChanged にしない（同一機で model が後着）", () => {
+    mockMonitorData.hostSpoolMap.h = "S1";
+    setHistory("h", [job("1000", 100)]);
+    // baseline は model 未取得（weak）で確定
+    mockMonitorData.machines.h.storedData = {};
+    recordObservation("h", { mountIntervalStatus: "ok", mountIntervalId: "iv1" });
+    const w0 = computeObservationWindow("h");
+    commitObservationWindow("h", { windowId: w0.windowId, expectedSequence: w0.currentSequence, candidatePersistedAt: 1 });
+    // 復帰後: model が届いた（strong）＋ offline 完了
+    mockMonitorData.machines.h.storedData = { model: { rawValue: "K1 Max" } };
+    setHistory("h", [job("1000", 100), job("1001", 200)]);
+    recordObservation("h", { mountIntervalStatus: "ok", mountIntervalId: "iv1" });
+    const w = computeObservationWindow("h");
+    expect(w.identityChanged).toBe(false);         // 補完であって交換ではない
+    expect(w.reason).toBe("diff-ok");
+  });
+
+  it("strong 同士で model 不一致＝プリンタ交換は identityChanged", () => {
+    mockMonitorData.hostSpoolMap.h = "S1";
+    mockMonitorData.machines.h = { printStore: { history: [job("1000", 100)] }, storedData: { model: { rawValue: "K1 Max" } } };
+    recordObservation("h", { mountIntervalStatus: "ok", mountIntervalId: "iv1" });
+    const w0 = computeObservationWindow("h");
+    commitObservationWindow("h", { windowId: w0.windowId, expectedSequence: w0.currentSequence, candidatePersistedAt: 1 });
+    mockMonitorData.machines.h.storedData = { model: { rawValue: "Ender 3" } }; // 別機種へ本体交換
+    setHistory("h", [job("1000", 100), job("2001", 300)]);
+    recordObservation("h", { mountIntervalStatus: "ok", mountIntervalId: "iv1" });
+    const w = computeObservationWindow("h");
+    expect(w.identityChanged).toBe(true);
+    expect(w.bounded).toBe(false);
+  });
+});
+
+describe("P0-4 連続印刷証拠の記録", () => {
+  it("activeJobId / printState / historyRevision を観測へ保存", () => {
+    mockMonitorData.hostSpoolMap.h = "S1";
+    mockMonitorData.machines.h = { printStore: { history: [job("1000", 100)], current: { id: "1000" }, revision: 7 }, storedData: {} };
+    const snap = recordObservation("h", { mountIntervalStatus: "ok", activeJobId: "1000", printState: 13 });
+    expect(snap.activeJobId).toBe("1000");
+    expect(snap.printState).toBe(13);
+    expect(snap.historyRevision).toBe(7);
+  });
+});
+
 describe("buildConfidence", () => {
-  it("level と reasons を保持、不正 level は none", () => {
-    expect(buildConfidence("high", ["seen-job"])).toEqual({ level: "high", reasons: ["seen-job"] });
-    expect(buildConfidence("bogus")).toEqual({ level: "none", reasons: [] });
+  it("level / reasons / contradictions を保持、不正 level は none", () => {
+    expect(buildConfidence("high", ["seen-job"])).toEqual({ level: "high", reasons: ["seen-job"], contradictions: [] });
+    expect(buildConfidence("none", ["r"], ["c"])).toEqual({ level: "none", reasons: ["r"], contradictions: ["c"] });
+    expect(buildConfidence("bogus")).toEqual({ level: "none", reasons: [], contradictions: [] });
   });
 });

--- a/tests/unit/dashboard_offline_observation.test.js
+++ b/tests/unit/dashboard_offline_observation.test.js
@@ -7,111 +7,161 @@ const mockMonitorData = {
   machines: {},
   hostSpoolMap: {},
   hostObservationWatermark: {},
+  hostObservationCurrent: {},
   appSettings: { connectionTargets: [] },
-  // 安全基盤（read-only であることの確認用に置く）
+  // 安全基盤（read-only 確認用）
   mountHistory: [{ evId: "keep" }],
   pendingUnattributedUsage: [{ pendingUsageId: "keep" }],
 };
 vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mockMonitorData }));
 
-const { recordHostObservation, computeOfflineWindow, buildConfidence } =
+const { recordHostObservation, commitObservationBaseline, computeOfflineWindow, buildConfidence } =
   await import("../../3dp_lib/dashboard_offline_observation.js");
 
-/** 完了ジョブ（printfinish あり）を作る */
+/** 完了ジョブ（id は文字列 canonical key を想定） */
 function job(id, extra = {}) {
   return { id, materialUsedMm: 5000, printfinish: 1, ...extra };
 }
 function setHistory(host, entries) {
-  mockMonitorData.machines[host] = { printStore: { history: entries }, storedData: {} };
+  if (!mockMonitorData.machines[host]) mockMonitorData.machines[host] = { printStore: {}, storedData: {} };
+  mockMonitorData.machines[host].printStore = { history: entries };
 }
 
 beforeEach(() => {
   mockMonitorData.machines = {};
   mockMonitorData.hostSpoolMap = {};
   mockMonitorData.hostObservationWatermark = {};
+  mockMonitorData.hostObservationCurrent = {};
   mockMonitorData.appSettings = { connectionTargets: [] };
   mockMonitorData.mountHistory = [{ evId: "keep" }];
   mockMonitorData.pendingUnattributedUsage = [{ pendingUsageId: "keep" }];
 });
 
-describe("recordHostObservation（read-only 観測）", () => {
-  it("完了ジョブの printId 集合・装着スプールを記録する（未完了は除外）", () => {
-    setHistory("h", [job(1000), job(1001), { id: 1002, materialUsedMm: 3000, printfinish: null }]);
+describe("recordHostObservation（current 更新・baseline 非上書き）", () => {
+  it("完了ジョブ key 集合・装着スプール・observationState を current へ記録", () => {
+    setHistory("h", [job("1000"), job("1001"), { id: "1002", materialUsedMm: 3000, printfinish: null }]);
     mockMonitorData.hostSpoolMap = { h: "S" };
-    const wm = recordHostObservation("h");
-    expect(wm.seenCompletedJobIds).toEqual([1000, 1001]); // 印刷中(1002)は除外
-    expect(wm.mountedSpoolId).toBe("S");
-    expect(wm.historyCount).toBe(2);
-    expect(typeof wm.printerIdentity).toBe("string");
-    // 保存先に入る
-    expect(mockMonitorData.hostObservationWatermark.h.seenCompletedJobIds).toEqual([1000, 1001]);
+    const snap = recordHostObservation("h", { mountIntervalId: "iv1", mountIntervalStatus: "ok" });
+    expect(snap.seenCompletedJobKeys).toEqual(["1000", "1001"]); // 印刷中(1002)除外
+    expect(snap.mountedSpoolId).toBe("S");
+    expect(snap.observationState).toBe("mounted");
+    expect(snap.mountIntervalId).toBe("iv1");       // #411-P0-4 配線
+    expect(snap.mountIntervalStatus).toBe("ok");
+    expect(mockMonitorData.hostObservationCurrent.h.seenCompletedJobKeys).toEqual(["1000", "1001"]);
+    // baseline 未設定だったので bootstrap される（新規導入＝offline無し）
+    expect(mockMonitorData.hostObservationWatermark.h.committedReason).toBe("bootstrap");
   });
 
-  it("旧データ(printfinish欠落だが endtime/usagetime あり)も完了として記録", () => {
-    setHistory("h", [job(1, { printfinish: undefined, endtime: 123 }), job(2, { printfinish: undefined, usagetime: 60 })]);
-    const wm = recordHostObservation("h");
-    expect(wm.seenCompletedJobIds).toEqual([1, 2]);
+  it("P0-3: スプール未装着でも記録し observationState=unmounted", () => {
+    setHistory("h", [job("1")]);
+    mockMonitorData.hostSpoolMap = {}; // 未装着
+    const snap = recordHostObservation("h");
+    expect(snap.observationState).toBe("unmounted");
+    expect(snap.mountedSpoolId).toBeNull();
+  });
+
+  it("P0-1: restore された baseline を起動直後の record が上書きしない", () => {
+    // 停止前 baseline（restore 済み）。printerIdentity は _identity('h')="h||" に一致させる。
+    mockMonitorData.hostObservationWatermark = {
+      h: { seenCompletedJobKeys: ["1000", "1001"], printerIdentity: "h||", historyCount: 2, mountedSpoolId: "S" }
+    };
+    // 再起動後: オフライン完了 1002,1003 が履歴へ出現
+    setHistory("h", [job("1000"), job("1001"), job("1002"), job("1003")]);
+    mockMonitorData.hostSpoolMap = { h: "S" };
+    recordHostObservation("h");
+    // ★ baseline は不変（seen={1000,1001} のまま＝証拠を消さない）
+    expect(mockMonitorData.hostObservationWatermark.h.seenCompletedJobKeys).toEqual(["1000", "1001"]);
+    // current は現在集合
+    expect(mockMonitorData.hostObservationCurrent.h.seenCompletedJobKeys).toEqual(["1000", "1001", "1002", "1003"]);
+    // オフライン窓 = 1002,1003
+    const w = computeOfflineWindow("h");
+    expect(w.bounded).toBe(true);
+    expect(w.offlineJobKeys).toEqual(["1002", "1003"]);
+  });
+
+  it("commitObservationBaseline は評価後に current を baseline へ昇格", () => {
+    mockMonitorData.hostObservationWatermark = { h: { seenCompletedJobKeys: ["1000"], printerIdentity: "h||", historyCount: 1 } };
+    setHistory("h", [job("1000"), job("1001")]);
+    recordHostObservation("h"); // current={1000,1001}, baseline 不変
+    commitObservationBaseline("h", { reason: "window-evaluated" });
+    expect(mockMonitorData.hostObservationWatermark.h.seenCompletedJobKeys).toEqual(["1000", "1001"]);
+    expect(mockMonitorData.hostObservationWatermark.h.committedReason).toBe("window-evaluated");
+    expect(typeof mockMonitorData.hostObservationWatermark.h.persistedAt).toBe("number");
   });
 
   it("安全基盤（mountHistory / pendingUnattributedUsage）に一切触れない（read-only）", () => {
-    setHistory("h", [job(1000)]);
+    setHistory("h", [job("1000")]);
     recordHostObservation("h");
+    commitObservationBaseline("h");
     expect(mockMonitorData.mountHistory).toEqual([{ evId: "keep" }]);
     expect(mockMonitorData.pendingUnattributedUsage).toEqual([{ pendingUsageId: "keep" }]);
   });
-
-  it("host 未指定は null", () => {
-    expect(recordHostObservation()).toBeNull();
-  });
 });
 
-describe("computeOfflineWindow（集合差分）", () => {
-  it("前回観測後に新たに現れた完了ジョブを集合差分で特定", () => {
-    setHistory("h", [job(1000), job(1001)]);
-    recordHostObservation("h"); // 観測: {1000,1001}
-    // アプリ停止中に 1002,1003 が完了して履歴に現れる
-    setHistory("h", [job(1000), job(1001), job(1002), job(1003)]);
+describe("computeOfflineWindow（集合差分＋世代反証）", () => {
+  function baseline(host, keys, extra = {}) {
+    mockMonitorData.hostObservationWatermark[host] = {
+      seenCompletedJobKeys: keys, printerIdentity: "h||", historyCount: keys.length, ...extra
+    };
+  }
+
+  it("集合差分でオフライン新規ジョブを特定", () => {
+    baseline("h", ["1000", "1001"]);
+    setHistory("h", [job("1000"), job("1001"), job("1002")]);
     const w = computeOfflineWindow("h");
     expect(w.bounded).toBe(true);
-    expect(w.offlineJobIds).toEqual([1002, 1003]);
+    expect(w.offlineJobKeys).toEqual(["1002"]);
     expect(w.reason).toBe("diff-ok");
   });
 
-  it("ID 巻き戻り（小さい id 出現）でも last-seen 比較でなく集合差分で拾う", () => {
-    setHistory("h", [job(1000), job(1001)]);
-    recordHostObservation("h");
-    // プリンタ再起動等で小さい id の完了が現れる
-    setHistory("h", [job(5), job(1000), job(1001)]);
-    const w = computeOfflineWindow("h");
-    expect(w.offlineJobIds).toEqual([5]); // id>lastSeen だと拾えないが集合差分なら拾う
-  });
-
-  it("前回観測が無ければ bounded=false（初回導入/移行）", () => {
-    setHistory("h", [job(1000)]);
+  it("前回観測なしは bounded=false", () => {
+    setHistory("h", [job("1000")]);
     const w = computeOfflineWindow("h");
     expect(w.bounded).toBe(false);
     expect(w.reason).toBe("no-prior-observation");
   });
 
-  it("printer identity 変化は bounded=false（同じ窓と断定しない）", () => {
-    setHistory("h", [job(1000)]);
-    mockMonitorData.machines.h.storedData = { model: { rawValue: "A" } };
-    recordHostObservation("h");
-    // identity を変える（モデル変更＝別プリンタ/再セットアップ相当）
-    mockMonitorData.machines.h.storedData = { model: { rawValue: "B" } };
-    mockMonitorData.machines.h.printStore = { history: [job(1000), job(1001)] };
+  it("P0-2: printer identity 変化は bounded=false", () => {
+    baseline("h", ["1000"], { printerIdentity: "h||OLD" });
+    setHistory("h", [job("1000"), job("1001")]);
     const w = computeOfflineWindow("h");
     expect(w.identityChanged).toBe(true);
     expect(w.bounded).toBe(false);
     expect(w.reason).toBe("printer-identity-changed");
   });
+
+  it("P0-2: 履歴 generation 交代（seen の過半が消失）は bounded=false", () => {
+    // 停止前 seen={1000,1001,1002,1003}、現在は別世代（IDが再利用され過半が消失）
+    baseline("h", ["1000", "1001", "1002", "1003"], { historyCount: 4 });
+    setHistory("h", [job("1"), job("2")]); // 現在は別ID・件数も縮小
+    const w = computeOfflineWindow("h");
+    expect(w.generationChanged).toBe(true);
+    expect(w.bounded).toBe(false);
+    // reason は history-generation-changed か history-shrunk（どちらも世代交代）
+    expect(["history-generation-changed", "history-shrunk"]).toContain(w.reason);
+  });
+
+  it("P1-1/P1-2: 重複IDや無効ID('0'/空)を除いた canonical string 集合で差分", () => {
+    baseline("h", ["1000"]);
+    setHistory("h", [job("1000"), job("1000"), job("2000"), job("0"), job("")]);
+    const w = computeOfflineWindow("h");
+    expect(w.offlineJobKeys).toEqual(["2000"]); // 重複1000は1つ、0/空は除外
+  });
+
+  it("stalenessMs を返す（鮮度＝confidence 判断材料）", () => {
+    baseline("h", ["1000"], { persistedAt: 1 });
+    setHistory("h", [job("1000")]);
+    const w = computeOfflineWindow("h");
+    expect(typeof w.stalenessMs).toBe("number");
+    expect(w.stalenessMs).toBeGreaterThan(0);
+  });
 });
 
 describe("buildConfidence（reasons 付き schema）", () => {
   it("level と reasons を保持する", () => {
-    const c = buildConfidence("high", ["seen-job", "continuous-print", "no-spool-change"]);
+    const c = buildConfidence("high", ["seen-job", "continuous-print"]);
     expect(c.level).toBe("high");
-    expect(c.reasons).toEqual(["seen-job", "continuous-print", "no-spool-change"]);
+    expect(c.reasons).toEqual(["seen-job", "continuous-print"]);
   });
   it("不正 level は none、reasons 既定は空", () => {
     expect(buildConfidence("bogus")).toEqual({ level: "none", reasons: [] });

--- a/tests/unit/dashboard_offline_observation.test.js
+++ b/tests/unit/dashboard_offline_observation.test.js
@@ -12,7 +12,7 @@ const mockMonitorData = {
 };
 vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mockMonitorData }));
 
-const { recordObservation, commitObservationWindow, computeObservationWindow, computeOfflineWindow, buildConfidence } =
+const { recordObservation, commitObservationWindow, computeObservationWindow, computeOfflineWindow, observationDue, buildConfidence } =
   await import("../../3dp_lib/dashboard_offline_observation.js");
 
 const BASE = 1_700_000_000_000; // epoch ms 基準（_epochMs が ms として扱える範囲）
@@ -331,10 +331,36 @@ describe("printerIdentity（P1-1 構造化・weak→strong は交換扱いしな
   });
 });
 
+describe("observationDue（P0-1 signature 判定・純関数）", () => {
+  const facts = (over = {}) => ({ historyRevision: 5, activeJobId: "1000", printState: 13, mountedSpoolId: "S1", mountIntervalStatus: "ok", mountIntervalId: "iv1", ...over });
+
+  it("初回（prev なし）は必ず記録", () => {
+    expect(observationDue(null, facts(), { nowMs: 1000 }).record).toBe(true);
+  });
+  it("★ _historyRev だけ変化したら 5s 未満でも即記録", () => {
+    const { signature } = observationDue(null, facts(), { nowMs: 1000 });
+    const due = observationDue({ lastAtMs: 1000, signature }, facts({ historyRevision: 6 }), { nowMs: 1200 });
+    expect(due.record).toBe(true);
+  });
+  it("★ 同一 spool・status=ok のまま intervalId だけ変化したら 5s 未満でも即記録", () => {
+    const { signature } = observationDue(null, facts(), { nowMs: 1000 });
+    const due = observationDue({ lastAtMs: 1000, signature }, facts({ mountIntervalId: "iv2" }), { nowMs: 1200 });
+    expect(due.record).toBe(true);
+  });
+  it("signature 不変かつ 5s 未満なら記録しない", () => {
+    const { signature } = observationDue(null, facts(), { nowMs: 1000 });
+    expect(observationDue({ lastAtMs: 1000, signature }, facts(), { nowMs: 1200 }).record).toBe(false);
+  });
+  it("signature 不変でも 5s 超過（heartbeat）なら記録", () => {
+    const { signature } = observationDue(null, facts(), { nowMs: 1000 });
+    expect(observationDue({ lastAtMs: 1000, signature }, facts(), { nowMs: 7000 }).record).toBe(true);
+  });
+});
+
 describe("P0-4 連続印刷証拠の記録", () => {
   it("activeJobId / printState / historyRevision を観測へ保存", () => {
     mockMonitorData.hostSpoolMap.h = "S1";
-    mockMonitorData.machines.h = { printStore: { history: [job("1000", 100)], current: { id: "1000" }, revision: 7 }, storedData: {} };
+    mockMonitorData.machines.h = { printStore: { history: [job("1000", 100)], current: { id: "1000" }, _historyRev: 7 }, storedData: {} };
     const snap = recordObservation("h", { mountIntervalStatus: "ok", activeJobId: "1000", printState: 13 });
     expect(snap.activeJobId).toBe("1000");
     expect(snap.printState).toBe(13);

--- a/tests/unit/dashboard_offline_observation.test.js
+++ b/tests/unit/dashboard_offline_observation.test.js
@@ -3,9 +3,9 @@
  * record / computeObservationWindow / commitObservationWindow の read-only 契約と
  * 5000件切詰め境界・候補単位の識別判定・fail-closed commit を検証する。
  *
- * @version 1.390.1246 (PR #411)
+ * @version 1.390.1247 (PR #411)
  * @since   2.3.0
- * @lastModified 2026-07-23 09:57:05
+ * @lastModified 2026-07-23 15:21:14
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
@@ -117,6 +117,29 @@ describe("computeObservationWindow — 5000件切詰め境界（P0-1・実運用
     const w = computeOfflineWindow(previous, current); // sessionId 未指定=fresh
     expect(w.offlineObservationKeys).toEqual([]);      // 誤 offline を出さない
     expect(w.bounded).toBe(false);                     // 境界不確定は fail-closed
+    expect(w.reason).toBe("history-truncated-unverifiable");
+  });
+
+  it("★codex-P1: truncated baselineで古い脱落履歴にfinishTimeが後付けされてもofflineへ再流入させない", () => {
+    const key = (id, finishAt) => JSON.stringify([String(id), 0, finishAt || 0, `f${id}.gcode`]);
+    const firstAt = BASE + 1001 * 1000;
+    const lastAt = BASE + 6000 * 1000;
+    const baselineKeys = []; for (let i = 1001; i <= 6000; i++) baselineKeys.push(key(i, BASE + i * 1000));
+    const currentKeys = [];
+    for (let i = 1; i <= 1000; i++) currentKeys.push(key(i, firstAt + i * 1000)); // 境界内へ後付けされた古い履歴
+    for (let i = 1001; i <= 6000; i++) currentKeys.push(key(i, BASE + i * 1000));
+    const previous = {
+      observationSequence: 1, observedAtEpochMs: BASE, persistedAt: BASE,
+      seenObservationKeys: baselineKeys, retainedObservationCount: 5000, totalCompletedCount: 6000, truncated: true,
+      retainedRange: { firstCompletedAt: firstAt, lastCompletedAt: lastAt, truncated: true },
+      generation: { latestCompletedAt: lastAt }, printerIdentity: { model: "K1", completeness: "strong" },
+      mountedSpoolId: "S1", observationState: "mounted", mountIntervalStatus: "ok"
+    };
+    const current = { ...previous, observationSequence: 2, seenObservationKeys: currentKeys, totalCompletedCount: 6000 };
+    const w = computeOfflineWindow(previous, current);
+    expect(w.offlineObservationKeys).toEqual([]);
+    expect(w.bounded).toBe(false);
+    expect(w.windowKind).toBe("insufficient");
     expect(w.reason).toBe("history-truncated-unverifiable");
   });
 

--- a/tests/unit/dashboard_offline_observation.test.js
+++ b/tests/unit/dashboard_offline_observation.test.js
@@ -220,6 +220,22 @@ describe("commitObservationWindow — fail-closed transaction（P0-3）", () => 
     expect(r.ok).toBe(false);
     expect(r.reason).toBe("observation_changed_since_evaluation");
   });
+
+  it("★P1-A: 旧セッションの current（sequence一致でも）は baseline へ昇格しない", () => {
+    const w = prep();
+    // candidate 永続化後・baseline 昇格前にクラッシュ→旧 current を復元した状況を模す
+    mockMonitorData.hostObservationCurrent.h = { ...mockMonitorData.hostObservationCurrent.h, appSessionId: "old-session" };
+    const r = commitObservationWindow("h", { windowId: "wS", expectedSequence: w.currentSequence, candidatePersistedAt: 1 });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("current_observation_stale");
+  });
+
+  it("★P1-A: expectedAppSessionId 不一致は昇格しない（transaction 境界）", () => {
+    const w = prep();
+    const r = commitObservationWindow("h", { windowId: "wT", expectedSequence: w.currentSequence, candidatePersistedAt: 1, expectedAppSessionId: "some-other" });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("app_session_changed_since_evaluation");
+  });
 });
 
 describe("computeObservationWindow — 観測事実の投影（O2-P0 用・解釈しない）", () => {
@@ -357,7 +373,7 @@ describe("observationDue（P0-1 signature 判定・純関数）", () => {
   });
 });
 
-describe("P0-4 連続印刷証拠の記録", () => {
+describe("P0-4 / P1-B 連続印刷証拠の記録", () => {
   it("activeJobId / printState / historyRevision を観測へ保存", () => {
     mockMonitorData.hostSpoolMap.h = "S1";
     mockMonitorData.machines.h = { printStore: { history: [job("1000", 100)], current: { id: "1000" }, _historyRev: 7 }, storedData: {} };
@@ -365,6 +381,18 @@ describe("P0-4 連続印刷証拠の記録", () => {
     expect(snap.activeJobId).toBe("1000");
     expect(snap.printState).toBe(13);
     expect(snap.historyRevision).toBe(7);
+  });
+
+  it("★P1-B: activePrinting のときだけ activeJobObservation（複合 identity）を保存", () => {
+    mockMonitorData.hostSpoolMap.h = "S1";
+    const current = { id: "1000", printStartTime: BASE, filename: "a.gcode" };
+    mockMonitorData.machines.h = { printStore: { history: [job("1000", 100)], current, _historyRev: 3 }, storedData: {} };
+    // 印刷中
+    const printing = recordObservation("h", { mountIntervalStatus: "ok", activePrinting: true });
+    expect(printing.activeJobObservation).toMatchObject({ canonicalJobId: "1000", startAt: BASE, fileSignature: "a.gcode" });
+    // idle（activePrinting=false）は null＝high の根拠にしない
+    const idle = recordObservation("h", { mountIntervalStatus: "ok", activePrinting: false });
+    expect(idle.activeJobObservation).toBeNull();
   });
 });
 

--- a/tests/unit/dashboard_offline_observation.test.js
+++ b/tests/unit/dashboard_offline_observation.test.js
@@ -222,6 +222,50 @@ describe("commitObservationWindow — fail-closed transaction（P0-3）", () => 
   });
 });
 
+describe("computeObservationWindow — 観測事実の投影（O2-P0 用・解釈しない）", () => {
+  it("baselineMount / currentMount / hasCurrentObservation / windowKind を返す", () => {
+    mockMonitorData.hostSpoolMap.h = "S1";
+    setHistory("h", [job("1000", 100)]);
+    recordObservation("h", { mountIntervalStatus: "ok", mountIntervalId: "iv1" });
+    const w0 = computeObservationWindow("h");
+    commitObservationWindow("h", { windowId: w0.windowId, expectedSequence: w0.currentSequence, candidatePersistedAt: 1 });
+    setHistory("h", [job("1000", 100), job("1001", 200)]);
+    recordObservation("h", { mountIntervalStatus: "ok", mountIntervalId: "iv1" });
+    const w = computeObservationWindow("h");
+    expect(w.hasCurrentObservation).toBe(true);
+    expect(w.windowKind).toBe("bounded");
+    expect(w.baselineMount).toMatchObject({ spoolId: "S1", intervalId: "iv1", intervalStatus: "ok", observationState: "mounted" });
+    expect(w.currentMount).toMatchObject({ spoolId: "S1", observationState: "mounted" });
+  });
+
+  it("baseline はあるが current 未観測なら hasCurrentObservation=false / windowKind=incomplete", () => {
+    mockMonitorData.hostObservationWatermark = { h: {
+      seenObservationKeys: [], observationSequence: 3, printerIdentity: "h||", generation: {},
+      retainedRange: {}, mountedSpoolId: "S1", observationState: "mounted", persistedAt: 1
+    } };
+    // hostObservationCurrent.h は未設定
+    setHistory("h", [job("1", 100)]);
+    const w = computeObservationWindow("h");
+    expect(w.hasCurrentObservation).toBe(false);
+    expect(w.windowKind).toBe("incomplete");
+    expect(w.baselineMount.spoolId).toBe("S1");
+  });
+
+  it("current が別スプールでも観測事実として反映する（分類はしない）", () => {
+    mockMonitorData.hostSpoolMap.h = "S1";
+    setHistory("h", [job("1000", 100)]);
+    recordObservation("h", { mountIntervalStatus: "ok", mountIntervalId: "iv1" });
+    const w0 = computeObservationWindow("h");
+    commitObservationWindow("h", { windowId: w0.windowId, expectedSequence: w0.currentSequence, candidatePersistedAt: 1 });
+    mockMonitorData.hostSpoolMap.h = "S2"; // 復帰後に別スプール
+    setHistory("h", [job("1000", 100), job("1001", 200)]);
+    recordObservation("h", { mountIntervalStatus: "ok", mountIntervalId: "iv9" });
+    const w = computeObservationWindow("h");
+    expect(w.baselineMount.spoolId).toBe("S1");
+    expect(w.currentMount.spoolId).toBe("S2");
+  });
+});
+
 describe("buildConfidence", () => {
   it("level と reasons を保持、不正 level は none", () => {
     expect(buildConfidence("high", ["seen-job"])).toEqual({ level: "high", reasons: ["seen-job"] });

--- a/tests/unit/dashboard_offline_observation.test.js
+++ b/tests/unit/dashboard_offline_observation.test.js
@@ -4,23 +4,22 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 const mockMonitorData = {
-  machines: {},
-  hostSpoolMap: {},
-  hostObservationWatermark: {},
-  hostObservationCurrent: {},
+  machines: {}, hostSpoolMap: {}, hostObservationWatermark: {}, hostObservationCurrent: {},
   appSettings: { connectionTargets: [] },
-  // 安全基盤（read-only 確認用）
-  mountHistory: [{ evId: "keep" }],
-  pendingUnattributedUsage: [{ pendingUsageId: "keep" }],
+  mountHistory: [{ evId: "keep" }], pendingUnattributedUsage: [{ pendingUsageId: "keep" }],
 };
 vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mockMonitorData }));
 
 const { recordHostObservation, commitObservationBaseline, computeOfflineWindow, buildConfidence } =
   await import("../../3dp_lib/dashboard_offline_observation.js");
 
-/** 完了ジョブ（id は文字列 canonical key を想定） */
-function job(id, extra = {}) {
-  return { id, materialUsedMm: 5000, printfinish: 1, ...extra };
+/** 完了ジョブ（finishTime＋filename で識別材料あり）。 */
+function job(id, finishAt, extra = {}) {
+  return { id, materialUsedMm: 5000, printfinish: 1, finishTime: finishAt, filename: `f${id}.gcode`, ...extra };
+}
+/** 識別材料の無い完了ジョブ（id のみ）。 */
+function bareJob(id) {
+  return { id, materialUsedMm: 5000, printfinish: 1 };
 }
 function setHistory(host, entries) {
   if (!mockMonitorData.machines[host]) mockMonitorData.machines[host] = { printStore: {}, storedData: {} };
@@ -37,133 +36,114 @@ beforeEach(() => {
   mockMonitorData.pendingUnattributedUsage = [{ pendingUsageId: "keep" }];
 });
 
-describe("recordHostObservation（current 更新・baseline 非上書き）", () => {
-  it("完了ジョブ key 集合・装着スプール・observationState を current へ記録", () => {
-    setHistory("h", [job("1000"), job("1001"), { id: "1002", materialUsedMm: 3000, printfinish: null }]);
-    mockMonitorData.hostSpoolMap = { h: "S" };
-    const snap = recordHostObservation("h", { mountIntervalId: "iv1", mountIntervalStatus: "ok" });
-    expect(snap.seenCompletedJobKeys).toEqual(["1000", "1001"]); // 印刷中(1002)除外
-    expect(snap.mountedSpoolId).toBe("S");
-    expect(snap.observationState).toBe("mounted");
-    expect(snap.mountIntervalId).toBe("iv1");       // #411-P0-4 配線
-    expect(snap.mountIntervalStatus).toBe("ok");
-    expect(mockMonitorData.hostObservationCurrent.h.seenCompletedJobKeys).toEqual(["1000", "1001"]);
-    // baseline 未設定だったので bootstrap される（新規導入＝offline無し）
-    expect(mockMonitorData.hostObservationWatermark.h.committedReason).toBe("bootstrap");
-  });
-
-  it("P0-3: スプール未装着でも記録し observationState=unmounted", () => {
-    setHistory("h", [job("1")]);
-    mockMonitorData.hostSpoolMap = {}; // 未装着
-    const snap = recordHostObservation("h");
+describe("record / commit / baseline 非上書き", () => {
+  it("P0-3: 未装着は observationState=unmounted、read-only（安全基盤不変）", () => {
+    setHistory("h", [job("1", 100)]);
+    const snap = recordHostObservation("h", { mountIntervalStatus: "none" });
     expect(snap.observationState).toBe("unmounted");
-    expect(snap.mountedSpoolId).toBeNull();
-  });
-
-  it("P0-1: restore された baseline を起動直後の record が上書きしない", () => {
-    // 停止前 baseline（restore 済み）。printerIdentity は _identity('h')="h||" に一致させる。
-    mockMonitorData.hostObservationWatermark = {
-      h: { seenCompletedJobKeys: ["1000", "1001"], printerIdentity: "h||", historyCount: 2, mountedSpoolId: "S" }
-    };
-    // 再起動後: オフライン完了 1002,1003 が履歴へ出現
-    setHistory("h", [job("1000"), job("1001"), job("1002"), job("1003")]);
-    mockMonitorData.hostSpoolMap = { h: "S" };
-    recordHostObservation("h");
-    // ★ baseline は不変（seen={1000,1001} のまま＝証拠を消さない）
-    expect(mockMonitorData.hostObservationWatermark.h.seenCompletedJobKeys).toEqual(["1000", "1001"]);
-    // current は現在集合
-    expect(mockMonitorData.hostObservationCurrent.h.seenCompletedJobKeys).toEqual(["1000", "1001", "1002", "1003"]);
-    // オフライン窓 = 1002,1003
-    const w = computeOfflineWindow("h");
-    expect(w.bounded).toBe(true);
-    expect(w.offlineJobKeys).toEqual(["1002", "1003"]);
-  });
-
-  it("commitObservationBaseline は評価後に current を baseline へ昇格", () => {
-    mockMonitorData.hostObservationWatermark = { h: { seenCompletedJobKeys: ["1000"], printerIdentity: "h||", historyCount: 1 } };
-    setHistory("h", [job("1000"), job("1001")]);
-    recordHostObservation("h"); // current={1000,1001}, baseline 不変
-    commitObservationBaseline("h", { reason: "window-evaluated" });
-    expect(mockMonitorData.hostObservationWatermark.h.seenCompletedJobKeys).toEqual(["1000", "1001"]);
-    expect(mockMonitorData.hostObservationWatermark.h.committedReason).toBe("window-evaluated");
-    expect(typeof mockMonitorData.hostObservationWatermark.h.persistedAt).toBe("number");
-  });
-
-  it("安全基盤（mountHistory / pendingUnattributedUsage）に一切触れない（read-only）", () => {
-    setHistory("h", [job("1000")]);
-    recordHostObservation("h");
-    commitObservationBaseline("h");
+    expect(snap.mountIntervalStatus).toBe("none");
     expect(mockMonitorData.mountHistory).toEqual([{ evId: "keep" }]);
     expect(mockMonitorData.pendingUnattributedUsage).toEqual([{ pendingUsageId: "keep" }]);
   });
-});
 
-describe("computeOfflineWindow（集合差分＋世代反証）", () => {
-  function baseline(host, keys, extra = {}) {
-    mockMonitorData.hostObservationWatermark[host] = {
-      seenCompletedJobKeys: keys, printerIdentity: "h||", historyCount: keys.length, ...extra
-    };
-  }
-
-  it("集合差分でオフライン新規ジョブを特定", () => {
-    baseline("h", ["1000", "1001"]);
-    setHistory("h", [job("1000"), job("1001"), job("1002")]);
+  it("P0-1: restore された baseline を起動直後の record が上書きしない", () => {
+    setHistory("h", [job("1000", 100), job("1001", 200)]);
+    recordHostObservation("h");                       // bootstrap baseline = {1000,1001}
+    commitObservationBaseline("h", { windowId: "w1" });
+    const baseKeys = mockMonitorData.hostObservationWatermark.h.seenObservationKeys.slice();
+    // 「再起動後」: オフライン完了が出現
+    setHistory("h", [job("1000", 100), job("1001", 200), job("1002", 300), job("1003", 400)]);
+    recordHostObservation("h");                       // current 更新・baseline 不変
+    expect(mockMonitorData.hostObservationWatermark.h.seenObservationKeys).toEqual(baseKeys);
     const w = computeOfflineWindow("h");
     expect(w.bounded).toBe(true);
-    expect(w.offlineJobKeys).toEqual(["1002"]);
+    expect(w.offlineJobKeys).toHaveLength(2);         // 1002,1003（複合キー）
+    expect(w.offlineJobKeys.every(k => k.includes("100"))).toBe(true);
+  });
+
+  it("commit は windowId 冪等（同一 windowId で二重昇格しない）", () => {
+    setHistory("h", [job("1000", 100)]);
+    recordHostObservation("h");
+    setHistory("h", [job("1000", 100), job("1001", 200)]);
+    recordHostObservation("h");
+    const first = commitObservationBaseline("h", { windowId: "w1" });
+    const firstKeys = first.seenObservationKeys.slice();
+    // current をさらに進めても、同一 windowId の再 commit は no-op
+    setHistory("h", [job("1000", 100), job("1001", 200), job("1002", 300)]);
+    recordHostObservation("h");
+    const second = commitObservationBaseline("h", { windowId: "w1" });
+    expect(second.seenObservationKeys).toEqual(firstKeys); // 昇格されない
+  });
+
+  it("P1-3: observationSequence は再起動で 1 へ戻らず継続採番", () => {
+    // baseline に seq=7 が復元された状態を模す
+    mockMonitorData.hostObservationWatermark = { h: { seenObservationKeys: [], observationSequence: 7, printerIdentity: "h||", generation: {} } };
+    setHistory("h", [job("1", 100)]);
+    const snap = recordHostObservation("h");
+    expect(snap.observationSequence).toBe(8); // max(7,...)+1
+  });
+});
+
+describe("computeOfflineWindow — 同一実行識別と世代反証", () => {
+  function commitBaseline(host, entries, windowId = "w") {
+    setHistory(host, entries);
+    recordHostObservation(host);
+    return commitObservationBaseline(host, { windowId });
+  }
+
+  it("P0-1: ID 再利用（同id・別完了時刻）を見失わず offline に出す/世代反証で bounded=false", () => {
+    commitBaseline("h", [job("1", 100), job("2", 200), job("3", 300)]);
+    // プリンタ再起動で id 1,2 が別の物理印刷（別 finishTime）として再利用され、履歴が置換される
+    setHistory("h", [job("1", 500), job("2", 600), job("3", 300)]);
+    const w = computeOfflineWindow("h");
+    // 複合キーが変わるので新実行は offline に現れる（= 見失わない）
+    expect(w.offlineJobKeys.length).toBeGreaterThan(0);
+    // 旧複合キーの過半が消えるため世代交代として bounded=false（安全側）
+    expect(w.bounded).toBe(false);
+  });
+
+  it("P0-2: latest completion の巻き戻りは history-time-rollback で bounded=false", () => {
+    commitBaseline("h", [job("1000", 300)]);
+    setHistory("h", [job("2000", 100)]); // 別世代・最新完了が過去へ
+    const w = computeOfflineWindow("h");
+    expect(w.bounded).toBe(false);
+    expect(w.reason).toBe("history-time-rollback");
+  });
+
+  it("P0-1: 識別材料不足（id のみ）は job-identity-insufficient で bounded=false", () => {
+    commitBaseline("h", [bareJob("1"), bareJob("2")]);
+    setHistory("h", [bareJob("1"), bareJob("2"), bareJob("3")]);
+    const w = computeOfflineWindow("h");
+    expect(w.bounded).toBe(false);
+    expect(w.reason).toBe("job-identity-insufficient");
+  });
+
+  it("正常系: 識別十分・世代連続なら diff-ok で bounded=true", () => {
+    commitBaseline("h", [job("1000", 100), job("1001", 200)]);
+    setHistory("h", [job("1000", 100), job("1001", 200), job("1002", 300)]);
+    const w = computeOfflineWindow("h");
+    expect(w.bounded).toBe(true);
     expect(w.reason).toBe("diff-ok");
+    expect(w.offlineJobKeys).toHaveLength(1);
   });
 
   it("前回観測なしは bounded=false", () => {
-    setHistory("h", [job("1000")]);
-    const w = computeOfflineWindow("h");
-    expect(w.bounded).toBe(false);
-    expect(w.reason).toBe("no-prior-observation");
+    setHistory("h", [job("1", 100)]);
+    expect(computeOfflineWindow("h").reason).toBe("no-prior-observation");
   });
 
-  it("P0-2: printer identity 変化は bounded=false", () => {
-    baseline("h", ["1000"], { printerIdentity: "h||OLD" });
-    setHistory("h", [job("1000"), job("1001")]);
-    const w = computeOfflineWindow("h");
-    expect(w.identityChanged).toBe(true);
-    expect(w.bounded).toBe(false);
-    expect(w.reason).toBe("printer-identity-changed");
-  });
-
-  it("P0-2: 履歴 generation 交代（seen の過半が消失）は bounded=false", () => {
-    // 停止前 seen={1000,1001,1002,1003}、現在は別世代（IDが再利用され過半が消失）
-    baseline("h", ["1000", "1001", "1002", "1003"], { historyCount: 4 });
-    setHistory("h", [job("1"), job("2")]); // 現在は別ID・件数も縮小
-    const w = computeOfflineWindow("h");
-    expect(w.generationChanged).toBe(true);
-    expect(w.bounded).toBe(false);
-    // reason は history-generation-changed か history-shrunk（どちらも世代交代）
-    expect(["history-generation-changed", "history-shrunk"]).toContain(w.reason);
-  });
-
-  it("P1-1/P1-2: 重複IDや無効ID('0'/空)を除いた canonical string 集合で差分", () => {
-    baseline("h", ["1000"]);
-    setHistory("h", [job("1000"), job("1000"), job("2000"), job("0"), job("")]);
-    const w = computeOfflineWindow("h");
-    expect(w.offlineJobKeys).toEqual(["2000"]); // 重複1000は1つ、0/空は除外
-  });
-
-  it("stalenessMs を返す（鮮度＝confidence 判断材料）", () => {
-    baseline("h", ["1000"], { persistedAt: 1 });
-    setHistory("h", [job("1000")]);
+  it("stalenessMs を返す（鮮度）", () => {
+    mockMonitorData.hostObservationWatermark = { h: { seenObservationKeys: [], printerIdentity: "h||", persistedAt: 1, generation: {}, retainedObservationCount: 0 } };
+    setHistory("h", [job("1", 100)]);
     const w = computeOfflineWindow("h");
     expect(typeof w.stalenessMs).toBe("number");
     expect(w.stalenessMs).toBeGreaterThan(0);
   });
 });
 
-describe("buildConfidence（reasons 付き schema）", () => {
-  it("level と reasons を保持する", () => {
-    const c = buildConfidence("high", ["seen-job", "continuous-print"]);
-    expect(c.level).toBe("high");
-    expect(c.reasons).toEqual(["seen-job", "continuous-print"]);
-  });
-  it("不正 level は none、reasons 既定は空", () => {
+describe("buildConfidence", () => {
+  it("level と reasons を保持、不正 level は none", () => {
+    expect(buildConfidence("high", ["seen-job"])).toEqual({ level: "high", reasons: ["seen-job"] });
     expect(buildConfidence("bogus")).toEqual({ level: "none", reasons: [] });
   });
 });

--- a/tests/unit/dashboard_offline_observation.test.js
+++ b/tests/unit/dashboard_offline_observation.test.js
@@ -1,5 +1,7 @@
 /**
- * @fileoverview dashboard_offline_observation.js（#411-O1 観測 watermark）の単体テスト
+ * @fileoverview dashboard_offline_observation.js（#411-O1 観測レイヤ）の単体テスト
+ * record / computeObservationWindow / commitObservationWindow の read-only 契約と
+ * 5000件切詰め境界・候補単位の識別判定・fail-closed commit を検証する。
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
@@ -10,20 +12,30 @@ const mockMonitorData = {
 };
 vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mockMonitorData }));
 
-const { recordHostObservation, commitObservationBaseline, computeOfflineWindow, buildConfidence } =
+const { recordObservation, commitObservationWindow, computeObservationWindow, buildConfidence } =
   await import("../../3dp_lib/dashboard_offline_observation.js");
 
-/** 完了ジョブ（finishTime＋filename で識別材料あり）。 */
-function job(id, finishAt, extra = {}) {
-  return { id, materialUsedMm: 5000, printfinish: 1, finishTime: finishAt, filename: `f${id}.gcode`, ...extra };
+const BASE = 1_700_000_000_000; // epoch ms 基準（_epochMs が ms として扱える範囲）
+/** 完了ジョブ（finishTime＋filename で識別材料あり）。t は基準からの相対秒。 */
+function job(id, t, extra = {}) {
+  return { id, materialUsedMm: 5000, printfinish: 1, finishTime: BASE + t * 1000, filename: `f${id}.gcode`, ...extra };
 }
-/** 識別材料の無い完了ジョブ（id のみ）。 */
+/** 識別材料の無い完了ジョブ（id のみ・時刻/ファイルなし）。 */
 function bareJob(id) {
   return { id, materialUsedMm: 5000, printfinish: 1 };
 }
 function setHistory(host, entries) {
   if (!mockMonitorData.machines[host]) mockMonitorData.machines[host] = { printStore: {}, storedData: {} };
   mockMonitorData.machines[host].printStore = { history: entries };
+}
+/** record→compute→commit の一連（baseline 昇格）を実行して window を返す。 */
+function commitBaseline(host, entries, tag) {
+  setHistory(host, entries);
+  recordObservation(host);
+  const w = computeObservationWindow(host);
+  const wid = tag || w.windowId;
+  commitObservationWindow(host, { windowId: wid, expectedSequence: w.currentSequence, candidatePersistedAt: 1 });
+  return w;
 }
 
 beforeEach(() => {
@@ -37,107 +49,176 @@ beforeEach(() => {
 });
 
 describe("record / commit / baseline 非上書き", () => {
-  it("P0-3: 未装着は observationState=unmounted、read-only（安全基盤不変）", () => {
+  it("read-only: 未装着は observationState=unmounted、安全基盤は不変", () => {
     setHistory("h", [job("1", 100)]);
-    const snap = recordHostObservation("h", { mountIntervalStatus: "none" });
+    const snap = recordObservation("h", { mountIntervalStatus: "none" });
     expect(snap.observationState).toBe("unmounted");
     expect(snap.mountIntervalStatus).toBe("none");
     expect(mockMonitorData.mountHistory).toEqual([{ evId: "keep" }]);
     expect(mockMonitorData.pendingUnattributedUsage).toEqual([{ pendingUsageId: "keep" }]);
   });
 
-  it("P0-1: restore された baseline を起動直後の record が上書きしない", () => {
-    setHistory("h", [job("1000", 100), job("1001", 200)]);
-    recordHostObservation("h");                       // bootstrap baseline = {1000,1001}
-    commitObservationBaseline("h", { windowId: "w1" });
+  it("起動直後の record は復元済み baseline を上書きしない（current のみ更新）", () => {
+    commitBaseline("h", [job("1000", 100), job("1001", 200)]);
     const baseKeys = mockMonitorData.hostObservationWatermark.h.seenObservationKeys.slice();
     // 「再起動後」: オフライン完了が出現
     setHistory("h", [job("1000", 100), job("1001", 200), job("1002", 300), job("1003", 400)]);
-    recordHostObservation("h");                       // current 更新・baseline 不変
+    recordObservation("h"); // current 更新・baseline 不変
     expect(mockMonitorData.hostObservationWatermark.h.seenObservationKeys).toEqual(baseKeys);
-    const w = computeOfflineWindow("h");
+    const w = computeObservationWindow("h");
     expect(w.bounded).toBe(true);
-    expect(w.offlineJobKeys).toHaveLength(2);         // 1002,1003（複合キー）
-    expect(w.offlineJobKeys.every(k => k.includes("100"))).toBe(true);
+    expect(w.offlineObservationKeys).toHaveLength(2); // 1002,1003
+    expect(w.reason).toBe("diff-ok");
   });
 
-  it("commit は windowId 冪等（同一 windowId で二重昇格しない）", () => {
-    setHistory("h", [job("1000", 100)]);
-    recordHostObservation("h");
-    setHistory("h", [job("1000", 100), job("1001", 200)]);
-    recordHostObservation("h");
-    const first = commitObservationBaseline("h", { windowId: "w1" });
-    const firstKeys = first.seenObservationKeys.slice();
-    // current をさらに進めても、同一 windowId の再 commit は no-op
-    setHistory("h", [job("1000", 100), job("1001", 200), job("1002", 300)]);
-    recordHostObservation("h");
-    const second = commitObservationBaseline("h", { windowId: "w1" });
-    expect(second.seenObservationKeys).toEqual(firstKeys); // 昇格されない
-  });
-
-  it("P1-3: observationSequence は再起動で 1 へ戻らず継続採番", () => {
-    // baseline に seq=7 が復元された状態を模す
+  it("observationSequence は再起動で 1 へ戻らず継続採番", () => {
     mockMonitorData.hostObservationWatermark = { h: { seenObservationKeys: [], observationSequence: 7, printerIdentity: "h||", generation: {} } };
     setHistory("h", [job("1", 100)]);
-    const snap = recordHostObservation("h");
-    expect(snap.observationSequence).toBe(8); // max(7,...)+1
+    const snap = recordObservation("h");
+    expect(snap.observationSequence).toBe(8); // max(7,0)+1
   });
 });
 
-describe("computeOfflineWindow — 同一実行識別と世代反証", () => {
-  function commitBaseline(host, entries, windowId = "w") {
-    setHistory(host, entries);
-    recordHostObservation(host);
-    return commitObservationBaseline(host, { windowId });
+describe("computeObservationWindow — 5000件切詰め境界（P0-1・実運用の主要被害）", () => {
+  function bulk(n, offset = 0) {
+    const arr = [];
+    for (let i = 1; i <= n; i++) arr.push(job(String(offset + i), i));
+    return arr;
   }
 
-  it("P0-1: ID 再利用（同id・別完了時刻）を見失わず offline に出す/世代反証で bounded=false", () => {
-    commitBaseline("h", [job("1", 100), job("2", 200), job("3", 300)]);
-    // プリンタ再起動で id 1,2 が別の物理印刷（別 finishTime）として再利用され、履歴が置換される
-    setHistory("h", [job("1", 500), job("2", 600), job("3", 300)]);
-    const w = computeOfflineWindow("h");
-    // 複合キーが変わるので新実行は offline に現れる（= 見失わない）
-    expect(w.offlineJobKeys.length).toBeGreaterThan(0);
-    // 旧複合キーの過半が消えるため世代交代として bounded=false（安全側）
-    expect(w.bounded).toBe(false);
+  it("6000件履歴・追加なし → offline は空（捨てた古い5000件超を false offline にしない）", () => {
+    const hist = bulk(6000);
+    commitBaseline("h", hist);
+    setHistory("h", hist); // 同一履歴を再観測
+    recordObservation("h");
+    const w = computeObservationWindow("h");
+    expect(w.truncated).toBe(true);
+    expect(w.offlineObservationKeys).toEqual([]);
+    expect(w.bounded).toBe(true);
   });
 
-  it("P0-2: latest completion の巻き戻りは history-time-rollback で bounded=false", () => {
+  it("6000件履歴＋新規2件 → offline は新規2件のみ（切詰めた古い分は混入しない）", () => {
+    const hist = bulk(6000);
+    commitBaseline("h", hist);
+    const grown = hist.concat([job("6001", 6001), job("6002", 6002)]);
+    setHistory("h", grown);
+    recordObservation("h");
+    const w = computeObservationWindow("h");
+    expect(w.offlineObservationKeys).toHaveLength(2);
+    expect(w.bounded).toBe(true);
+    expect(w.reason).toBe("diff-ok");
+  });
+});
+
+describe("computeObservationWindow — 同一実行識別と世代反証", () => {
+  it("ID 再利用（同id・別完了時刻・別ファイル）は見失わず offline に出る／世代反証で bounded=false", () => {
+    commitBaseline("h", [job("1", 100), job("2", 200), job("3", 300)]);
+    // 再起動で id 1,2 が別物理印刷（別 finishTime/別 file）として再利用され履歴置換
+    setHistory("h", [job("1", 500, { filename: "x.gcode" }), job("2", 600, { filename: "y.gcode" }), job("3", 300)]);
+    recordObservation("h");
+    const w = computeObservationWindow("h");
+    expect(w.offlineObservationKeys.length).toBeGreaterThan(0); // 見失わない
+    expect(w.bounded).toBe(false);                              // 過半消失＝世代交代
+  });
+
+  it("latest completion の巻き戻りは history-time-rollback で bounded=false", () => {
     commitBaseline("h", [job("1000", 300)]);
     setHistory("h", [job("2000", 100)]); // 別世代・最新完了が過去へ
-    const w = computeOfflineWindow("h");
+    recordObservation("h");
+    const w = computeObservationWindow("h");
     expect(w.bounded).toBe(false);
     expect(w.reason).toBe("history-time-rollback");
   });
 
-  it("P0-1: 識別材料不足（id のみ）は job-identity-insufficient で bounded=false", () => {
+  it("識別材料不足（id のみ・新規）は job-identity-insufficient で bounded=false、unresolvedJobIds に載る", () => {
     commitBaseline("h", [bareJob("1"), bareJob("2")]);
     setHistory("h", [bareJob("1"), bareJob("2"), bareJob("3")]);
-    const w = computeOfflineWindow("h");
+    recordObservation("h");
+    const w = computeObservationWindow("h");
     expect(w.bounded).toBe(false);
     expect(w.reason).toBe("job-identity-insufficient");
+    expect(w.unresolvedJobIds).toContain("3");
   });
 
   it("正常系: 識別十分・世代連続なら diff-ok で bounded=true", () => {
     commitBaseline("h", [job("1000", 100), job("1001", 200)]);
     setHistory("h", [job("1000", 100), job("1001", 200), job("1002", 300)]);
-    const w = computeOfflineWindow("h");
+    recordObservation("h");
+    const w = computeObservationWindow("h");
     expect(w.bounded).toBe(true);
     expect(w.reason).toBe("diff-ok");
-    expect(w.offlineJobKeys).toHaveLength(1);
+    expect(w.offlineObservationKeys).toHaveLength(1);
   });
 
-  it("前回観測なしは bounded=false", () => {
+  it("前回観測なしは bounded=false / no-prior-observation", () => {
     setHistory("h", [job("1", 100)]);
-    expect(computeOfflineWindow("h").reason).toBe("no-prior-observation");
+    // record せず watermark も無い
+    expect(computeObservationWindow("h").reason).toBe("no-prior-observation");
   });
 
   it("stalenessMs を返す（鮮度）", () => {
-    mockMonitorData.hostObservationWatermark = { h: { seenObservationKeys: [], printerIdentity: "h||", persistedAt: 1, generation: {}, retainedObservationCount: 0 } };
+    mockMonitorData.hostObservationWatermark = { h: { seenObservationKeys: [], printerIdentity: "h||", persistedAt: 1, generation: {}, retainedObservationCount: 0, retainedRange: {} } };
     setHistory("h", [job("1", 100)]);
-    const w = computeOfflineWindow("h");
+    recordObservation("h");
+    const w = computeObservationWindow("h");
     expect(typeof w.stalenessMs).toBe("number");
     expect(w.stalenessMs).toBeGreaterThan(0);
+  });
+});
+
+describe("commitObservationWindow — fail-closed transaction（P0-3）", () => {
+  function prep(host = "h") {
+    setHistory(host, [job("1000", 100)]);
+    recordObservation(host);
+    return computeObservationWindow(host);
+  }
+
+  it("windowId 空は window_id_required で拒否", () => {
+    const w = prep();
+    expect(commitObservationWindow("h", { windowId: "", expectedSequence: w.currentSequence, candidatePersistedAt: 1 }).reason).toBe("window_id_required");
+  });
+
+  it("candidatePersistedAt 無しは candidate_not_persisted で拒否", () => {
+    const w = prep();
+    expect(commitObservationWindow("h", { windowId: w.windowId, expectedSequence: w.currentSequence }).reason).toBe("candidate_not_persisted");
+  });
+
+  it("評価後に current が変わったら observation_changed_since_evaluation で前進しない", () => {
+    const w = prep();
+    // 評価後に新しい観測が来る（sequence 進行）
+    setHistory("h", [job("1000", 100), job("1001", 200)]);
+    recordObservation("h");
+    const r = commitObservationWindow("h", { windowId: w.windowId, expectedSequence: w.currentSequence, candidatePersistedAt: 1 });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("observation_changed_since_evaluation");
+  });
+
+  it("同一 windowId の再 commit は冪等 no-op（二重昇格しない）", () => {
+    const w = prep();
+    const first = commitObservationWindow("h", { windowId: "wX", expectedSequence: w.currentSequence, candidatePersistedAt: 1 });
+    expect(first.ok).toBe(true);
+    const firstKeys = first.baseline.seenObservationKeys.slice();
+    // current を進めても同一 windowId は no-op
+    setHistory("h", [job("1000", 100), job("1001", 200), job("1002", 300)]);
+    recordObservation("h");
+    const second = commitObservationWindow("h", { windowId: "wX", expectedSequence: 999, candidatePersistedAt: 1 });
+    expect(second.idempotent).toBe(true);
+    expect(second.baseline.seenObservationKeys).toEqual(firstKeys);
+  });
+
+  it("windowA→windowB 昇格後に windowA を再 commit すると reject（観測が進んでいる）", () => {
+    // A 昇格
+    const wa = prep();
+    commitObservationWindow("h", { windowId: "wA", expectedSequence: wa.currentSequence, candidatePersistedAt: 1 });
+    // 観測進行 → B 昇格
+    setHistory("h", [job("1000", 100), job("1001", 200)]);
+    recordObservation("h");
+    const wb = computeObservationWindow("h");
+    commitObservationWindow("h", { windowId: "wB", expectedSequence: wb.currentSequence, candidatePersistedAt: 1 });
+    // 旧 A を再 commit（sequence は A 評価時のまま古い）→ reject
+    const r = commitObservationWindow("h", { windowId: "wA-stale", expectedSequence: wa.currentSequence, candidatePersistedAt: 1 });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("observation_changed_since_evaluation");
   });
 });
 

--- a/tests/unit/dashboard_offline_observation.test.js
+++ b/tests/unit/dashboard_offline_observation.test.js
@@ -1,0 +1,119 @@
+/**
+ * @fileoverview dashboard_offline_observation.js（#411-O1 観測 watermark）の単体テスト
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockMonitorData = {
+  machines: {},
+  hostSpoolMap: {},
+  hostObservationWatermark: {},
+  appSettings: { connectionTargets: [] },
+  // 安全基盤（read-only であることの確認用に置く）
+  mountHistory: [{ evId: "keep" }],
+  pendingUnattributedUsage: [{ pendingUsageId: "keep" }],
+};
+vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mockMonitorData }));
+
+const { recordHostObservation, computeOfflineWindow, buildConfidence } =
+  await import("../../3dp_lib/dashboard_offline_observation.js");
+
+/** 完了ジョブ（printfinish あり）を作る */
+function job(id, extra = {}) {
+  return { id, materialUsedMm: 5000, printfinish: 1, ...extra };
+}
+function setHistory(host, entries) {
+  mockMonitorData.machines[host] = { printStore: { history: entries }, storedData: {} };
+}
+
+beforeEach(() => {
+  mockMonitorData.machines = {};
+  mockMonitorData.hostSpoolMap = {};
+  mockMonitorData.hostObservationWatermark = {};
+  mockMonitorData.appSettings = { connectionTargets: [] };
+  mockMonitorData.mountHistory = [{ evId: "keep" }];
+  mockMonitorData.pendingUnattributedUsage = [{ pendingUsageId: "keep" }];
+});
+
+describe("recordHostObservation（read-only 観測）", () => {
+  it("完了ジョブの printId 集合・装着スプールを記録する（未完了は除外）", () => {
+    setHistory("h", [job(1000), job(1001), { id: 1002, materialUsedMm: 3000, printfinish: null }]);
+    mockMonitorData.hostSpoolMap = { h: "S" };
+    const wm = recordHostObservation("h");
+    expect(wm.seenCompletedJobIds).toEqual([1000, 1001]); // 印刷中(1002)は除外
+    expect(wm.mountedSpoolId).toBe("S");
+    expect(wm.historyCount).toBe(2);
+    expect(typeof wm.printerIdentity).toBe("string");
+    // 保存先に入る
+    expect(mockMonitorData.hostObservationWatermark.h.seenCompletedJobIds).toEqual([1000, 1001]);
+  });
+
+  it("旧データ(printfinish欠落だが endtime/usagetime あり)も完了として記録", () => {
+    setHistory("h", [job(1, { printfinish: undefined, endtime: 123 }), job(2, { printfinish: undefined, usagetime: 60 })]);
+    const wm = recordHostObservation("h");
+    expect(wm.seenCompletedJobIds).toEqual([1, 2]);
+  });
+
+  it("安全基盤（mountHistory / pendingUnattributedUsage）に一切触れない（read-only）", () => {
+    setHistory("h", [job(1000)]);
+    recordHostObservation("h");
+    expect(mockMonitorData.mountHistory).toEqual([{ evId: "keep" }]);
+    expect(mockMonitorData.pendingUnattributedUsage).toEqual([{ pendingUsageId: "keep" }]);
+  });
+
+  it("host 未指定は null", () => {
+    expect(recordHostObservation()).toBeNull();
+  });
+});
+
+describe("computeOfflineWindow（集合差分）", () => {
+  it("前回観測後に新たに現れた完了ジョブを集合差分で特定", () => {
+    setHistory("h", [job(1000), job(1001)]);
+    recordHostObservation("h"); // 観測: {1000,1001}
+    // アプリ停止中に 1002,1003 が完了して履歴に現れる
+    setHistory("h", [job(1000), job(1001), job(1002), job(1003)]);
+    const w = computeOfflineWindow("h");
+    expect(w.bounded).toBe(true);
+    expect(w.offlineJobIds).toEqual([1002, 1003]);
+    expect(w.reason).toBe("diff-ok");
+  });
+
+  it("ID 巻き戻り（小さい id 出現）でも last-seen 比較でなく集合差分で拾う", () => {
+    setHistory("h", [job(1000), job(1001)]);
+    recordHostObservation("h");
+    // プリンタ再起動等で小さい id の完了が現れる
+    setHistory("h", [job(5), job(1000), job(1001)]);
+    const w = computeOfflineWindow("h");
+    expect(w.offlineJobIds).toEqual([5]); // id>lastSeen だと拾えないが集合差分なら拾う
+  });
+
+  it("前回観測が無ければ bounded=false（初回導入/移行）", () => {
+    setHistory("h", [job(1000)]);
+    const w = computeOfflineWindow("h");
+    expect(w.bounded).toBe(false);
+    expect(w.reason).toBe("no-prior-observation");
+  });
+
+  it("printer identity 変化は bounded=false（同じ窓と断定しない）", () => {
+    setHistory("h", [job(1000)]);
+    mockMonitorData.machines.h.storedData = { model: { rawValue: "A" } };
+    recordHostObservation("h");
+    // identity を変える（モデル変更＝別プリンタ/再セットアップ相当）
+    mockMonitorData.machines.h.storedData = { model: { rawValue: "B" } };
+    mockMonitorData.machines.h.printStore = { history: [job(1000), job(1001)] };
+    const w = computeOfflineWindow("h");
+    expect(w.identityChanged).toBe(true);
+    expect(w.bounded).toBe(false);
+    expect(w.reason).toBe("printer-identity-changed");
+  });
+});
+
+describe("buildConfidence（reasons 付き schema）", () => {
+  it("level と reasons を保持する", () => {
+    const c = buildConfidence("high", ["seen-job", "continuous-print", "no-spool-change"]);
+    expect(c.level).toBe("high");
+    expect(c.reasons).toEqual(["seen-job", "continuous-print", "no-spool-change"]);
+  });
+  it("不正 level は none、reasons 既定は空", () => {
+    expect(buildConfidence("bogus")).toEqual({ level: "none", reasons: [] });
+  });
+});

--- a/tests/unit/dashboard_offline_observation.test.js
+++ b/tests/unit/dashboard_offline_observation.test.js
@@ -3,9 +3,9 @@
  * record / computeObservationWindow / commitObservationWindow の read-only 契約と
  * 5000件切詰め境界・候補単位の識別判定・fail-closed commit を検証する。
  *
- * @version 1.390.1247 (PR #411)
+ * @version 1.390.1248 (PR #411)
  * @since   2.3.0
- * @lastModified 2026-07-23 15:21:14
+ * @lastModified 2026-07-23 15:24:14
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
@@ -16,7 +16,7 @@ const mockMonitorData = {
 };
 vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mockMonitorData }));
 
-const { recordObservation, commitObservationWindow, computeObservationWindow, computeOfflineWindow, observationDue, buildConfidence } =
+const { recordObservation, commitObservationWindow, rollbackObservationWindowCommit, computeObservationWindow, computeOfflineWindow, observationDue, buildConfidence } =
   await import("../../3dp_lib/dashboard_offline_observation.js");
 
 const BASE = 1_700_000_000_000; // epoch ms 基準（_epochMs が ms として扱える範囲）
@@ -281,6 +281,34 @@ describe("commitObservationWindow — fail-closed transaction（P0-3）", () => 
     const r = commitObservationWindow("h", { windowId: "wT", expectedSequence: w.currentSequence, candidatePersistedAt: 1, expectedAppSessionId: "some-other" });
     expect(r.ok).toBe(false);
     expect(r.reason).toBe("app_session_changed_since_evaluation");
+  });
+
+  it("baseline耐久保存失敗時は対象windowIdだけ直前baselineへ巻き戻せる", () => {
+    const w = prep();
+    const before = { ...mockMonitorData.hostObservationWatermark.h };
+    const committed = commitObservationWindow("h", { windowId: "wRollback", expectedSequence: w.currentSequence, candidatePersistedAt: 1 });
+    expect(committed.ok).toBe(true);
+    expect(committed.previousBaseline).toEqual(before);
+    const rolledBack = rollbackObservationWindowCommit("h", {
+      windowId: "wRollback",
+      previousBaseline: committed.previousBaseline
+    });
+    expect(rolledBack.ok).toBe(true);
+    expect(rolledBack.reason).toBe("rolled_back");
+    expect(mockMonitorData.hostObservationWatermark.h).toEqual(before);
+  });
+
+  it("baselineが別windowへ進んでいれば巻き戻さない", () => {
+    const w = prep();
+    const committed = commitObservationWindow("h", { windowId: "wRollbackA", expectedSequence: w.currentSequence, candidatePersistedAt: 1 });
+    mockMonitorData.hostObservationWatermark.h = { ...mockMonitorData.hostObservationWatermark.h, lastCommittedWindowId: "wRollbackB" };
+    const rolledBack = rollbackObservationWindowCommit("h", {
+      windowId: "wRollbackA",
+      previousBaseline: committed.previousBaseline
+    });
+    expect(rolledBack.ok).toBe(false);
+    expect(rolledBack.reason).toBe("baseline_changed_since_commit");
+    expect(mockMonitorData.hostObservationWatermark.h.lastCommittedWindowId).toBe("wRollbackB");
   });
 });
 

--- a/tests/unit/dashboard_offline_observation.test.js
+++ b/tests/unit/dashboard_offline_observation.test.js
@@ -2,6 +2,10 @@
  * @fileoverview dashboard_offline_observation.js（#411-O1 観測レイヤ）の単体テスト
  * record / computeObservationWindow / commitObservationWindow の read-only 契約と
  * 5000件切詰め境界・候補単位の識別判定・fail-closed commit を検証する。
+ *
+ * @version 1.390.1246 (PR #411)
+ * @since   2.3.0
+ * @lastModified 2026-07-23 09:57:05
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
@@ -95,6 +99,25 @@ describe("computeObservationWindow — 5000件切詰め境界（P0-1・実運用
     expect(w.truncated).toBe(true);
     expect(w.offlineObservationKeys).toEqual([]);
     expect(w.bounded).toBe(true);
+  });
+
+  it("★codex-P1: truncated baseline＋完了時刻なしの差分を offline 確定しない（fail-closed）", () => {
+    // Codex 指摘: 5000件切詰め後、完了時刻が無い/境界時刻が作れない古い履歴を offline 誤検出する。
+    const key = (id) => JSON.stringify([id, 0, 0, `f${id}.gcode`]);
+    const baselineKeys = []; for (let i = 1001; i <= 6000; i++) baselineKeys.push(key(String(i)));
+    const currentKeys = []; for (let i = 1; i <= 6000; i++) currentKeys.push(key(String(i))); // 1..1000 は baseline に無い（切詰め済）
+    const previous = {
+      observationSequence: 1, observedAtEpochMs: BASE, persistedAt: BASE,
+      seenObservationKeys: baselineKeys, retainedObservationCount: 5000, truncated: true,
+      retainedRange: { firstCompletedAt: 0, truncated: true },
+      generation: { latestCompletedAt: 0 }, printerIdentity: { model: "K1", completeness: "strong" },
+      mountedSpoolId: "S1", observationState: "mounted", mountIntervalStatus: "ok"
+    };
+    const current = { ...previous, observationSequence: 2, seenObservationKeys: currentKeys };
+    const w = computeOfflineWindow(previous, current); // sessionId 未指定=fresh
+    expect(w.offlineObservationKeys).toEqual([]);      // 誤 offline を出さない
+    expect(w.bounded).toBe(false);                     // 境界不確定は fail-closed
+    expect(w.reason).toBe("history-truncated-unverifiable");
   });
 
   it("6000件履歴＋新規2件 → offline は新規2件のみ（切詰めた古い分は混入しない）", () => {

--- a/tests/unit/dashboard_offline_projection.test.js
+++ b/tests/unit/dashboard_offline_projection.test.js
@@ -1,0 +1,222 @@
+/**
+ * @fileoverview dashboard_offline_projection.js（#411-O3 純粋 projection）の単体テスト
+ * O2 continuity candidate から、確定残量を壊さず projectedRemainingMm だけを導出することを検証する。
+ */
+import { describe, it, expect } from "vitest";
+
+import {
+  buildInferredContinuityProjection,
+  estimateHistoryEntryUsedMm,
+  evaluateCandidateObservationKey
+} from "../../3dp_lib/dashboard_offline_projection.js";
+import { jobObservationIdentity } from "../../3dp_lib/dashboard_history_identity.js";
+
+const ATTR_CLASS = Object.freeze({
+  CONTINUITY_CANDIDATE: "continuity-candidate",
+  CONTINUITY_CONTRADICTED: "continuity-contradicted"
+});
+
+const BASE = 1_700_000_000_000;
+
+/**
+ * 完了履歴 fixture を作る。
+ *
+ * 【詳細説明】
+ * - O1/O2 と同じ複合 observation key を作れるよう、id・開始時刻・完了時刻・ファイル名を固定する。
+ * - 帰属済みテストでは filamentInfo / filamentId を後から上書きして使う。
+ *
+ * @function job
+ * @param {string} id - ジョブ ID。
+ * @param {number} usedMm - 消費量 mm。
+ * @param {number} offsetSec - BASE からの完了時刻差分秒。
+ * @param {Object} [over] - 履歴行へ追加するプロパティ。
+ * @returns {Object} printStore.history 相当の履歴行。
+ */
+function job(id, usedMm, offsetSec, over = {}) {
+  return {
+    id,
+    printStartTime: BASE + offsetSec * 1000 - 20_000,
+    finishTime: BASE + offsetSec * 1000,
+    filename: `plate-${id}.gcode`,
+    printfinish: 1,
+    materialUsedMm: usedMm,
+    ...over
+  };
+}
+
+/**
+ * 履歴行から observation key を返す。
+ *
+ * @function keyOf
+ * @param {Object} entry - 履歴行。
+ * @returns {string} 複合 observation key。
+ */
+function keyOf(entry) {
+  return jobObservationIdentity(entry).key;
+}
+
+/**
+ * continuity-candidate の fixture を作る。
+ *
+ * @function classification
+ * @param {Array<string>} keys - candidate offline observation keys。
+ * @param {Object} [over] - 分類結果へ追加するプロパティ。
+ * @returns {Object} classifyObservationWindow の戻り値相当。
+ */
+function classification(keys, over = {}) {
+  return {
+    classification: ATTR_CLASS.CONTINUITY_CANDIDATE,
+    host: "k1",
+    windowId: "k1|b1|c2",
+    candidate: {
+      candidateSpoolId: "S1",
+      candidateBaselineIntervalId: "iv1",
+      candidateCurrentIntervalId: "iv1",
+      offlineObservationKeys: keys,
+      windowId: "k1|b1|c2"
+    },
+    ...over
+  };
+}
+
+describe("estimateHistoryEntryUsedMm", () => {
+  it("materialUsedMm を優先して消費量を返す", () => {
+    expect(estimateHistoryEntryUsedMm({ materialUsedMm: "123.4", filamentInfo: [{ usedMm: 999 }] })).toBe(123.4);
+  });
+
+  it("materialUsedMm が無い旧履歴では filamentInfo[].usedMm を合算する", () => {
+    expect(estimateHistoryEntryUsedMm({ filamentInfo: [{ usedMm: 100 }, { usedMm: "250" }, { usedMm: -1 }] })).toBe(350);
+  });
+
+  it("消費量が判定できなければ 0 を返す", () => {
+    expect(estimateHistoryEntryUsedMm({ materialUsedMm: "bad" })).toBe(0);
+  });
+});
+
+describe("evaluateCandidateObservationKey", () => {
+  it("未帰属かつ消費量ありなら inferred-debit", () => {
+    const entry = job("101", 1200, 101);
+    const r = evaluateCandidateObservationKey(keyOf(entry), entry, "S1");
+    expect(r.status).toBe("inferred-debit");
+    expect(r.usedMm).toBe(1200);
+    expect(r.reason).toBe("unattributed-usage");
+  });
+
+  it("候補スプールへ確定済みなら confirmed-same-spool（二重減算しない）", () => {
+    const entry = job("102", 2200, 102, { filamentInfo: [{ spoolId: "S1", usedMm: 2200 }] });
+    const r = evaluateCandidateObservationKey(keyOf(entry), entry, "S1");
+    expect(r.status).toBe("confirmed-same-spool");
+    expect(r.confirmedSpoolIds).toEqual(["S1"]);
+  });
+
+  it("別スプールへ確定済みなら confirmed-other-spool（矛盾）", () => {
+    const entry = job("103", 3300, 103, { filamentId: "S2" });
+    const r = evaluateCandidateObservationKey(keyOf(entry), entry, "S1");
+    expect(r.status).toBe("confirmed-other-spool");
+    expect(r.confirmedSpoolIds).toEqual(["S2"]);
+  });
+
+  it("履歴から消えた key は unresolved として推定しない", () => {
+    const r = evaluateCandidateObservationKey("[\"missing\",0,0,\"\"]", null, "S1");
+    expect(r.status).toBe("unresolved");
+    expect(r.usedMm).toBe(0);
+  });
+});
+
+describe("buildInferredContinuityProjection", () => {
+  it("未帰属 candidate だけを inferredContinuityUsedMm に集計し projectedRemainingMm を下げる", () => {
+    const j1 = job("201", 1000, 201);
+    const j2 = job("202", 2500, 202);
+    const spool = { id: "S1", remainingLengthMm: 10_000 };
+
+    const before = JSON.parse(JSON.stringify(spool));
+    const result = buildInferredContinuityProjection(classification([keyOf(j1), keyOf(j2)]), spool, [j1, j2]);
+
+    expect(result.confirmedRemainingMm).toBe(10_000);
+    expect(result.inferredContinuityUsedMm).toBe(3500);
+    expect(result.projectedRemainingMm).toBe(6500);
+    expect(result.candidateDebits.map(d => d.status)).toEqual(["inferred-debit", "inferred-debit"]);
+    expect(result.readOnly).toBe(true);
+    expect(spool).toEqual(before);
+  });
+
+  it("候補スプールへ確定帰属済みの履歴は projected から除外して二重減算しない", () => {
+    const pending = job("301", 1000, 301);
+    const confirmed = job("302", 2000, 302, { filamentInfo: [{ spoolId: "S1", usedMm: 2000 }] });
+    const result = buildInferredContinuityProjection(
+      classification([keyOf(pending), keyOf(confirmed)]),
+      { id: "S1", remainingLengthMm: 8000 },
+      [pending, confirmed]
+    );
+
+    expect(result.inferredContinuityUsedMm).toBe(1000);
+    expect(result.projectedRemainingMm).toBe(7000);
+    expect(result.candidateDebits.map(d => d.status)).toEqual(["inferred-debit", "confirmed-same-spool"]);
+  });
+
+  it("別スプール確定済みは contradiction に分離し projected へ入れない", () => {
+    const other = job("401", 4000, 401, { filamentInfo: [{ spoolId: "S2", usedMm: 4000 }] });
+    const result = buildInferredContinuityProjection(
+      classification([keyOf(other)]),
+      { id: "S1", remainingLengthMm: 9000 },
+      [other]
+    );
+
+    expect(result.inferredContinuityUsedMm).toBe(0);
+    expect(result.projectedRemainingMm).toBe(9000);
+    expect(result.contradictions).toHaveLength(1);
+    expect(result.contradictions[0].reason).toBe("already-confirmed-on-other-spool");
+  });
+
+  it("履歴消失と使用量不明は unresolved に分離し projected へ入れない", () => {
+    const zero = job("501", 0, 501);
+    const result = buildInferredContinuityProjection(
+      classification([keyOf(zero), "[\"gone\",0,999,\"\"]"]),
+      { id: "S1", remainingLengthMm: 5000 },
+      [zero]
+    );
+
+    expect(result.inferredContinuityUsedMm).toBe(0);
+    expect(result.projectedRemainingMm).toBe(5000);
+    expect(result.unresolved.map(d => d.status)).toEqual(["no-usage", "unresolved"]);
+  });
+
+  it("continuity-candidate 以外の分類では推定 debit しない", () => {
+    const entry = job("601", 1600, 601);
+    const result = buildInferredContinuityProjection(
+      classification([keyOf(entry)], { classification: ATTR_CLASS.CONTINUITY_CONTRADICTED, candidate: null }),
+      { id: "S1", remainingLengthMm: 7000 },
+      [entry]
+    );
+
+    expect(result.inferredContinuityUsedMm).toBe(0);
+    expect(result.candidateDebits).toEqual([]);
+    expect(result.projectedRemainingMm).toBe(7000);
+  });
+
+  it("projection 対象 spool と candidate spool が違う場合は矛盾として debit しない", () => {
+    const entry = job("701", 1600, 701);
+    const result = buildInferredContinuityProjection(
+      classification([keyOf(entry)]),
+      { id: "S2", remainingLengthMm: 7000 },
+      [entry]
+    );
+
+    expect(result.inferredContinuityUsedMm).toBe(0);
+    expect(result.candidateDebits).toEqual([]);
+    expect(result.contradictions[0].reason).toBe("projection-spool-mismatch");
+    expect(result.projectedRemainingMm).toBe(7000);
+  });
+
+  it("推定 debit が確定残量を超えても projectedRemainingMm は 0 未満にしない", () => {
+    const entry = job("801", 9000, 801);
+    const result = buildInferredContinuityProjection(
+      classification([keyOf(entry)]),
+      { id: "S1", remainingLengthMm: 1000 },
+      [entry]
+    );
+
+    expect(result.inferredContinuityUsedMm).toBe(9000);
+    expect(result.projectedRemainingMm).toBe(0);
+  });
+});


### PR DESCRIPTION
## 概要

**Option 4（inferred-continuity＝オフライン推定帰属）専用 PR。** #409（安全修正）／#410（再起動冪等性・台帳決定性）の安全基盤の**上に**、新しい業務仕様として推定帰属を追加する。レビュー4で「#411 は read-only 限定で開始 OK」と承認された方針に従う。

- **base = `claude/filament-restart-hardening`（#410）にスタック。** #409→#410 が main へ着地したら本 PR を main へ rebase する。
- **絶対条件（reviewer）: 安全基盤は read-only。** `completionObservationId` / `completionOpId` / `opId` / `intervalId` / `pendingUnattributedUsage` / `mountHistoryRejectedEvents` / `ledgerRepairRequired` / `mountHistory` / `usedLengthLog` / `remainingLengthMm` には**一切書き込まない**。追加するのは Observation watermark / seen job set / offline window / inference / confidence / candidate のみ。**残量は減らさない**（O2 以降・ユーザ確認後）。

全 **1028 テスト緑・lint 0 エラー**。（O1＝PASS＋O2ライブ配線前の追加ハードニング2巡／O2＝分類器＋continuity 誤帰属 P0 修正まで反映。**O2 は未だ aggregator へライブ配線していない**＝O3 前に再レビュー予定）

## O1/O2 追加ハードニング 第2巡（f8b9a29 固有指摘）

- **P0-1 観測 signature**: 履歴 revision を `printStore.revision`（存在しない＝常に null）から正式フィールド `printStore._historyRev` へ修正。signature 判定＋構築を純関数 `observationDue(prev, facts, {nowMs})` に切り出し、`mountIntervalId` も含める（iv1→iv2 の detach/reattach を 5s 待たず記録）。
- **P0-2 baseline 破損拒否**: 分類器は current だけでなく **baseline の mount interval が corrupt/ambiguous なら continuity-contradicted**（破損台帳を推定 debit の根拠にしない）。
- **P0-3 confidence tier**: `high` は **activeJobContinued（停止前ジョブの完了を観測）＋同一 interval＋前後 interval=ok** が前提。完全オフライン（開始をアプリが観測していない）は **medium 止まり**、interval none/unknown・interval id 変化・truncated・stale は **low**。
- **P1-1 identity 一致強度**: `sameStrongPrinterIdentity` は **serial/deviceId 一致（same-strong）のみ true**。model 一致は同機種で共通し得るため `same-descriptive` とし、evidence に `printerIdentityMatch{status, matchedBy}` を持つ。
- **P1-2 セッション鮮度**: 観測に `appSessionId` を付与し、**永続復元された旧 current は stale＝不採用**（`observation-incomplete`）。現セッションで fresh 観測を取るまで candidate を出さない。

## O1 追加ハードニング（O2 ライブ配線前・再レビュー反映）

- **純関数化（P1-4）**: `computeOfflineWindow(previous, current)` を新設し、グローバル状態（watermark/履歴/live identity）を一切参照しない完全な純関数へ。`computeObservationWindow(host)` は薄いラッパ。鮮度も `current観測時刻 − baseline永続時刻` で算出し wall clock を読まない。
- **構造化 printerIdentity（P1-1）**: `{host, printerType, model, serialNumber, deviceId, completeness}`。model/serial/deviceId のいずれか機器着信で `strong`、未取得 `weak`。strong 同士の安定識別子不一致のみ交換判定、**weak→strong の補完・weak 同士は反証にしない**（起動直後 `h||`→`h|k1|K1 Max` の同一機を交換誤認する事故を根治）。
- **ISO 完了判定（P1-2）**: `isCompletedHistoryEntry`/`jobTemporal` が ISO8601（Z/offset）の finishTime/endtime を epoch ms 受理（`Number()` で NaN 問題）。
- **連続印刷証拠（P0-4）**: 観測に `activeJobId`/`printState`/`historyRevision` を保存。O2 は baseline の activeJobId が offline 集合に現れるかで `activeJobContinued` を判定。
- **観測タイミング（P1-5）**: aggregator は 5s heartbeat だけでなく観測 signature（履歴rev/現在ジョブ/印刷状態/装着/interval）変化時にも記録。**read-only 観測ブロック全体を try で囲い、台帳参照等の例外が本流（帰属/消費トラッキング）を止めないよう堅牢化**。
- **O2 強化**: 分類結果に `evidence{sameStrongPrinterIdentity, sameMountedSpool, sameMountInterval, activeJobContinued, historyShrank, mountStatus, elapsedMs}` と `confidence.contradictions[]` を追加。
- （P0-1/P0-2/P0-3＝baseline/current 分離・spool 非依存記録・intervalId 台帳配線 は既存コミットで解消済。P1-3 Set 重複排除も既存）

## O1（実装済・レビュー4巡反映済）

O1 を「観測・保存・比較」だけの **Observation レイヤ**として再構成。公開 API は3つ：
`recordObservation(host)` / `computeObservationWindow(host)` / `commitObservationWindow(host,{...})`。

新規 `dashboard_offline_observation.js` ＋ 下位 util `dashboard_history_identity.js`（read-only）:
- **baseline/current 分離**: `hostObservationWatermark`(停止前基準)と `hostObservationCurrent`(現観測)を別スロット化。`recordObservation` は current のみ更新し baseline を上書きしない（起動直後に証拠を消さない）。
- **retainedRange 境界（P0-1・実運用の主要被害を根治）**: baseline は completion 時系列で最新 `SEEN_CAP(5000)` 件のみ保持するため、watermark に `retainedRange`(first/last completedAt・truncated)を保存し、差分は**境界以降の完了のみ**に限定。6000件履歴でも切詰めた古い分は false offline に混入しない（`truncated=true` は返すが offline=[]）。
- **候補単位の識別判定（P0-2）**: 全履歴比率をやめ、offline 候補ごとに判定。`canonicalJobId` が baseline と衝突する再利用IDが検証不能なら `reused-job-id-unverifiable`、識別材料不足は `job-identity-insufficient` として `bounded=false`＋`unresolvedJobIds[]`。識別十分なら再利用IDでも別実行として offline に保持（見失わない）。
- **fail-closed commit（P0-3）**: `commitObservationWindow` を transaction 化。`windowId` 非空・`candidatePersistedAt`・評価時 `expectedSequence` 一致を必須にし、不一致は昇格せず `window_id_required`／`candidate_not_persisted`／`observation_changed_since_evaluation` を返す。同一 windowId は冪等 no-op。
- **複合観測 identity（P1-2）**: `jobObservationIdentity = 構造体{canonicalJobId,startAt,finishAt,fileSignature}` → JSON tuple で安定 encode（区切り文字衝突排除）。ファイル同一性は正規化(NFC/大小/バックスラッシュ/URLデコード)。表示用 id は `canonicalJobKey`（Number 化しない・2^53超/文字列/"0"対応）と分離。
- **時刻正規化（P1-1/P1-3）**: `jobTemporal` は id を時刻 fallback にせず（巨大 id の Number 化＝丸め衝突排除）、開始/完了時刻を epoch ms へ正規化（秒/ms 自動判定）し `timeSource` を保持。
- **時系列 generation fingerprint（P1-4）**: `historyGenerationFingerprint`(completedCount/earliest/latest/順序hash)を baseline/current で実比較。latest completion 巻き戻り＝`history-time-rollback`、世代交代/大幅縮小＝`bounded=false`。
- `computeObservationWindow` は `ObservationWindow{windowId,bounded,truncated,generationChanged,reason,offlineObservationKeys,unresolvedJobIds,baselineFingerprint,currentFingerprint,baselineSequence,currentSequence,stalenessMs}` を返す純関数（O2 はこれを分類）。
- 未装着も観測（`observationState`、未装着 status=`none`）。`observationSequence` は再起動で継続採番。
- **`buildConfidence(level, reasons[])`**: confidence を最初から理由付きで持つ schema。
- `hostObservationWatermark`/`hostObservationCurrent` を **LS/IDB/restore で永続化（親専用・relay 同期しない）**。子には生の観測（最大5000件のキー）を流さず、O4/O5 で分類結果／candidate／confidence のみを必要範囲で同期する方針。

## O2（実装済・レビュー2巡＝continuity 誤帰属 P0 修正まで反映）

新規 `dashboard_offline_classifier.js`（純関数・**monitorData 非参照＝副作用ゼロ**）。Observation 層は**変更せず利用のみ**：
- **`classifyObservationWindow(window)`**: ObservationWindow **だけ**を入力に、`分類 → candidate → confidence(理由付き)` を返す純関数。
- **`ATTR_CLASS`（8分類）**: `continuity-candidate` / `continuity-contradicted` / `no-offline-activity` / `no-mounted-spool` / `observation-incomplete` / `unbounded` / `insufficient` / `no-prior`。
- **継続候補の必須条件（O2-P0-1・最重要）**: 「停止前に A が付いていた」だけでは不足＝**復帰後も同じスプールが観測された事実**を要求。①current 観測あり ②baseline/current とも mounted ③spoolId 一致 ④current の mount interval が corrupt/ambiguous でない。1つでも欠ければ candidate を出さない。→ **停止前A・復帰後B で A へ candidate を出す誤帰属を根治**（別スプール/未装着/corrupt=`continuity-contradicted`、baseline 未装着=`no-mounted-spool`）。
- **O2-P0-2**: baseline はあるが復帰後 current 未観測は `observation-incomplete`（`no-prior` とは別）。装着未確認の段階で候補を出さない。
- 観測事実の追加（**O1 責務は不変・戻り値拡張のみ**）: `computeObservationWindow` が `baselineMount`/`currentMount`（spoolId/intervalId/intervalStatus/observationState）・`hasCurrentObservation`・`windowKind` を返す。O2 は `windowKind`（構造化）で分類し `reason` は表示専用（P1-1）。
- **candidate** = `{candidateSpoolId, candidateBaselineIntervalId, candidateCurrentIntervalId, offlineObservationKeys, windowId}`。confidence は同一スプール継続を基準に、current-interval が none/interval-id 変化/truncated/stale で1段ずつ降格（**下限 low**）。interval corrupt/ambiguous は候補化せず矛盾扱い（P1-3）。
- **`classifyHostAttribution(host)`**: `computeObservationWindow` を呼んで分類する公開エントリ（read-only）。
- **O2 は remaining を触らない**（projected は O3）。永続化/relay/確認UI は O4/O5。

## O3..O5（後続・本 PR で継続）

- **O3**: `confirmedRemainingMm` / `projectedRemainingMm` / `inferredContinuityUsedMm` の分離と inferred debit（可逆・確定アンカー非破壊）。
- **O4**: inferred marker の永続化・relay・クラッシュ冪等（同一 window を2回処理しても二重減算しない）。
- **O5**: 推定残量の表示・不可逆操作ゲート（推定値だけで runout 確定/在庫消費/廃棄/停止しない）＋確認/否認/再割当て。undo・一括はさらに後続。

## やらないこと（この段階）
残量減算、known への確定昇格、安全基盤の変更。すべて O3 以降＋ユーザ確認後。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
