### PR TITLE
feat(filament): persist inferred continuity candidates

### DIFF
--- a/3dp_lib/dashboard_client_sync.js
+++ b/3dp_lib/dashboard_client_sync.js
@@ -20,9 +20,9 @@
  * - {@link sendRelayCommand}：親経由でプリンタにコマンド送信
  * - {@link sendRelayFilament}：親経由でフィラメント操作
  *
- * @version 1.390.1110 (PR #380)
+ * @version 1.390.1245 (PR #412)
  * @since   1.390.820 (PR #367)
- * @lastModified 2026-06-12 12:00:00
+ * @lastModified 2026-07-19 18:45:00
  * -----------------------------------------------------------
  */
 
@@ -312,7 +312,7 @@ function _applyRelayPrintStore(hostname, ps) {
  * ※ モジュール内部用だが、マージ規則の回帰テストのために export している。
  *
  * @function _applySharedFilamentState
- * @param {{filamentSpools?:Array<Object>, hostSpoolMap?:Object, mountHistory?:Array<Object>, pendingUnattributedUsage?:Array<Object>}} shared
+ * @param {{filamentSpools?:Array<Object>, hostSpoolMap?:Object, mountHistory?:Array<Object>, pendingUnattributedUsage?:Array<Object>, inferredCandidateStore?:Object}} shared
  *   - 受信した共有データ
  * @returns {void}
  */
@@ -355,6 +355,15 @@ export function _applySharedFilamentState(shared) {
     const arch = monitorData.pendingUnattributedUsageArchive;
     for (const k of Object.keys(arch)) delete arch[k];
     Object.assign(arch, shared.pendingUnattributedUsageArchive);
+  }
+  // ★ #412-O4: 推定 candidate store は親が権威。子は全置換で表示・確認導線用の状態を同期する。
+  if (shared.inferredCandidateStore && typeof shared.inferredCandidateStore === "object") {
+    if (!monitorData.inferredCandidateStore || typeof monitorData.inferredCandidateStore !== "object") {
+      monitorData.inferredCandidateStore = {};
+    }
+    const store = monitorData.inferredCandidateStore;
+    for (const k of Object.keys(store)) delete store[k];
+    Object.assign(store, shared.inferredCandidateStore);
   }
   if (shared.filamentEventContext && typeof shared.filamentEventContext === "object") {
     if (!monitorData.filamentEventContext || typeof monitorData.filamentEventContext !== "object") {

--- a/3dp_lib/dashboard_data.js
+++ b/3dp_lib/dashboard_data.js
@@ -19,9 +19,9 @@
  * - {@link getDisplayValue}：表示用値取得
  * - {@link markAllKeysDirty}：全キーを変更済みにマーク
  *
-* @version 1.390.787 (PR #367)
+* @version 1.390.1245 (PR #412)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-03-12
+* @lastModified 2026-07-19 18:45:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -292,6 +292,15 @@ export const monitorData = {
    */
   hostObservationCurrent: {},
   /**
+   * ★ #412-O4: オフライン継続推定 candidate の親権威ストア。
+   * O2/O3 で得た分類・推定 debit を、baseline commit 前に耐久保存するための領域。
+   * 削除ではなく status 遷移と events 追記で監査可能にし、子へは分類結果と推定量のみ同期する。
+   * hash -> { candidateHash, windowId, candidateSpoolId, observationKeys, usedMm, confidence, evidence,
+   *           status, createdAt, updatedAt, resolvedAt, events:Array<Object> }
+   * @type {Object.<string, Object>}
+   */
+  inferredCandidateStore: {},
+  /**
    * ★ Phase2A: 有効な jobId が無いまま完了した消費の隔離領域。
    * 電源投入直後などで printStartTime が 0/null の「無効ID」ジョブは
    * 履歴・usedLengthLog・境界へ確定記録を作らず（過去全履歴の誤減算＝退行を防ぐ）、
@@ -531,6 +540,5 @@ export function markAllKeysDirty(hostname) {
     dirtySet.add(key);
   }
 }
-
 
 

--- a/3dp_lib/dashboard_offline_candidate_store.js
+++ b/3dp_lib/dashboard_offline_candidate_store.js
@@ -1,0 +1,281 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用オフライン継続推定 candidate store モジュール
+ * @file dashboard_offline_candidate_store.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * @author pumpCurry
+ * -----------------------------------------------------------
+ * @module dashboard_offline_candidate_store
+ *
+ * 【機能内容サマリ】
+ * - #412-O4 の candidate 永続化層として、O2/O3 の分類結果と projection 結果を
+ *   `monitorData.inferredCandidateStore` へ冪等保存する。
+ * - 同一 window/candidate/observation key 集合は同じ candidateHash へ畳み、再起動や再送で
+ *   推定 debit が二重作成されないようにする。
+ * - candidate は削除せず、`status` と `events` による状態遷移で監査可能にする。
+ *
+ * 【公開関数一覧】
+ * - {@link buildInferredCandidateHash}：candidate の安定 hash を生成する
+ * - {@link persistInferredCandidate}：O2/O3 結果を candidate store へ冪等保存する
+ * - {@link transitionInferredCandidate}：candidate の状態を監査 event 付きで変更する
+ * - {@link getInferredCandidatesForHost}：host 単位で candidate を取得する
+ *
+ * @version 1.390.1245 (PR #412)
+ * @since   1.390.1245 (PR #412)
+ * @lastModified 2026-07-19 18:45:00
+ * -----------------------------------------------------------
+ * @todo
+ * - O4 後続で aggregator の O2/O3 ライブ配線から `persistInferredCandidate` を呼び出す。
+ * - O5 で confirmed/rejected/reassigned の UI 操作から `transitionInferredCandidate` を呼び出す。
+ */
+
+"use strict";
+
+import { monitorData } from "./dashboard_data.js";
+
+/** candidate store で許可する状態。 */
+export const INFERRED_CANDIDATE_STATUS = Object.freeze({
+  PENDING: "pending",
+  CONFIRMED: "confirmed",
+  REJECTED: "rejected",
+  REASSIGNED: "reassigned",
+  SUPERSEDED: "superseded"
+});
+
+/**
+ * JSON 化前にオブジェクトのキー順を安定させる。
+ *
+ * 【詳細説明】
+ * - candidateHash は再起動後にも同じ値でなければならないため、Object の挿入順に依存しない
+ *   安定 JSON を作る。
+ * - 配列順は observation の意味を持つためそのまま保持する。O2 側で順序が安定している前提。
+ *
+ * @private
+ * @function _stable
+ * @param {*} value - 安定化したい値。
+ * @returns {*} キー順を正規化した値。
+ */
+function _stable(value) {
+  if (Array.isArray(value)) return value.map(_stable);
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const key of Object.keys(value).sort()) out[key] = _stable(value[key]);
+    return out;
+  }
+  return value;
+}
+
+/**
+ * 決定論的な FNV-1a 32bit hash を返す。
+ *
+ * 【詳細説明】
+ * - crypto API を使わず、browser / Node テスト双方で同じ値を返す軽量 hash。
+ * - 衝突可能性はゼロではないため、candidateHash は安全上の権威 ID ではなく、冪等キーとして扱う。
+ *
+ * @private
+ * @function _hashString
+ * @param {string} text - hash 対象文字列。
+ * @returns {string} 16進 hash。
+ */
+function _hashString(text) {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+}
+
+/**
+ * 現在 epoch ms を返す。
+ *
+ * @private
+ * @function _nowMs
+ * @param {{nowMs?:number}} [options] - テスト用 clock 注入。
+ * @returns {number} epoch ms。
+ */
+function _nowMs(options = {}) {
+  const injected = Number(options.nowMs);
+  if (Number.isFinite(injected) && injected > 0) return injected;
+  return Date.now();
+}
+
+/**
+ * candidate store オブジェクトを初期化して返す。
+ *
+ * @private
+ * @function _store
+ * @returns {Object.<string, Object>} candidateHash をキーにした store。
+ */
+function _store() {
+  if (!monitorData.inferredCandidateStore || typeof monitorData.inferredCandidateStore !== "object") {
+    monitorData.inferredCandidateStore = {};
+  }
+  return monitorData.inferredCandidateStore;
+}
+
+/**
+ * O2/O3 candidate の安定 hash を生成する。
+ *
+ * 【詳細説明】
+ * - windowId、候補スプール、offline observation keys、推定 debit 総量を hash 材料にする。
+ * - confidence や evidence は表示・監査属性であり、後から詳細が増えても同じ物理 candidate を
+ *   別物にしないため hash 材料へ入れない。
+ *
+ * @function buildInferredCandidateHash
+ * @param {{windowId?:?string, candidate?:?Object}} classificationResult - O2 分類結果。
+ * @param {{inferredContinuityUsedMm?:number, candidateDebits?:Array<Object>}} projection - O3 projection 結果。
+ * @returns {string} `ic-` 接頭辞付き candidate hash。
+ * @example
+ * const hash = buildInferredCandidateHash(classification, projection);
+ */
+export function buildInferredCandidateHash(classificationResult, projection) {
+  const candidate = classificationResult?.candidate || {};
+  const keys = Array.isArray(candidate.offlineObservationKeys) ? candidate.offlineObservationKeys.slice().sort() : [];
+  const material = {
+    windowId: classificationResult?.windowId ?? candidate.windowId ?? null,
+    candidateSpoolId: candidate.candidateSpoolId ?? null,
+    candidateBaselineIntervalId: candidate.candidateBaselineIntervalId ?? null,
+    candidateCurrentIntervalId: candidate.candidateCurrentIntervalId ?? null,
+    observationKeys: keys,
+    usedMm: Math.max(0, Number(projection?.inferredContinuityUsedMm) || 0)
+  };
+  return `ic-${_hashString(JSON.stringify(_stable(material)))}`;
+}
+
+/**
+ * O2/O3 の結果を candidate store へ冪等保存する。
+ *
+ * 【詳細説明】
+ * - `projection.inferredContinuityUsedMm` が 0 以下なら、推定 debit 対象が無いため保存しない。
+ * - 同じ candidateHash が既に存在する場合は既存レコードを返し、二重作成しない。
+ * - 作成時点の candidate/projection/confidence/evidence をスナップショット化し、後続 UI が
+ *   生の 5000 件 observation を見ずに状態表示できるようにする。
+ *
+ * @function persistInferredCandidate
+ * @param {Object} classificationResult - `classifyObservationWindow()` の戻り値。
+ * @param {Object} projection - `buildInferredContinuityProjection()` の戻り値。
+ * @param {{nowMs?:number}} [options] - テスト用 clock 注入。
+ * @returns {{ok:boolean, reason:string, candidateHash:?string, record:?Object, idempotent?:boolean}}
+ *   保存結果。
+ * @example
+ * const result = persistInferredCandidate(classification, projection);
+ */
+export function persistInferredCandidate(classificationResult, projection, options = {}) {
+  const usedMm = Math.max(0, Number(projection?.inferredContinuityUsedMm) || 0);
+  if (usedMm <= 0) {
+    return { ok: false, reason: "no_inferred_debit", candidateHash: null, record: null };
+  }
+  const candidate = classificationResult?.candidate || null;
+  if (!candidate?.candidateSpoolId || !classificationResult?.windowId) {
+    return { ok: false, reason: "candidate_incomplete", candidateHash: null, record: null };
+  }
+  const candidateHash = buildInferredCandidateHash(classificationResult, projection);
+  const store = _store();
+  if (store[candidateHash]) {
+    return { ok: true, reason: "idempotent", candidateHash, record: store[candidateHash], idempotent: true };
+  }
+
+  const now = _nowMs(options);
+  const record = {
+    candidateHash,
+    windowId: classificationResult.windowId,
+    host: classificationResult.host ?? projection?.host ?? null,
+    candidateSpoolId: String(candidate.candidateSpoolId),
+    candidateBaselineIntervalId: candidate.candidateBaselineIntervalId ?? null,
+    candidateCurrentIntervalId: candidate.candidateCurrentIntervalId ?? null,
+    observationKeys: Array.isArray(candidate.offlineObservationKeys) ? candidate.offlineObservationKeys.slice() : [],
+    candidateDebits: Array.isArray(projection?.candidateDebits) ? projection.candidateDebits.map(item => ({
+      observationKey: item.observationKey,
+      status: item.status,
+      usedMm: Math.max(0, Number(item.usedMm) || 0),
+      reason: item.reason,
+      confirmedSpoolIds: Array.isArray(item.confirmedSpoolIds) ? item.confirmedSpoolIds.slice() : []
+    })) : [],
+    usedMm,
+    confidence: classificationResult.confidence ? { ...classificationResult.confidence } : null,
+    evidence: classificationResult.evidence ? { ...classificationResult.evidence } : null,
+    status: INFERRED_CANDIDATE_STATUS.PENDING,
+    createdAt: now,
+    updatedAt: now,
+    resolvedAt: null,
+    events: [{ type: "created", at: now, status: INFERRED_CANDIDATE_STATUS.PENDING, usedMm }]
+  };
+  store[candidateHash] = record;
+  return { ok: true, reason: "created", candidateHash, record };
+}
+
+/**
+ * candidate の状態を監査 event 付きで変更する。
+ *
+ * 【詳細説明】
+ * - candidate は削除しない。確認・否認・再割当て・supersede は status と event として記録する。
+ * - 同じ状態へ再適用された場合も event を増殖させず、冪等 no-op として返す。
+ * - `reassigned` では `assignedSpoolId` を保持し、後続 UI/確定処理が候補スプール以外へ割当可能にする。
+ *
+ * @function transitionInferredCandidate
+ * @param {string} candidateHash - 対象 candidateHash。
+ * @param {"pending"|"confirmed"|"rejected"|"reassigned"|"superseded"} status - 新しい状態。
+ * @param {{nowMs?:number, actor?:string, reason?:string, assignedSpoolId?:?string, supersededBy?:?string}} [options]
+ *   - 状態遷移に付与する監査情報。
+ * @returns {{ok:boolean, reason:string, record:?Object}}
+ * @example
+ * const result = transitionInferredCandidate(hash, "rejected", { reason: "user-denied" });
+ */
+export function transitionInferredCandidate(candidateHash, status, options = {}) {
+  const allowed = new Set(Object.values(INFERRED_CANDIDATE_STATUS));
+  if (!candidateHash) return { ok: false, reason: "candidate_hash_required", record: null };
+  if (!allowed.has(status)) return { ok: false, reason: "invalid_status", record: null };
+  const record = _store()[candidateHash];
+  if (!record) return { ok: false, reason: "candidate_not_found", record: null };
+
+  const assignedSpoolId = options.assignedSpoolId ?? null;
+  const supersededBy = options.supersededBy ?? null;
+  if (record.status === status
+      && (status !== INFERRED_CANDIDATE_STATUS.REASSIGNED || record.assignedSpoolId === assignedSpoolId)
+      && (status !== INFERRED_CANDIDATE_STATUS.SUPERSEDED || record.supersededBy === supersededBy)) {
+    return { ok: true, reason: "idempotent", record };
+  }
+
+  const now = _nowMs(options);
+  record.status = status;
+  record.updatedAt = now;
+  if (status !== INFERRED_CANDIDATE_STATUS.PENDING) record.resolvedAt = now;
+  if (status === INFERRED_CANDIDATE_STATUS.REASSIGNED) record.assignedSpoolId = assignedSpoolId;
+  if (status === INFERRED_CANDIDATE_STATUS.SUPERSEDED) record.supersededBy = supersededBy;
+  if (!Array.isArray(record.events)) record.events = [];
+  record.events.push({
+    type: "status-changed",
+    at: now,
+    status,
+    actor: options.actor ?? "system",
+    reason: options.reason ?? null,
+    assignedSpoolId,
+    supersededBy
+  });
+  return { ok: true, reason: "transitioned", record };
+}
+
+/**
+ * 指定 host の candidate 一覧を取得する。
+ *
+ * 【詳細説明】
+ * - UI や relay 確認用に、host で絞り込んだコピーを返す。
+ * - status 指定がある場合はその状態だけを返す。元 store は変更しない。
+ *
+ * @function getInferredCandidatesForHost
+ * @param {string} host - 対象ホスト名。
+ * @param {{status?:string}} [options] - 絞り込み条件。
+ * @returns {Array<Object>} candidate レコードの浅いコピー配列。
+ * @example
+ * const pending = getInferredCandidatesForHost("k1", { status: "pending" });
+ */
+export function getInferredCandidatesForHost(host, options = {}) {
+  const out = [];
+  for (const record of Object.values(_store())) {
+    if (!record || record.host !== host) continue;
+    if (options.status && record.status !== options.status) continue;
+    out.push({ ...record, events: Array.isArray(record.events) ? record.events.slice() : [] });
+  }
+  return out.sort((a, b) => (Number(a.createdAt) || 0) - (Number(b.createdAt) || 0));
+}

--- a/3dp_lib/dashboard_offline_candidate_store.js
+++ b/3dp_lib/dashboard_offline_candidate_store.js
@@ -20,9 +20,9 @@
  * - {@link transitionInferredCandidate}：candidate の状態を監査 event 付きで変更する
  * - {@link getInferredCandidatesForHost}：host 単位で candidate を取得する
  *
- * @version 1.390.1245 (PR #412)
+ * @version 1.390.1250 (PR #412)
  * @since   1.390.1245 (PR #412)
- * @lastModified 2026-07-19 18:45:00
+ * @lastModified 2026-07-25 12:17:09
  * -----------------------------------------------------------
  * @todo
  * - O4 後続で aggregator の O2/O3 ライブ配線から `persistInferredCandidate` を呼び出す。
@@ -32,6 +32,7 @@
 "use strict";
 
 import { monitorData } from "./dashboard_data.js";
+import { wallNowMs } from "./dashboard_time.js";
 
 /** candidate store で許可する状態。 */
 export const INFERRED_CANDIDATE_STATUS = Object.freeze({
@@ -97,7 +98,7 @@ function _hashString(text) {
 function _nowMs(options = {}) {
   const injected = Number(options.nowMs);
   if (Number.isFinite(injected) && injected > 0) return injected;
-  return Date.now();
+  return wallNowMs();
 }
 
 /**
@@ -115,10 +116,88 @@ function _store() {
 }
 
 /**
+ * candidate の物理同一性を表す材料を作る。
+ *
+ * 【詳細説明】
+ * - 32bit hash は衝突し得るため、store 内の既存レコードと同一候補かどうかは hash だけで
+ *   判断しない。
+ * - 推定使用量や confidence は再評価で変わり得る表示属性なので、同一性材料から外す。
+ *
+ * @private
+ * @function _candidateIdentityMaterial
+ * @param {{windowId?:?string, candidate?:?Object}} classificationResult - O2 分類結果。
+ * @returns {{windowId:?string,candidateSpoolId:?string,candidateBaselineIntervalId:?string,candidateCurrentIntervalId:?string,observationKeys:Array<string>}}
+ *   candidate の完全照合用材料。
+ */
+function _candidateIdentityMaterial(classificationResult) {
+  const candidate = classificationResult?.candidate || {};
+  const keys = Array.isArray(candidate.offlineObservationKeys)
+    ? candidate.offlineObservationKeys.map(key => String(key)).sort()
+    : [];
+  return {
+    windowId: classificationResult?.windowId ?? candidate.windowId ?? null,
+    candidateSpoolId: candidate.candidateSpoolId != null ? String(candidate.candidateSpoolId) : null,
+    candidateBaselineIntervalId: candidate.candidateBaselineIntervalId ?? null,
+    candidateCurrentIntervalId: candidate.candidateCurrentIntervalId ?? null,
+    observationKeys: keys
+  };
+}
+
+/**
+ * 既存 candidate と新しい同一性材料が完全一致するか判定する。
+ *
+ * 【詳細説明】
+ * - 新形式では `identityMaterial` を保存して直接比較する。
+ * - 旧形式レコードを読む場合は、保存済みフィールドから同じ材料を復元して比較し、import/restore
+ *   互換を保つ。
+ *
+ * @private
+ * @function _sameCandidateIdentity
+ * @param {Object} record - store 内の既存 candidate record。
+ * @param {Object} identityMaterial - 新しく保存しようとしている candidate の同一性材料。
+ * @returns {boolean} 完全一致する場合は true。
+ */
+function _sameCandidateIdentity(record, identityMaterial) {
+  if (!record || !identityMaterial) return false;
+  const existing = record.identityMaterial && typeof record.identityMaterial === "object"
+    ? record.identityMaterial
+    : {
+        windowId: record.windowId ?? null,
+        candidateSpoolId: record.candidateSpoolId != null ? String(record.candidateSpoolId) : null,
+        candidateBaselineIntervalId: record.candidateBaselineIntervalId ?? null,
+        candidateCurrentIntervalId: record.candidateCurrentIntervalId ?? null,
+        observationKeys: Array.isArray(record.observationKeys) ? record.observationKeys.map(key => String(key)).sort() : []
+      };
+  return JSON.stringify(_stable(existing)) === JSON.stringify(_stable(identityMaterial));
+}
+
+/**
+ * projection の debit 配列を candidate record 用にコピーする。
+ *
+ * 【詳細説明】
+ * - projection は純粋計算結果だが、store へ保持する値は後続の再分類やテスト fixture の変更で
+ *   参照が変化しないようにスナップショット化する。
+ *
+ * @private
+ * @function _snapshotCandidateDebits
+ * @param {Array<Object>} candidateDebits - O3 projection の candidateDebits。
+ * @returns {Array<Object>} store 保存用に正規化した debit 配列。
+ */
+function _snapshotCandidateDebits(candidateDebits) {
+  return Array.isArray(candidateDebits) ? candidateDebits.map(item => ({
+    observationKey: item.observationKey,
+    status: item.status,
+    usedMm: Math.max(0, Number(item.usedMm) || 0),
+    reason: item.reason,
+    confirmedSpoolIds: Array.isArray(item.confirmedSpoolIds) ? item.confirmedSpoolIds.slice() : []
+  })) : [];
+}
+
+/**
  * O2/O3 candidate の安定 hash を生成する。
  *
  * 【詳細説明】
- * - windowId、候補スプール、offline observation keys、推定 debit 総量を hash 材料にする。
+ * - windowId、候補スプール、interval、offline observation keys を hash 材料にする。
  * - confidence や evidence は表示・監査属性であり、後から詳細が増えても同じ物理 candidate を
  *   別物にしないため hash 材料へ入れない。
  *
@@ -130,16 +209,8 @@ function _store() {
  * const hash = buildInferredCandidateHash(classification, projection);
  */
 export function buildInferredCandidateHash(classificationResult, projection) {
-  const candidate = classificationResult?.candidate || {};
-  const keys = Array.isArray(candidate.offlineObservationKeys) ? candidate.offlineObservationKeys.slice().sort() : [];
-  const material = {
-    windowId: classificationResult?.windowId ?? candidate.windowId ?? null,
-    candidateSpoolId: candidate.candidateSpoolId ?? null,
-    candidateBaselineIntervalId: candidate.candidateBaselineIntervalId ?? null,
-    candidateCurrentIntervalId: candidate.candidateCurrentIntervalId ?? null,
-    observationKeys: keys,
-    usedMm: Math.max(0, Number(projection?.inferredContinuityUsedMm) || 0)
-  };
+  void projection;
+  const material = _candidateIdentityMaterial(classificationResult);
   return `ic-${_hashString(JSON.stringify(_stable(material)))}`;
 }
 
@@ -147,8 +218,10 @@ export function buildInferredCandidateHash(classificationResult, projection) {
  * O2/O3 の結果を candidate store へ冪等保存する。
  *
  * 【詳細説明】
+ * - `projection.eligibleForPersistence` が true でなければ fail-closed で保存しない。
  * - `projection.inferredContinuityUsedMm` が 0 以下なら、推定 debit 対象が無いため保存しない。
  * - 同じ candidateHash が既に存在する場合は既存レコードを返し、二重作成しない。
+ * - 同じ candidateHash でも同一性材料が完全一致しない場合は hash 衝突として保存を拒否する。
  * - 作成時点の candidate/projection/confidence/evidence をスナップショット化し、後続 UI が
  *   生の 5000 件 observation を見ずに状態表示できるようにする。
  *
@@ -162,6 +235,9 @@ export function buildInferredCandidateHash(classificationResult, projection) {
  * const result = persistInferredCandidate(classification, projection);
  */
 export function persistInferredCandidate(classificationResult, projection, options = {}) {
+  if (projection?.eligibleForPersistence !== true) {
+    return { ok: false, reason: "projection_not_eligible", candidateHash: null, record: null };
+  }
   const usedMm = Math.max(0, Number(projection?.inferredContinuityUsedMm) || 0);
   if (usedMm <= 0) {
     return { ok: false, reason: "no_inferred_debit", candidateHash: null, record: null };
@@ -171,27 +247,48 @@ export function persistInferredCandidate(classificationResult, projection, optio
     return { ok: false, reason: "candidate_incomplete", candidateHash: null, record: null };
   }
   const candidateHash = buildInferredCandidateHash(classificationResult, projection);
+  const identityMaterial = _candidateIdentityMaterial(classificationResult);
   const store = _store();
   if (store[candidateHash]) {
+    if (!_sameCandidateIdentity(store[candidateHash], identityMaterial)) {
+      return { ok: false, reason: "candidate_hash_collision", candidateHash, record: null, collision: store[candidateHash] };
+    }
+    const existing = store[candidateHash];
+    const now = _nowMs(options);
+    const nextDebits = _snapshotCandidateDebits(projection?.candidateDebits);
+    const usedChanged = Math.max(0, Number(existing.usedMm) || 0) !== usedMm;
+    const debitsChanged = JSON.stringify(existing.candidateDebits || []) !== JSON.stringify(nextDebits);
+    const confidenceChanged = JSON.stringify(existing.confidence || null) !== JSON.stringify(classificationResult.confidence || null);
+    const evidenceChanged = JSON.stringify(existing.evidence || null) !== JSON.stringify(classificationResult.evidence || null);
+    if (usedChanged || debitsChanged || confidenceChanged || evidenceChanged) {
+      existing.usedMm = usedMm;
+      existing.candidateDebits = nextDebits;
+      existing.confidence = classificationResult.confidence ? { ...classificationResult.confidence } : null;
+      existing.evidence = classificationResult.evidence ? { ...classificationResult.evidence } : null;
+      existing.updatedAt = now;
+      if (!Array.isArray(existing.events)) existing.events = [];
+      existing.events.push({
+        type: "updated",
+        at: now,
+        status: existing.status,
+        usedMm,
+        reason: usedChanged ? "projection-used-mm-changed" : "projection-metadata-changed"
+      });
+    }
     return { ok: true, reason: "idempotent", candidateHash, record: store[candidateHash], idempotent: true };
   }
 
   const now = _nowMs(options);
   const record = {
     candidateHash,
+    identityMaterial,
     windowId: classificationResult.windowId,
     host: classificationResult.host ?? projection?.host ?? null,
     candidateSpoolId: String(candidate.candidateSpoolId),
     candidateBaselineIntervalId: candidate.candidateBaselineIntervalId ?? null,
     candidateCurrentIntervalId: candidate.candidateCurrentIntervalId ?? null,
     observationKeys: Array.isArray(candidate.offlineObservationKeys) ? candidate.offlineObservationKeys.slice() : [],
-    candidateDebits: Array.isArray(projection?.candidateDebits) ? projection.candidateDebits.map(item => ({
-      observationKey: item.observationKey,
-      status: item.status,
-      usedMm: Math.max(0, Number(item.usedMm) || 0),
-      reason: item.reason,
-      confirmedSpoolIds: Array.isArray(item.confirmedSpoolIds) ? item.confirmedSpoolIds.slice() : []
-    })) : [],
+    candidateDebits: _snapshotCandidateDebits(projection?.candidateDebits),
     usedMm,
     confidence: classificationResult.confidence ? { ...classificationResult.confidence } : null,
     evidence: classificationResult.evidence ? { ...classificationResult.evidence } : null,

--- a/3dp_lib/dashboard_relay_bridge.js
+++ b/3dp_lib/dashboard_relay_bridge.js
@@ -20,9 +20,9 @@
  * - {@link buildCameraEndpoints}：カメラパススルー用エンドポイントを構築する
  * - {@link relayBroadcastIfNeeded}：変更があれば子へデルタ配信する
  *
- * @version 1.390.1110 (PR #380)
+ * @version 1.390.1245 (PR #412)
  * @since   1.390.820 (PR #367)
- * @lastModified 2026-06-12 12:00:00
+ * @lastModified 2026-07-19 18:45:00
  * -----------------------------------------------------------
  */
 
@@ -46,6 +46,9 @@ let _prevMountHash = "";
 
 /** 前回ブロードキャストした pendingUnattributedUsage（未帰属消費 隔離領域）のハッシュ（変更検出） */
 let _prevPendingHash = "";
+
+/** 前回ブロードキャストした inferredCandidateStore（オフライン推定候補）のハッシュ（変更検出） */
+let _prevInferredCandidateHash = "";
 
 /** 前回ブロードキャストした ItemKeeper 設定のハッシュ（変更検出） */
 let _prevIkHash = "";
@@ -612,6 +615,16 @@ function _buildDelta() {
     hasChanges = true;
   }
 
+  // ★ #412-O4: O2/O3 の分類結果・推定 debit を子へミラーする。
+  //   生の 5000 件観測ではなく、親が耐久保存した candidate store だけを同期する。
+  const inferredCandidateHash = _quickHash(monitorData.inferredCandidateStore || {});
+  if (inferredCandidateHash !== _prevInferredCandidateHash) {
+    _prevInferredCandidateHash = inferredCandidateHash;
+    sharedDelta = sharedDelta || {};
+    sharedDelta.inferredCandidateStore = monitorData.inferredCandidateStore || {};
+    hasChanges = true;
+  }
+
   // ★ 監査 P0(第2報): フィラメント補助ドメイン（在庫・カスタムプリセット・表示/
   //   お気に入り・切れ文脈・serialCounter・使用履歴）の変更検出。従来は
   //   filamentSpools/hostSpoolMap/mountHistory のみ共有していたため、これらが親子で
@@ -719,6 +732,8 @@ function _buildFullSnapshot() {
     // ★ Phase4/P0-1: 未帰属消費の隔離領域とアーカイブも同梱（親=権威、子は読み取り専用ミラー）。
     pendingUnattributedUsage: monitorData.pendingUnattributedUsage || [],
     pendingUnattributedUsageArchive: monitorData.pendingUnattributedUsageArchive || {},
+    // ★ #412-O4: 子は分類済み candidate と推定量だけを受け取り、生観測は受け取らない。
+    inferredCandidateStore: monitorData.inferredCandidateStore || {},
     // ★ 監査 P0(第2報): フィラメント補助ドメインをスナップショットにも同梱（親=権威）。
     filamentInventory: monitorData.filamentInventory || [],
     userPresets: monitorData.userPresets || [],

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -26,9 +26,9 @@
  * - {@link loadPrintCurrent}：現ジョブ読込
  * - {@link savePrintCurrent}：現ジョブ保存
  *
-* @version 1.390.787 (PR #367)
+* @version 1.390.1245 (PR #412)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-03-12
+* @lastModified 2026-07-19 18:45:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -257,6 +257,22 @@ export async function importAllData(data) {
     for (const [h, a] of Object.entries(data.pendingUnattributedUsageArchive)) {
       if (a && !monitorData.pendingUnattributedUsageArchive[h]) {
         monitorData.pendingUnattributedUsageArchive[h] = { ...a };
+      }
+    }
+  }
+
+  // ── ★ #412-O4: inferredCandidateStore は candidateHash 単位でマージ ──
+  //   同一 window/candidate の二重処理を避け、既存候補と import 候補が衝突した場合は
+  //   updatedAt が新しい方を採用する。削除ではなく状態遷移で監査する前提のため、未知状態も保持する。
+  if (data.inferredCandidateStore && typeof data.inferredCandidateStore === "object") {
+    if (!monitorData.inferredCandidateStore || typeof monitorData.inferredCandidateStore !== "object") {
+      monitorData.inferredCandidateStore = {};
+    }
+    for (const [hash, value] of Object.entries(data.inferredCandidateStore)) {
+      if (!value || typeof value !== "object") continue;
+      const current = monitorData.inferredCandidateStore[hash];
+      if (!current || (Number(value.updatedAt) || 0) >= (Number(current.updatedAt) || 0)) {
+        monitorData.inferredCandidateStore[hash] = { ...value };
       }
     }
   }
@@ -658,6 +674,8 @@ const LS_GLOBAL_FIELDS = [
   "mountHistoryRejectedEvents",
   // ★ #411-O1: オフライン推定の観測 watermark（baseline＝再起動後の差分基準）＋現セッション観測
   "hostObservationWatermark", "hostObservationCurrent",
+  // ★ #412-O4: オフライン継続推定 candidate（親権威・状態遷移つき）
+  "inferredCandidateStore",
   // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない）
   "pendingUnattributedUsage", "pendingUnattributedUsageArchive",
   // ★ RR-2: 台帳修復要求フラグ（破損時に暗黙クローズせず可視化）
@@ -882,6 +900,7 @@ function _flushStorage() {
       queueSharedWrite("mountHistoryRejectedEvents", monitorData.mountHistoryRejectedEvents);
       queueSharedWrite("hostObservationWatermark", monitorData.hostObservationWatermark);
       queueSharedWrite("hostObservationCurrent",   monitorData.hostObservationCurrent);
+      queueSharedWrite("inferredCandidateStore",   monitorData.inferredCandidateStore);
       // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない・子へも配信）
       queueSharedWrite("pendingUnattributedUsage",        monitorData.pendingUnattributedUsage);
       queueSharedWrite("pendingUnattributedUsageArchive", monitorData.pendingUnattributedUsageArchive);
@@ -1257,6 +1276,21 @@ function _restoreFromData(shared, machines) {
     }
     for (const [h, v] of Object.entries(shared.hostObservationCurrent)) {
       if (v && !monitorData.hostObservationCurrent[h]) monitorData.hostObservationCurrent[h] = { ...v };
+    }
+  }
+
+  // ★ #412-O4: inferredCandidateStore は candidateHash 単位でマージする。
+  //   既存候補がある場合は updatedAt が新しい方を採用し、同一 window の二重処理を避ける。
+  if (shared?.inferredCandidateStore && typeof shared.inferredCandidateStore === "object") {
+    if (!monitorData.inferredCandidateStore || typeof monitorData.inferredCandidateStore !== "object") {
+      monitorData.inferredCandidateStore = {};
+    }
+    for (const [hash, value] of Object.entries(shared.inferredCandidateStore)) {
+      if (!value || typeof value !== "object") continue;
+      const current = monitorData.inferredCandidateStore[hash];
+      if (!current || (Number(value.updatedAt) || 0) >= (Number(current.updatedAt) || 0)) {
+        monitorData.inferredCandidateStore[hash] = { ...value };
+      }
     }
   }
 

--- a/3dp_lib/dashboard_storage_idb.js
+++ b/3dp_lib/dashboard_storage_idb.js
@@ -23,9 +23,9 @@
  * - {@link exportAllIdb}：全データを単一オブジェクトとして読み出し
  * - {@link importAllIdb}：単一オブジェクトから全データを書き込み
  *
- * @version 1.390.787 (PR #366)
+ * @version 1.390.1245 (PR #412)
  * @since   1.390.787 (PR #366)
- * @lastModified 2026-03-11 01:00:00
+ * @lastModified 2026-07-19 18:45:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -106,6 +106,8 @@ const SHARED_KEYS = [
   // ★ #411-O1: オフライン推定の観測 watermark（baseline）＋現セッション観測
   "hostObservationWatermark",
   "hostObservationCurrent",
+  // #412-O4: candidate store は baseline commit 前の耐久保存対象。
+  "inferredCandidateStore",
   // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない）
   "pendingUnattributedUsage",
   "pendingUnattributedUsageArchive",

--- a/tests/unit/dashboard_client_sync_filament_sync.test.js
+++ b/tests/unit/dashboard_client_sync_filament_sync.test.js
@@ -153,6 +153,10 @@ describe("_applySharedFilamentState — フィラメント補助ドメイン（�
     monitorData.pendingUnattributedUsage.splice(0, monitorData.pendingUnattributedUsage.length);
     for (const k of Object.keys(monitorData.filamentEventContext)) delete monitorData.filamentEventContext[k];
     monitorData.spoolSerialCounter = 0;
+    if (!monitorData.inferredCandidateStore || typeof monitorData.inferredCandidateStore !== "object") {
+      monitorData.inferredCandidateStore = {};
+    }
+    for (const k of Object.keys(monitorData.inferredCandidateStore)) delete monitorData.inferredCandidateStore[k];
   });
 
   it("Phase4: pendingUnattributedUsage を親からミラー（in-place 全置換・参照維持）", () => {
@@ -181,6 +185,19 @@ describe("_applySharedFilamentState — フィラメント補助ドメイン（�
     });
     expect(monitorData.pendingUnattributedUsageArchive.stale).toBeUndefined();
     expect(monitorData.pendingUnattributedUsageArchive.k1).toEqual({ count: 3, totalUsedMm: 300 });
+  });
+
+  it("#412-O4: inferredCandidateStore を親から全置換ミラー", () => {
+    monitorData.inferredCandidateStore.stale = { candidateHash: "stale", status: "pending" };
+    _applySharedFilamentState({
+      inferredCandidateStore: {
+        "ic-a": { candidateHash: "ic-a", host: "k1", status: "pending", usedMm: 1200 },
+      },
+    });
+    expect(monitorData.inferredCandidateStore.stale).toBeUndefined();
+    expect(monitorData.inferredCandidateStore["ic-a"]).toEqual({
+      candidateHash: "ic-a", host: "k1", status: "pending", usedMm: 1200
+    });
   });
 
   it("在庫・プリセット・使用履歴を親からミラー（in-place 全置換・参照維持）", () => {

--- a/tests/unit/dashboard_offline_candidate_store.test.js
+++ b/tests/unit/dashboard_offline_candidate_store.test.js
@@ -1,0 +1,151 @@
+/**
+ * @fileoverview dashboard_offline_candidate_store.js（#412-O4 candidate store）の単体テスト
+ * O2/O3 の結果を冪等に永続候補化し、削除ではなく状態遷移で監査できることを検証する。
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mockMonitorData = { inferredCandidateStore: {} };
+vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mockMonitorData }));
+
+const {
+  INFERRED_CANDIDATE_STATUS,
+  buildInferredCandidateHash,
+  persistInferredCandidate,
+  transitionInferredCandidate,
+  getInferredCandidatesForHost
+} = await import("../../3dp_lib/dashboard_offline_candidate_store.js");
+
+/**
+ * O2 分類結果 fixture を作る。
+ *
+ * @function cls
+ * @param {Object} [over] - 上書き値。
+ * @returns {Object} classifyObservationWindow の戻り値相当。
+ */
+function cls(over = {}) {
+  return {
+    classification: "continuity-candidate",
+    host: "k1",
+    windowId: "k1|b1|c2",
+    confidence: { level: "medium", reasons: ["bounded"], contradictions: [] },
+    evidence: { sameMountedSpool: true },
+    candidate: {
+      candidateSpoolId: "S1",
+      candidateBaselineIntervalId: "iv1",
+      candidateCurrentIntervalId: "iv1",
+      offlineObservationKeys: ["kA", "kB"],
+      windowId: "k1|b1|c2"
+    },
+    ...over
+  };
+}
+
+/**
+ * O3 projection fixture を作る。
+ *
+ * @function proj
+ * @param {Object} [over] - 上書き値。
+ * @returns {Object} buildInferredContinuityProjection の戻り値相当。
+ */
+function proj(over = {}) {
+  return {
+    host: "k1",
+    inferredContinuityUsedMm: 3000,
+    candidateDebits: [
+      { observationKey: "kA", status: "inferred-debit", usedMm: 1000, reason: "unattributed-usage", confirmedSpoolIds: [] },
+      { observationKey: "kB", status: "inferred-debit", usedMm: 2000, reason: "unattributed-usage", confirmedSpoolIds: [] }
+    ],
+    ...over
+  };
+}
+
+beforeEach(() => {
+  mockMonitorData.inferredCandidateStore = {};
+});
+
+describe("buildInferredCandidateHash", () => {
+  it("observationKeys の順序差を同じ candidateHash に畳む", () => {
+    const a = buildInferredCandidateHash(cls(), proj());
+    const b = buildInferredCandidateHash(cls({
+      candidate: { ...cls().candidate, offlineObservationKeys: ["kB", "kA"] }
+    }), proj());
+    expect(a).toBe(b);
+    expect(a.startsWith("ic-")).toBe(true);
+  });
+
+  it("windowId が異なれば別 candidateHash になる", () => {
+    const a = buildInferredCandidateHash(cls(), proj());
+    const b = buildInferredCandidateHash(cls({ windowId: "k1|b2|c3" }), proj());
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("persistInferredCandidate", () => {
+  it("O2/O3 結果を pending candidate として保存する", () => {
+    const r = persistInferredCandidate(cls(), proj(), { nowMs: 1000 });
+    expect(r.ok).toBe(true);
+    expect(r.reason).toBe("created");
+    expect(r.record.status).toBe(INFERRED_CANDIDATE_STATUS.PENDING);
+    expect(r.record.usedMm).toBe(3000);
+    expect(r.record.observationKeys).toEqual(["kA", "kB"]);
+    expect(r.record.events).toHaveLength(1);
+    expect(Object.keys(mockMonitorData.inferredCandidateStore)).toEqual([r.candidateHash]);
+  });
+
+  it("同一 candidateHash は再保存しても増殖しない", () => {
+    const first = persistInferredCandidate(cls(), proj(), { nowMs: 1000 });
+    const second = persistInferredCandidate(cls(), proj(), { nowMs: 2000 });
+    expect(second.reason).toBe("idempotent");
+    expect(second.record).toBe(first.record);
+    expect(Object.keys(mockMonitorData.inferredCandidateStore)).toHaveLength(1);
+    expect(second.record.events).toHaveLength(1);
+  });
+
+  it("推定 debit が 0 なら保存しない", () => {
+    const r = persistInferredCandidate(cls(), proj({ inferredContinuityUsedMm: 0 }), { nowMs: 1000 });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("no_inferred_debit");
+    expect(mockMonitorData.inferredCandidateStore).toEqual({});
+  });
+});
+
+describe("transitionInferredCandidate", () => {
+  it("confirmed へ状態遷移し resolvedAt と event を追記する", () => {
+    const created = persistInferredCandidate(cls(), proj(), { nowMs: 1000 });
+    const r = transitionInferredCandidate(created.candidateHash, "confirmed", {
+      nowMs: 2000, actor: "user", reason: "same-spool-confirmed"
+    });
+    expect(r.ok).toBe(true);
+    expect(r.record.status).toBe("confirmed");
+    expect(r.record.resolvedAt).toBe(2000);
+    expect(r.record.events).toHaveLength(2);
+    expect(r.record.events[1].actor).toBe("user");
+  });
+
+  it("同じ状態への再適用は冪等で event を増やさない", () => {
+    const created = persistInferredCandidate(cls(), proj(), { nowMs: 1000 });
+    transitionInferredCandidate(created.candidateHash, "rejected", { nowMs: 2000 });
+    const r = transitionInferredCandidate(created.candidateHash, "rejected", { nowMs: 3000 });
+    expect(r.reason).toBe("idempotent");
+    expect(r.record.events).toHaveLength(2);
+  });
+
+  it("reassigned は assignedSpoolId を保持する", () => {
+    const created = persistInferredCandidate(cls(), proj(), { nowMs: 1000 });
+    const r = transitionInferredCandidate(created.candidateHash, "reassigned", {
+      nowMs: 2000, assignedSpoolId: "S2"
+    });
+    expect(r.record.assignedSpoolId).toBe("S2");
+  });
+});
+
+describe("getInferredCandidatesForHost", () => {
+  it("host と status で candidate を取得する", () => {
+    const k1 = persistInferredCandidate(cls(), proj(), { nowMs: 1000 });
+    persistInferredCandidate(cls({ host: "k2", windowId: "k2|b1|c2" }), proj({ host: "k2" }), { nowMs: 2000 });
+    transitionInferredCandidate(k1.candidateHash, "confirmed", { nowMs: 3000 });
+    expect(getInferredCandidatesForHost("k1")).toHaveLength(1);
+    expect(getInferredCandidatesForHost("k1", { status: "pending" })).toHaveLength(0);
+    expect(getInferredCandidatesForHost("k1", { status: "confirmed" })).toHaveLength(1);
+  });
+});

--- a/tests/unit/dashboard_offline_candidate_store.test.js
+++ b/tests/unit/dashboard_offline_candidate_store.test.js
@@ -50,6 +50,7 @@ function cls(over = {}) {
 function proj(over = {}) {
   return {
     host: "k1",
+    eligibleForPersistence: true,
     inferredContinuityUsedMm: 3000,
     candidateDebits: [
       { observationKey: "kA", status: "inferred-debit", usedMm: 1000, reason: "unattributed-usage", confirmedSpoolIds: [] },
@@ -78,6 +79,12 @@ describe("buildInferredCandidateHash", () => {
     const b = buildInferredCandidateHash(cls({ windowId: "k1|b2|c3" }), proj());
     expect(a).not.toBe(b);
   });
+
+  it("同一 candidate の使用量変化では candidateHash を変えない", () => {
+    const a = buildInferredCandidateHash(cls(), proj({ inferredContinuityUsedMm: 3000 }));
+    const b = buildInferredCandidateHash(cls(), proj({ inferredContinuityUsedMm: 4500 }));
+    expect(a).toBe(b);
+  });
 });
 
 describe("persistInferredCandidate", () => {
@@ -101,11 +108,72 @@ describe("persistInferredCandidate", () => {
     expect(second.record.events).toHaveLength(1);
   });
 
+  it("同一 candidateHash の再評価では使用量と根拠を同一 record 上で更新する", () => {
+    const first = persistInferredCandidate(cls(), proj(), { nowMs: 1000 });
+    const second = persistInferredCandidate(
+      cls({
+        confidence: { level: "high", reasons: ["bounded", "stable"], contradictions: [] },
+        evidence: { sameMountedSpool: true, operatorConfirmed: false }
+      }),
+      proj({
+        inferredContinuityUsedMm: 4500,
+        candidateDebits: [
+          { observationKey: "kA", status: "inferred-debit", usedMm: 1500, reason: "unattributed-usage", confirmedSpoolIds: [] },
+          { observationKey: "kB", status: "inferred-debit", usedMm: 3000, reason: "unattributed-usage", confirmedSpoolIds: [] }
+        ]
+      }),
+      { nowMs: 2000 }
+    );
+    expect(second.reason).toBe("idempotent");
+    expect(second.record).toBe(first.record);
+    expect(second.record.usedMm).toBe(4500);
+    expect(second.record.confidence.level).toBe("high");
+    expect(second.record.evidence.operatorConfirmed).toBe(false);
+    expect(second.record.events).toHaveLength(2);
+    expect(second.record.events[1].reason).toBe("projection-used-mm-changed");
+    expect(Object.keys(mockMonitorData.inferredCandidateStore)).toHaveLength(1);
+  });
+
+  it("projection が永続化対象外なら candidate を保存しない", () => {
+    const r = persistInferredCandidate(cls(), proj({ eligibleForPersistence: false }), { nowMs: 1000 });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("projection_not_eligible");
+    expect(mockMonitorData.inferredCandidateStore).toEqual({});
+  });
+
   it("推定 debit が 0 なら保存しない", () => {
     const r = persistInferredCandidate(cls(), proj({ inferredContinuityUsedMm: 0 }), { nowMs: 1000 });
     expect(r.ok).toBe(false);
     expect(r.reason).toBe("no_inferred_debit");
     expect(mockMonitorData.inferredCandidateStore).toEqual({});
+  });
+
+  it("hash が一致しても identity が違う既存 record は衝突として拒否する", () => {
+    const candidateHash = buildInferredCandidateHash(cls(), proj());
+    mockMonitorData.inferredCandidateStore[candidateHash] = {
+      candidateHash,
+      status: INFERRED_CANDIDATE_STATUS.PENDING,
+      windowId: "k9|b1|c2",
+      host: "k9",
+      candidateSpoolId: "S9",
+      candidateBaselineIntervalId: "iv9",
+      candidateCurrentIntervalId: "iv9",
+      observationKeys: ["kZ"],
+      identityMaterial: {
+        windowId: "k9|b1|c2",
+        candidateSpoolId: "S9",
+        candidateBaselineIntervalId: "iv9",
+        candidateCurrentIntervalId: "iv9",
+        observationKeys: ["kZ"]
+      },
+      events: []
+    };
+    const r = persistInferredCandidate(cls(), proj(), { nowMs: 2000 });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("candidate_hash_collision");
+    expect(r.collision).toBe(mockMonitorData.inferredCandidateStore[candidateHash]);
+    expect(Object.keys(mockMonitorData.inferredCandidateStore)).toHaveLength(1);
+    expect(mockMonitorData.inferredCandidateStore[candidateHash].windowId).toBe("k9|b1|c2");
   });
 });
 

--- a/tests/unit/dashboard_storage_migration.test.js
+++ b/tests/unit/dashboard_storage_migration.test.js
@@ -41,6 +41,7 @@ const monitorData = {
   mountHistorySeq: 0,
   pendingUnattributedUsage: [],
   pendingUnattributedUsageArchive: {},
+  inferredCandidateStore: {},
   ledgerRepairRequired: {},
   filamentEventContext: {},
   hostSpoolMap: {},
@@ -64,6 +65,7 @@ function resetMonitorData() {
   monitorData.mountHistorySeq = 0;
   monitorData.pendingUnattributedUsage = [];
   monitorData.pendingUnattributedUsageArchive = {};
+  monitorData.inferredCandidateStore = {};
   monitorData.ledgerRepairRequired = {};
   monitorData.hostSpoolMap = {};
   monitorData.hostCameraToggle = {};
@@ -162,6 +164,9 @@ describe('v2.2.1027 追加フィールドの round-trip', () => {
     };
     monitorData.mountHistorySeq = 42;
     monitorData.ledgerRepairRequired = { h: { spoolId: "S", status: "ambiguous", detectedAtEpochMs: 99 } };
+    monitorData.inferredCandidateStore = {
+      "ic-a": { candidateHash: "ic-a", host: "h", windowId: "w1", candidateSpoolId: "S", usedMm: 1234, status: "pending", updatedAt: 111 },
+    };
 
     saveUnifiedStorage(true);
     resetMonitorData(); // リロード模擬（隔離・アーカイブ・seq・修復要求を空へ）
@@ -178,6 +183,25 @@ describe('v2.2.1027 追加フィールドの round-trip', () => {
     expect(monitorData.mountHistorySeq).toBe(42);
     // RR-2: 台帳修復要求フラグも往復で保持
     expect(monitorData.ledgerRepairRequired.h.status).toBe("ambiguous");
+    // #412-O4: 推定 candidate store も往復で保持
+    expect(monitorData.inferredCandidateStore["ic-a"].usedMm).toBe(1234);
+  });
+
+  it('#412-O4: import は candidateHash 単位で冪等マージし updatedAt が新しい方を採用する', async () => {
+    monitorData.inferredCandidateStore = {
+      "ic-a": { candidateHash: "ic-a", status: "pending", usedMm: 100, updatedAt: 20 },
+      "ic-old": { candidateHash: "ic-old", status: "pending", usedMm: 50, updatedAt: 100 },
+    };
+    await importAllData({
+      inferredCandidateStore: {
+        "ic-a": { candidateHash: "ic-a", status: "confirmed", usedMm: 100, updatedAt: 30 },
+        "ic-old": { candidateHash: "ic-old", status: "rejected", usedMm: 50, updatedAt: 10 },
+        "ic-b": { candidateHash: "ic-b", status: "pending", usedMm: 200, updatedAt: 40 },
+      },
+    });
+    expect(monitorData.inferredCandidateStore["ic-a"].status).toBe("confirmed");
+    expect(monitorData.inferredCandidateStore["ic-old"].status).toBe("pending");
+    expect(monitorData.inferredCandidateStore["ic-b"].usedMm).toBe(200);
   });
 
   it('P1-1: import は同一 opId(別evId)の mount を1件に畳む', async () => {


### PR DESCRIPTION
## Summary
- add an inferred continuity candidate store with deterministic candidate hashes
- persist candidate state through localStorage/IndexedDB/import/restore paths
- mirror candidate summaries to relay children without syncing raw observation windows

## Validation
- npx vitest run tests/unit/dashboard_offline_candidate_store.test.js tests/unit/dashboard_storage_migration.test.js tests/unit/dashboard_client_sync_filament_sync.test.js
- npx vitest run --silent --reporter=dot
- npx eslint 3dp_lib/dashboard_offline_candidate_store.js 3dp_lib/dashboard_data.js 3dp_lib/dashboard_storage.js 3dp_lib/dashboard_storage_idb.js 3dp_lib/dashboard_relay_bridge.js 3dp_lib/dashboard_client_sync.js