### PR TITLE
Wire inferred continuity shadow flow

### DIFF
--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -23,7 +23,7 @@
  *
 * @version 1.390.1246 (PR #413)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-07-22 12:00:00
+* @lastModified 2026-07-22 19:00:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -1363,13 +1363,15 @@ export function aggregatorUpdate() {
         // ★ #413-O2/O3/O4 live shadow: #409 catch-up 後も未帰属として残った offline 完了だけを
         //   inferredCandidateStore へ冪等保存し、candidate 保存成功時のみ観測 baseline を昇格する。
         //   projection/candidate は確認 UI 用の pending 情報であり、確定残量や filamentInfo は変更しない。
-        runInferredContinuityShadow(host, spool).then((shadow) => {
-          if (shadow.ok && shadow.persist?.candidateHash) {
-            console.debug(`[aggregator] ${host}: inferred continuity candidate=${shadow.persist.candidateHash} commit=${shadow.commit?.reason}`);
-          }
-        }).catch((e) => {
-          console.warn("[aggregator] inferred continuity shadow 失敗:", e?.message || e);
-        });
+        if (!_isRelayChild()) {
+          runInferredContinuityShadow(host, spool).then((shadow) => {
+            if (shadow.ok && shadow.persist?.candidateHash) {
+              console.debug(`[aggregator] ${host}: inferred continuity candidate=${shadow.persist.candidateHash} commit=${shadow.commit?.reason}`);
+            }
+          }).catch((e) => {
+            console.warn("[aggregator] inferred continuity shadow 失敗:", e?.message || e);
+          });
+        }
       } catch (e) { console.warn("[aggregator] catchUp 失敗:", e?.message || e); }
     }
 

--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -21,9 +21,9 @@
  * - {@link setHistoryPersistFunc}：履歴永続化関数の登録
  * - {@link getCurrentPrintID}：現在の印刷IDを取得
  *
-* @version 1.390.1110 (PR #380)
+* @version 1.390.1246 (PR #413)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-06-12 12:00:00
+* @lastModified 2026-07-22 02:00:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -60,6 +60,7 @@ import { getConnectionState } from "./dashboard_connection.js";
 import { normalizeJobId } from "./dashboard_utils.js";
 import { monotonicNowMs, randomEventId } from "./dashboard_time.js";
 import { recordObservation, observationDue } from "./dashboard_offline_observation.js";
+import { runInferredContinuityShadow } from "./dashboard_offline_live_shadow.js";
 
 // ---------------------------------------------------------------------------
 // 状態変数／タイムスタンプ定義（per-host 管理）
@@ -1358,6 +1359,13 @@ export function aggregatorUpdate() {
         }
         if (linked > 0) {
           console.debug(`[aggregator] ${host}: catchUp linked=${linked}`);
+        }
+        // ★ #413-O2/O3/O4 live shadow: #409 catch-up 後も未帰属として残った offline 完了だけを
+        //   inferredCandidateStore へ冪等保存し、candidate 保存成功時のみ観測 baseline を昇格する。
+        //   projection/candidate は確認 UI 用の pending 情報であり、確定残量や filamentInfo は変更しない。
+        const shadow = runInferredContinuityShadow(host, spool);
+        if (shadow.ok && shadow.persist?.candidateHash) {
+          console.debug(`[aggregator] ${host}: inferred continuity candidate=${shadow.persist.candidateHash} commit=${shadow.commit?.reason}`);
         }
       } catch (e) { console.warn("[aggregator] catchUp 失敗:", e?.message || e); }
     }

--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -23,7 +23,7 @@
  *
 * @version 1.390.1246 (PR #413)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-07-22 02:00:00
+* @lastModified 2026-07-22 12:00:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -1363,10 +1363,13 @@ export function aggregatorUpdate() {
         // ★ #413-O2/O3/O4 live shadow: #409 catch-up 後も未帰属として残った offline 完了だけを
         //   inferredCandidateStore へ冪等保存し、candidate 保存成功時のみ観測 baseline を昇格する。
         //   projection/candidate は確認 UI 用の pending 情報であり、確定残量や filamentInfo は変更しない。
-        const shadow = runInferredContinuityShadow(host, spool);
-        if (shadow.ok && shadow.persist?.candidateHash) {
-          console.debug(`[aggregator] ${host}: inferred continuity candidate=${shadow.persist.candidateHash} commit=${shadow.commit?.reason}`);
-        }
+        runInferredContinuityShadow(host, spool).then((shadow) => {
+          if (shadow.ok && shadow.persist?.candidateHash) {
+            console.debug(`[aggregator] ${host}: inferred continuity candidate=${shadow.persist.candidateHash} commit=${shadow.commit?.reason}`);
+          }
+        }).catch((e) => {
+          console.warn("[aggregator] inferred continuity shadow 失敗:", e?.message || e);
+        });
       } catch (e) { console.warn("[aggregator] catchUp 失敗:", e?.message || e); }
     }
 

--- a/3dp_lib/dashboard_offline_candidate_store.js
+++ b/3dp_lib/dashboard_offline_candidate_store.js
@@ -20,9 +20,9 @@
  * - {@link transitionInferredCandidate}：candidate の状態を監査 event 付きで変更する
  * - {@link getInferredCandidatesForHost}：host 単位で candidate を取得する
  *
- * @version 1.390.1250 (PR #412)
+ * @version 1.390.1246 (PR #413)
  * @since   1.390.1245 (PR #412)
- * @lastModified 2026-07-25 12:17:09
+ * @lastModified 2026-07-22 12:00:00
  * -----------------------------------------------------------
  * @todo
  * - O4 後続で aggregator の O2/O3 ライブ配線から `persistInferredCandidate` を呼び出す。
@@ -220,6 +220,8 @@ export function buildInferredCandidateHash(classificationResult, projection) {
  * 【詳細説明】
  * - `projection.eligibleForPersistence` が true でなければ fail-closed で保存しない。
  * - `projection.inferredContinuityUsedMm` が 0 以下なら、推定 debit 対象が無いため保存しない。
+ * - `projection.eligibleForPersistence` が true でない場合は、矛盾・曖昧・残量不明などの fail-closed
+ *   判定を尊重して保存しない。
  * - 同じ candidateHash が既に存在する場合は既存レコードを返し、二重作成しない。
  * - 同じ candidateHash でも同一性材料が完全一致しない場合は hash 衝突として保存を拒否する。
  * - 作成時点の candidate/projection/confidence/evidence をスナップショット化し、後続 UI が
@@ -236,7 +238,8 @@ export function buildInferredCandidateHash(classificationResult, projection) {
  */
 export function persistInferredCandidate(classificationResult, projection, options = {}) {
   if (projection?.eligibleForPersistence !== true) {
-    return { ok: false, reason: "projection_not_eligible", candidateHash: null, record: null };
+    const reason = projection?.status && projection.status !== "ok" ? projection.status : "projection_not_eligible";
+    return { ok: false, reason, candidateHash: null, record: null };
   }
   const usedMm = Math.max(0, Number(projection?.inferredContinuityUsedMm) || 0);
   if (usedMm <= 0) {

--- a/3dp_lib/dashboard_offline_candidate_store.js
+++ b/3dp_lib/dashboard_offline_candidate_store.js
@@ -20,9 +20,9 @@
  * - {@link transitionInferredCandidate}：candidate の状態を監査 event 付きで変更する
  * - {@link getInferredCandidatesForHost}：host 単位で candidate を取得する
  *
- * @version 1.390.1256 (PR #413)
+ * @version 1.390.1260 (PR #413)
  * @since   1.390.1245 (PR #412)
- * @lastModified 2026-07-25 11:15:54
+ * @lastModified 2026-07-25 12:38:02
  * -----------------------------------------------------------
  * @todo
  * - O4 後続で aggregator の O2/O3 ライブ配線から `persistInferredCandidate` を呼び出す。
@@ -258,6 +258,9 @@ export function persistInferredCandidate(classificationResult, projection, optio
       return { ok: false, reason: "candidate_hash_collision", candidateHash, record: null, collision: store[candidateHash] };
     }
     const existing = store[candidateHash];
+    if (existing.status !== INFERRED_CANDIDATE_STATUS.PENDING) {
+      return { ok: false, reason: "candidate_not_pending", candidateHash, record: existing };
+    }
     if (existing.status === INFERRED_CANDIDATE_STATUS.PENDING) {
       const nextDebits = _snapshotCandidateDebits(projection?.candidateDebits);
       const nextConfidence = classificationResult.confidence ? { ...classificationResult.confidence } : null;

--- a/3dp_lib/dashboard_offline_candidate_store.js
+++ b/3dp_lib/dashboard_offline_candidate_store.js
@@ -20,9 +20,9 @@
  * - {@link transitionInferredCandidate}：candidate の状態を監査 event 付きで変更する
  * - {@link getInferredCandidatesForHost}：host 単位で candidate を取得する
  *
- * @version 1.390.1246 (PR #413)
+ * @version 1.390.1256 (PR #413)
  * @since   1.390.1245 (PR #412)
- * @lastModified 2026-07-22 19:00:00
+ * @lastModified 2026-07-25 11:15:54
  * -----------------------------------------------------------
  * @todo
  * - O4 後続で aggregator の O2/O3 ライブ配線から `persistInferredCandidate` を呼び出す。
@@ -258,27 +258,27 @@ export function persistInferredCandidate(classificationResult, projection, optio
       return { ok: false, reason: "candidate_hash_collision", candidateHash, record: null, collision: store[candidateHash] };
     }
     const existing = store[candidateHash];
-    const now = _nowMs(options);
-    const nextDebits = _snapshotCandidateDebits(projection?.candidateDebits);
-    const usedChanged = Math.max(0, Number(existing.usedMm) || 0) !== usedMm;
-    const debitsChanged = JSON.stringify(existing.candidateDebits || []) !== JSON.stringify(nextDebits);
-    const confidenceChanged = JSON.stringify(existing.confidence || null) !== JSON.stringify(classificationResult.confidence || null);
-    const evidenceChanged = JSON.stringify(existing.evidence || null) !== JSON.stringify(classificationResult.evidence || null);
-    if (usedChanged || debitsChanged || confidenceChanged || evidenceChanged) {
-      existing.usedMm = usedMm;
-      existing.candidateDebits = nextDebits;
-      existing.confidence = classificationResult.confidence ? { ...classificationResult.confidence } : null;
-      existing.evidence = classificationResult.evidence ? { ...classificationResult.evidence } : null;
-      existing.updatedAt = now;
-      if (!Array.isArray(existing.events)) existing.events = [];
-      existing.events.push({
-        type: "updated",
-        at: now,
-        status: existing.status,
-        usedMm,
-        reason: usedChanged ? "projection-used-mm-changed" : "projection-metadata-changed"
-      });
-      return { ok: true, reason: "updated", candidateHash, record: existing };
+    if (existing.status === INFERRED_CANDIDATE_STATUS.PENDING) {
+      const nextDebits = _snapshotCandidateDebits(projection?.candidateDebits);
+      const nextConfidence = classificationResult.confidence ? { ...classificationResult.confidence } : null;
+      const nextEvidence = classificationResult.evidence ? { ...classificationResult.evidence } : null;
+      const usedChanged = existing.usedMm !== usedMm;
+      const debitsChanged = JSON.stringify(existing.candidateDebits ?? null) !== JSON.stringify(nextDebits);
+      const confidenceChanged = JSON.stringify(existing.confidence ?? null) !== JSON.stringify(nextConfidence);
+      const evidenceChanged = JSON.stringify(existing.evidence ?? null) !== JSON.stringify(nextEvidence);
+      if (usedChanged || debitsChanged || confidenceChanged || evidenceChanged) {
+        const now = _nowMs(options);
+        existing.usedMm = usedMm;
+        existing.updatedAt = now;
+        existing.candidateDebits = nextDebits;
+        existing.confidence = nextConfidence;
+        existing.evidence = nextEvidence;
+        if (!Array.isArray(existing.events)) existing.events = [];
+        if (usedChanged) {
+          existing.events.push({ type: "updated", at: now, status: existing.status, usedMm, reason: "projection-used-mm-changed" });
+        }
+        return { ok: true, reason: "updated", candidateHash, record: existing };
+      }
     }
     return { ok: true, reason: "idempotent", candidateHash, record: store[candidateHash], idempotent: true };
   }

--- a/3dp_lib/dashboard_offline_candidate_store.js
+++ b/3dp_lib/dashboard_offline_candidate_store.js
@@ -22,7 +22,7 @@
  *
  * @version 1.390.1246 (PR #413)
  * @since   1.390.1245 (PR #412)
- * @lastModified 2026-07-22 12:00:00
+ * @lastModified 2026-07-22 19:00:00
  * -----------------------------------------------------------
  * @todo
  * - O4 後続で aggregator の O2/O3 ライブ配線から `persistInferredCandidate` を呼び出す。
@@ -222,7 +222,8 @@ export function buildInferredCandidateHash(classificationResult, projection) {
  * - `projection.inferredContinuityUsedMm` が 0 以下なら、推定 debit 対象が無いため保存しない。
  * - `projection.eligibleForPersistence` が true でない場合は、矛盾・曖昧・残量不明などの fail-closed
  *   判定を尊重して保存しない。
- * - 同じ candidateHash が既に存在する場合は既存レコードを返し、二重作成しない。
+ * - 同じ candidateHash が既に存在する場合は既存レコードを返し、推定 debit が変化した時だけ同じ
+ *   レコードを更新して監査 event を追記する。
  * - 同じ candidateHash でも同一性材料が完全一致しない場合は hash 衝突として保存を拒否する。
  * - 作成時点の candidate/projection/confidence/evidence をスナップショット化し、後続 UI が
  *   生の 5000 件 observation を見ずに状態表示できるようにする。
@@ -277,6 +278,7 @@ export function persistInferredCandidate(classificationResult, projection, optio
         usedMm,
         reason: usedChanged ? "projection-used-mm-changed" : "projection-metadata-changed"
       });
+      return { ok: true, reason: "updated", candidateHash, record: existing };
     }
     return { ok: true, reason: "idempotent", candidateHash, record: store[candidateHash], idempotent: true };
   }

--- a/3dp_lib/dashboard_offline_classifier.js
+++ b/3dp_lib/dashboard_offline_classifier.js
@@ -61,11 +61,6 @@ function _levelMin(a, b) {
   return _LEVELS[Math.max(ia < 0 ? 0 : ia, ib < 0 ? 0 : ib)];
 }
 
-/** 複合キー(JSON tuple)から canonicalJobId を取り出す。 */
-function _idOfKey(key) {
-  try { const a = JSON.parse(key); return Array.isArray(a) ? String(a[0]) : ""; } catch { return ""; }
-}
-
 /**
  * 停止前に印刷中だったジョブの完了を offline で観測できたか（＝開始をアプリが観測済み）。
  * ★ P1-B: ID 一致だけでは不十分（idle の残存 current・ID 再利用で誤判定）。印刷中に取得した

--- a/3dp_lib/dashboard_offline_live_shadow.js
+++ b/3dp_lib/dashboard_offline_live_shadow.js
@@ -20,7 +20,7 @@
  *
  * @version 1.390.1246 (PR #413)
  * @since   1.390.1246 (PR #413)
- * @lastModified 2026-07-22 12:00:00
+ * @lastModified 2026-07-22 19:00:00
  * -----------------------------------------------------------
  * @todo
  * - O5 で UI 確認・否認・再割当てから candidate status を遷移させる。
@@ -34,6 +34,7 @@ import { ATTR_CLASS, classifyHostAttribution } from "./dashboard_offline_classif
 import { commitObservationWindow } from "./dashboard_offline_observation.js";
 import { buildInferredContinuityProjection } from "./dashboard_offline_projection.js";
 import { persistInferredCandidate } from "./dashboard_offline_candidate_store.js";
+import { wallNowMs } from "./dashboard_time.js";
 
 /**
  * 現在の観測スナップショットから app session ID を取り出す。
@@ -126,11 +127,11 @@ export async function runInferredContinuityShadow(host, spool, options = {}) {
       return { ok: false, reason: persist?.reason || "candidate_not_persisted", classification, projection, persist };
     }
 
-    const save = await _saveIfEnabled(options);
+    const save = persist.idempotent ? null : await _saveIfEnabled(options);
     if (save && save.ok === false) {
       return { ok: false, reason: save.reason || "candidate_not_durably_saved", classification, projection, persist, save };
     }
-    const persistedAt = Number(persist.record?.createdAt) || Number(persist.record?.updatedAt) || Date.now();
+    const persistedAt = Number(persist.record?.createdAt) || Number(persist.record?.updatedAt) || wallNowMs();
     const commit = commitObservationWindow(host, {
       windowId: classification.windowId,
       expectedSequence: classification.currentSequence,
@@ -138,7 +139,7 @@ export async function runInferredContinuityShadow(host, spool, options = {}) {
       candidateHash: persist.candidateHash,
       expectedAppSessionId
     });
-    const commitSave = commit?.ok ? await _saveIfEnabled(options) : null;
+    const commitSave = commit?.ok && !commit.idempotent ? await _saveIfEnabled(options) : null;
     if (commit?.ok && commitSave && commitSave.ok === false) {
       return { ok: false, reason: commitSave.reason || "baseline_not_durably_saved", classification, projection, persist, commit, save: commitSave };
     }

--- a/3dp_lib/dashboard_offline_live_shadow.js
+++ b/3dp_lib/dashboard_offline_live_shadow.js
@@ -18,9 +18,9 @@
  * 【公開関数一覧】
  * - {@link runInferredContinuityShadow}：host 単位で O2/O3/O4 の shadow 評価を実行する。
  *
- * @version 1.390.1246 (PR #413)
+ * @version 1.390.1255 (PR #413)
  * @since   1.390.1246 (PR #413)
- * @lastModified 2026-07-22 20:30:00
+ * @lastModified 2026-07-23 15:29:05
  * -----------------------------------------------------------
  * @todo
  * - O5 で UI 確認・否認・再割当てから candidate status を遷移させる。
@@ -31,10 +31,13 @@
 import { monitorData } from "./dashboard_data.js";
 import { saveUnifiedStorageDurably } from "./dashboard_storage.js";
 import { ATTR_CLASS, classifyHostAttribution } from "./dashboard_offline_classifier.js";
-import { commitObservationWindow } from "./dashboard_offline_observation.js";
+import { commitObservationWindow, rollbackObservationWindowCommit } from "./dashboard_offline_observation.js";
 import { buildInferredContinuityProjection } from "./dashboard_offline_projection.js";
 import { persistInferredCandidate } from "./dashboard_offline_candidate_store.js";
 import { wallNowMs } from "./dashboard_time.js";
+
+/** host 単位で live shadow の多重実行を防ぐ in-flight registry。 */
+const _shadowInflightByHost = new Map();
 
 /**
  * 現在の観測スナップショットから app session ID を取り出す。
@@ -154,6 +157,33 @@ async function _saveIfEnabled(options) {
  * const result = await runInferredContinuityShadow("printer-a", spool);
  */
 export async function runInferredContinuityShadow(host, spool, options = {}) {
+  if (host && _shadowInflightByHost.has(host)) {
+    return { ok: false, reason: "shadow_in_flight" };
+  }
+  const run = _runInferredContinuityShadow(host, spool, options);
+  if (host) _shadowInflightByHost.set(host, run);
+  try {
+    return await run;
+  } finally {
+    if (host && _shadowInflightByHost.get(host) === run) _shadowInflightByHost.delete(host);
+  }
+}
+
+/**
+ * オフライン継続候補を live shadow mode で評価する内部実装。
+ *
+ * 【詳細説明】
+ * - 公開関数側で host 単位の in-flight 直列化を行い、この関数は1回分の評価だけを担当する。
+ *
+ * @private
+ * @function _runInferredContinuityShadow
+ * @param {string} host - 対象ホスト名。
+ * @param {?Object} spool - 現在選択中の spool オブジェクト。
+ * @param {{save?:boolean}} [options] - テスト用オプション。
+ * @returns {Promise<{ok:boolean, reason:string, classification?:Object, projection?:Object, persist?:Object, commit?:Object, save?:Object, rollback?:Object, error?:string}>}
+ *   shadow 評価結果。
+ */
+async function _runInferredContinuityShadow(host, spool, options = {}) {
   try {
     if (!host) return { ok: false, reason: "host_required" };
     if (!spool || !spool.id) return { ok: false, reason: "spool_required" };
@@ -172,7 +202,7 @@ export async function runInferredContinuityShadow(host, spool, options = {}) {
       return { ok: false, reason: persist?.reason || "candidate_not_persisted", classification, projection, persist };
     }
 
-    const save = persist.idempotent ? null : await _saveIfEnabled(options);
+    const save = await _saveIfEnabled(options);
     if (save && save.ok === false) {
       return { ok: false, reason: save.reason || "candidate_not_durably_saved", classification, projection, persist, save };
     }
@@ -198,7 +228,11 @@ export async function runInferredContinuityShadow(host, spool, options = {}) {
     });
     const commitSave = commit?.ok && !commit.idempotent ? await _saveIfEnabled(options) : null;
     if (commit?.ok && commitSave && commitSave.ok === false) {
-      return { ok: false, reason: commitSave.reason || "baseline_not_durably_saved", classification, projection, persist, commit, save: commitSave };
+      const rollback = rollbackObservationWindowCommit(host, {
+        windowId: commitClassification.windowId,
+        previousBaseline: commit.previousBaseline
+      });
+      return { ok: false, reason: commitSave.reason || "baseline_not_durably_saved", classification, projection, persist, commit, save: commitSave, rollback };
     }
 
     return {

--- a/3dp_lib/dashboard_offline_live_shadow.js
+++ b/3dp_lib/dashboard_offline_live_shadow.js
@@ -18,9 +18,9 @@
  * 【公開関数一覧】
  * - {@link runInferredContinuityShadow}：host 単位で O2/O3/O4 の shadow 評価を実行する。
  *
- * @version 1.390.1255 (PR #413)
+ * @version 1.390.1259 (PR #413)
  * @since   1.390.1246 (PR #413)
- * @lastModified 2026-07-23 15:29:05
+ * @lastModified 2026-07-25 12:23:47
  * -----------------------------------------------------------
  * @todo
  * - O5 で UI 確認・否認・再割当てから candidate status を遷移させる。
@@ -33,7 +33,7 @@ import { saveUnifiedStorageDurably } from "./dashboard_storage.js";
 import { ATTR_CLASS, classifyHostAttribution } from "./dashboard_offline_classifier.js";
 import { commitObservationWindow, rollbackObservationWindowCommit } from "./dashboard_offline_observation.js";
 import { buildInferredContinuityProjection } from "./dashboard_offline_projection.js";
-import { persistInferredCandidate } from "./dashboard_offline_candidate_store.js";
+import { INFERRED_CANDIDATE_STATUS, persistInferredCandidate, transitionInferredCandidate } from "./dashboard_offline_candidate_store.js";
 import { wallNowMs } from "./dashboard_time.js";
 
 /** host 単位で live shadow の多重実行を防ぐ in-flight registry。 */
@@ -138,6 +138,31 @@ async function _saveIfEnabled(options) {
 }
 
 /**
+ * baseline commit に進めなかった保存済み candidate を superseded へ遷移する。
+ *
+ * 【詳細説明】
+ * - candidate の耐久保存後に分類変化や observation commit 失敗が起きた場合、pending のまま残すと
+ *   O5 で古い候補と再評価後の候補が二重表示される。
+ * - 保存された candidate は削除せず、監査履歴を残すため `superseded` へ遷移する。
+ *
+ * @private
+ * @function _supersedePersistedCandidate
+ * @param {Object} persist - `persistInferredCandidate()` の戻り値。
+ * @param {string} reason - supersede する理由。
+ * @param {Object} [options] - テスト用 clock などのオプション。
+ * @returns {{ok:boolean, reason:string, record:?Object}|null} 遷移結果。candidateHash が無い場合は null。
+ */
+function _supersedePersistedCandidate(persist, reason, options = {}) {
+  if (!persist?.candidateHash) return null;
+  return transitionInferredCandidate(persist.candidateHash, INFERRED_CANDIDATE_STATUS.SUPERSEDED, {
+    actor: "system",
+    reason,
+    supersededBy: null,
+    nowMs: options?.nowMs
+  });
+}
+
+/**
  * オフライン継続候補を live shadow mode で評価し、pending candidate と baseline commit を冪等に作成する。
  *
  * 【詳細説明】
@@ -208,6 +233,21 @@ async function _runInferredContinuityShadow(host, spool, options = {}) {
     }
     const commitClassification = classifyHostAttribution(host);
     if (!_sameCandidateIdentity(classification, commitClassification)) {
+      const supersede = _supersedePersistedCandidate(persist, "classification-changed-after-persist", options);
+      const supersedeSave = supersede?.ok && !supersede.idempotent ? await _saveIfEnabled(options) : null;
+      if (supersedeSave && supersedeSave.ok === false) {
+        return {
+          ok: false,
+          reason: supersedeSave.reason || "candidate_supersede_not_durably_saved",
+          classification,
+          commitClassification,
+          projection,
+          persist,
+          save,
+          supersede,
+          supersedeSave
+        };
+      }
       return {
         ok: false,
         reason: "classification_changed_since_candidate_persisted",
@@ -215,7 +255,9 @@ async function _runInferredContinuityShadow(host, spool, options = {}) {
         commitClassification,
         projection,
         persist,
-        save
+        save,
+        supersede,
+        supersedeSave
       };
     }
     const persistedAt = Number(persist.record?.createdAt) || Number(persist.record?.updatedAt) || wallNowMs();
@@ -226,13 +268,45 @@ async function _runInferredContinuityShadow(host, spool, options = {}) {
       candidateHash: persist.candidateHash,
       expectedAppSessionId: _currentAppSessionId(host)
     });
+    if (!commit?.ok) {
+      const supersede = _supersedePersistedCandidate(persist, "observation-commit-failed", options);
+      const supersedeSave = supersede?.ok && !supersede.idempotent ? await _saveIfEnabled(options) : null;
+      if (supersedeSave && supersedeSave.ok === false) {
+        return {
+          ok: false,
+          reason: supersedeSave.reason || "candidate_supersede_not_durably_saved",
+          classification,
+          projection,
+          persist,
+          commit,
+          save,
+          supersede,
+          supersedeSave
+        };
+      }
+      return {
+        ok: false,
+        reason: commit?.reason || "commit_failed",
+        classification,
+        projection,
+        persist,
+        commit,
+        save,
+        supersede,
+        supersedeSave
+      };
+    }
     const commitSave = commit?.ok && !commit.idempotent ? await _saveIfEnabled(options) : null;
     if (commit?.ok && commitSave && commitSave.ok === false) {
       const rollback = rollbackObservationWindowCommit(host, {
         windowId: commitClassification.windowId,
         previousBaseline: commit.previousBaseline
       });
-      return { ok: false, reason: commitSave.reason || "baseline_not_durably_saved", classification, projection, persist, commit, save: commitSave, rollback };
+      const rollbackSave = rollback?.ok ? await _saveIfEnabled(options) : null;
+      const reason = rollbackSave && rollbackSave.ok === false
+        ? rollbackSave.reason || "rollback_not_durably_saved"
+        : commitSave.reason || "baseline_not_durably_saved";
+      return { ok: false, reason, classification, projection, persist, commit, save: commitSave, rollback, rollbackSave };
     }
 
     return {

--- a/3dp_lib/dashboard_offline_live_shadow.js
+++ b/3dp_lib/dashboard_offline_live_shadow.js
@@ -20,7 +20,7 @@
  *
  * @version 1.390.1246 (PR #413)
  * @since   1.390.1246 (PR #413)
- * @lastModified 2026-07-22 19:00:00
+ * @lastModified 2026-07-22 20:30:00
  * -----------------------------------------------------------
  * @todo
  * - O5 で UI 確認・否認・再割当てから candidate status を遷移させる。
@@ -71,6 +71,52 @@ function _historyForHost(host) {
 }
 
 /**
+ * offline observation key 配列が同じ候補窓を表すか判定する。
+ *
+ * 【詳細説明】
+ * - O2 の candidate identity は observation key 集合で決まるため、順序差は同一とみなす。
+ * - 保存待ち中に新しい offline job が増えた場合は別窓として扱い、baseline commit を止める。
+ *
+ * @private
+ * @function _sameObservationKeys
+ * @param {Array<string>} a - 比較元 key 配列。
+ * @param {Array<string>} b - 比較先 key 配列。
+ * @returns {boolean} 同じ key 集合なら true。
+ */
+function _sameObservationKeys(a, b) {
+  const left = Array.isArray(a) ? a.map(String).sort() : [];
+  const right = Array.isArray(b) ? b.map(String).sort() : [];
+  if (left.length !== right.length) return false;
+  return left.every((key, index) => key === right[index]);
+}
+
+/**
+ * candidate 保存後の再分類結果が、保存済み candidate と同じ窓 identity を保っているか判定する。
+ *
+ * 【詳細説明】
+ * - `saveUnifiedStorageDurably()` の await 中に observationSequence だけが進んだ場合は、
+ *   同一窓として最新 sequence で baseline commit してよい。
+ * - spool、mount interval、windowId、offline key 集合のいずれかが変わった場合は、保存済み
+ *   candidate と現在窓が一致しないため fail-closed する。
+ *
+ * @private
+ * @function _sameCandidateIdentity
+ * @param {Object} before - candidate 保存前に使った classification。
+ * @param {Object} after - candidate 保存後に再取得した classification。
+ * @returns {boolean} baseline commit に同じ candidateHash を使えるなら true。
+ */
+function _sameCandidateIdentity(before, after) {
+  if (after?.classification !== ATTR_CLASS.CONTINUITY_CANDIDATE) return false;
+  const b = before?.candidate || {};
+  const a = after?.candidate || {};
+  return (before?.windowId ?? b.windowId ?? null) === (after?.windowId ?? a.windowId ?? null)
+    && (b.candidateSpoolId ?? null) === (a.candidateSpoolId ?? null)
+    && (b.candidateBaselineIntervalId ?? null) === (a.candidateBaselineIntervalId ?? null)
+    && (b.candidateCurrentIntervalId ?? null) === (a.candidateCurrentIntervalId ?? null)
+    && _sameObservationKeys(b.offlineObservationKeys, a.offlineObservationKeys);
+}
+
+/**
  * candidate 保存後に永続化を即時 flush する。
  *
  * 【詳細説明】
@@ -117,7 +163,6 @@ export async function runInferredContinuityShadow(host, spool, options = {}) {
       return { ok: false, reason: classification?.classification || "not_continuity_candidate", classification };
     }
 
-    const expectedAppSessionId = _currentAppSessionId(host);
     const projection = buildInferredContinuityProjection(classification, spool, _historyForHost(host));
     if (projection?.eligibleForPersistence !== true) {
       return { ok: false, reason: projection?.status || "projection_not_eligible", classification, projection };
@@ -131,13 +176,25 @@ export async function runInferredContinuityShadow(host, spool, options = {}) {
     if (save && save.ok === false) {
       return { ok: false, reason: save.reason || "candidate_not_durably_saved", classification, projection, persist, save };
     }
+    const commitClassification = classifyHostAttribution(host);
+    if (!_sameCandidateIdentity(classification, commitClassification)) {
+      return {
+        ok: false,
+        reason: "classification_changed_since_candidate_persisted",
+        classification,
+        commitClassification,
+        projection,
+        persist,
+        save
+      };
+    }
     const persistedAt = Number(persist.record?.createdAt) || Number(persist.record?.updatedAt) || wallNowMs();
     const commit = commitObservationWindow(host, {
-      windowId: classification.windowId,
-      expectedSequence: classification.currentSequence,
+      windowId: commitClassification.windowId,
+      expectedSequence: commitClassification.currentSequence,
       candidatePersistedAt: persistedAt,
       candidateHash: persist.candidateHash,
-      expectedAppSessionId
+      expectedAppSessionId: _currentAppSessionId(host)
     });
     const commitSave = commit?.ok && !commit.idempotent ? await _saveIfEnabled(options) : null;
     if (commit?.ok && commitSave && commitSave.ok === false) {

--- a/3dp_lib/dashboard_offline_live_shadow.js
+++ b/3dp_lib/dashboard_offline_live_shadow.js
@@ -20,7 +20,7 @@
  *
  * @version 1.390.1246 (PR #413)
  * @since   1.390.1246 (PR #413)
- * @lastModified 2026-07-22 02:00:00
+ * @lastModified 2026-07-22 12:00:00
  * -----------------------------------------------------------
  * @todo
  * - O5 で UI 確認・否認・再割当てから candidate status を遷移させる。
@@ -29,7 +29,7 @@
 "use strict";
 
 import { monitorData } from "./dashboard_data.js";
-import { saveUnifiedStorage } from "./dashboard_storage.js";
+import { saveUnifiedStorageDurably } from "./dashboard_storage.js";
 import { ATTR_CLASS, classifyHostAttribution } from "./dashboard_offline_classifier.js";
 import { commitObservationWindow } from "./dashboard_offline_observation.js";
 import { buildInferredContinuityProjection } from "./dashboard_offline_projection.js";
@@ -80,11 +80,11 @@ function _historyForHost(host) {
  * @function _saveIfEnabled
  * @param {Object} options - 実行オプション。
  * @param {boolean} [options.save=true] - false の場合は保存をスキップする。
- * @returns {*} saveUnifiedStorage の戻り値。保存しない場合は null。
+ * @returns {Promise<*>} saveUnifiedStorageDurably の戻り値。保存しない場合は null。
  */
-function _saveIfEnabled(options) {
+async function _saveIfEnabled(options) {
   if (options?.save === false) return null;
-  return saveUnifiedStorage(true);
+  return await saveUnifiedStorageDurably();
 }
 
 /**
@@ -94,19 +94,19 @@ function _saveIfEnabled(options) {
  * - O2 が `continuity-candidate` を返した場合だけ O3 projection と O4 candidate store へ進む。
  * - O3 で推定 debit が 0 の場合は、既に catch-up で同一スプールへ確定済み、または消費量不明のため
  *   candidate を保存せず、baseline も進めない。
- * - candidate 永続化の直後に保存し、その保存が例外なく終わった後で `commitObservationWindow()` を呼ぶ。
+ * - candidate 永続化の直後に耐久保存を待ち、その保存が成功した後で `commitObservationWindow()` を呼ぶ。
  * - aggregator から呼ばれる shadow 経路なので、例外は返り値へ畳み、本流の帰属・消費処理を止めない。
  *
  * @function runInferredContinuityShadow
  * @param {string} host - 対象ホスト名。
  * @param {?Object} spool - 現在選択中の spool オブジェクト。
  * @param {{save?:boolean}} [options] - テスト用オプション。
- * @returns {{ok:boolean, reason:string, classification?:Object, projection?:Object, persist?:Object, commit?:Object, error?:string}}
+ * @returns {Promise<{ok:boolean, reason:string, classification?:Object, projection?:Object, persist?:Object, commit?:Object, save?:Object, error?:string}>}
  *   shadow 評価結果。
  * @example
- * const result = runInferredContinuityShadow("printer-a", spool);
+ * const result = await runInferredContinuityShadow("printer-a", spool);
  */
-export function runInferredContinuityShadow(host, spool, options = {}) {
+export async function runInferredContinuityShadow(host, spool, options = {}) {
   try {
     if (!host) return { ok: false, reason: "host_required" };
     if (!spool || !spool.id) return { ok: false, reason: "spool_required" };
@@ -118,12 +118,18 @@ export function runInferredContinuityShadow(host, spool, options = {}) {
 
     const expectedAppSessionId = _currentAppSessionId(host);
     const projection = buildInferredContinuityProjection(classification, spool, _historyForHost(host));
+    if (projection?.eligibleForPersistence !== true) {
+      return { ok: false, reason: projection?.status || "projection_not_eligible", classification, projection };
+    }
     const persist = persistInferredCandidate(classification, projection);
     if (!persist?.ok) {
       return { ok: false, reason: persist?.reason || "candidate_not_persisted", classification, projection, persist };
     }
 
-    _saveIfEnabled(options);
+    const save = await _saveIfEnabled(options);
+    if (save && save.ok === false) {
+      return { ok: false, reason: save.reason || "candidate_not_durably_saved", classification, projection, persist, save };
+    }
     const persistedAt = Number(persist.record?.createdAt) || Number(persist.record?.updatedAt) || Date.now();
     const commit = commitObservationWindow(host, {
       windowId: classification.windowId,
@@ -132,7 +138,10 @@ export function runInferredContinuityShadow(host, spool, options = {}) {
       candidateHash: persist.candidateHash,
       expectedAppSessionId
     });
-    if (commit?.ok) _saveIfEnabled(options);
+    const commitSave = commit?.ok ? await _saveIfEnabled(options) : null;
+    if (commit?.ok && commitSave && commitSave.ok === false) {
+      return { ok: false, reason: commitSave.reason || "baseline_not_durably_saved", classification, projection, persist, commit, save: commitSave };
+    }
 
     return {
       ok: !!commit?.ok,
@@ -140,7 +149,8 @@ export function runInferredContinuityShadow(host, spool, options = {}) {
       classification,
       projection,
       persist,
-      commit
+      commit,
+      save: commitSave || save
     };
   } catch (e) {
     return { ok: false, reason: "shadow_failed", error: e?.message || String(e) };

--- a/3dp_lib/dashboard_offline_live_shadow.js
+++ b/3dp_lib/dashboard_offline_live_shadow.js
@@ -18,9 +18,9 @@
  * 【公開関数一覧】
  * - {@link runInferredContinuityShadow}：host 単位で O2/O3/O4 の shadow 評価を実行する。
  *
- * @version 1.390.1259 (PR #413)
+ * @version 1.390.1260 (PR #413)
  * @since   1.390.1246 (PR #413)
- * @lastModified 2026-07-25 12:23:47
+ * @lastModified 2026-07-25 12:38:02
  * -----------------------------------------------------------
  * @todo
  * - O5 で UI 確認・否認・再割当てから candidate status を遷移させる。
@@ -225,6 +225,9 @@ async function _runInferredContinuityShadow(host, spool, options = {}) {
     const persist = persistInferredCandidate(classification, projection);
     if (!persist?.ok) {
       return { ok: false, reason: persist?.reason || "candidate_not_persisted", classification, projection, persist };
+    }
+    if (persist.record?.status !== INFERRED_CANDIDATE_STATUS.PENDING) {
+      return { ok: false, reason: "candidate_not_pending", classification, projection, persist };
     }
 
     const save = await _saveIfEnabled(options);

--- a/3dp_lib/dashboard_offline_live_shadow.js
+++ b/3dp_lib/dashboard_offline_live_shadow.js
@@ -1,0 +1,148 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用オフライン継続推定 live shadow 配線モジュール
+ * @file dashboard_offline_live_shadow.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * @author pumpCurry
+ * -----------------------------------------------------------
+ * @module dashboard_offline_live_shadow
+ *
+ * 【機能内容サマリ】
+ * - O1/O2/O3/O4 を aggregator から shadow mode で呼び出し、未帰属のオフライン完了だけを
+ *   inferredCandidateStore へ冪等保存する。
+ * - candidate の永続保存が成功した場合だけ ObservationWindow の baseline を昇格し、再起動後の
+ *   二重候補化を防ぐ。
+ * - 確定台帳、spool.remainingLengthMm、履歴の filamentInfo には書き込まず、O5 の確認 UI へ渡す
+ *   pending candidate のみを作成する。
+ *
+ * 【公開関数一覧】
+ * - {@link runInferredContinuityShadow}：host 単位で O2/O3/O4 の shadow 評価を実行する。
+ *
+ * @version 1.390.1246 (PR #413)
+ * @since   1.390.1246 (PR #413)
+ * @lastModified 2026-07-22 02:00:00
+ * -----------------------------------------------------------
+ * @todo
+ * - O5 で UI 確認・否認・再割当てから candidate status を遷移させる。
+ */
+
+"use strict";
+
+import { monitorData } from "./dashboard_data.js";
+import { saveUnifiedStorage } from "./dashboard_storage.js";
+import { ATTR_CLASS, classifyHostAttribution } from "./dashboard_offline_classifier.js";
+import { commitObservationWindow } from "./dashboard_offline_observation.js";
+import { buildInferredContinuityProjection } from "./dashboard_offline_projection.js";
+import { persistInferredCandidate } from "./dashboard_offline_candidate_store.js";
+
+/**
+ * 現在の観測スナップショットから app session ID を取り出す。
+ *
+ * 【詳細説明】
+ * - `commitObservationWindow()` は `expectedAppSessionId` を指定すると、評価後に current が
+ *   差し替わった場合の baseline 昇格を拒否する。
+ * - hostObservationCurrent が無い場合は null を返し、commit 側の既存 fail-closed 判定へ委ねる。
+ *
+ * @private
+ * @function _currentAppSessionId
+ * @param {string} host - 対象ホスト名。
+ * @returns {?string} current 観測の appSessionId。存在しない場合は null。
+ */
+function _currentAppSessionId(host) {
+  return monitorData.hostObservationCurrent?.[host]?.appSessionId ?? null;
+}
+
+/**
+ * host の print history 配列を取得する。
+ *
+ * 【詳細説明】
+ * - O3 projection は履歴を read-only に照合するため、存在しない場合は空配列を渡す。
+ * - 戻り値の配列自体はコピーせず、projection 側が変更しない契約に合わせて参照を渡す。
+ *
+ * @private
+ * @function _historyForHost
+ * @param {string} host - 対象ホスト名。
+ * @returns {Array<Object>} printStore.history 相当の配列。
+ */
+function _historyForHost(host) {
+  const history = monitorData.machines?.[host]?.printStore?.history;
+  return Array.isArray(history) ? history : [];
+}
+
+/**
+ * candidate 保存後に永続化を即時 flush する。
+ *
+ * 【詳細説明】
+ * - `candidate保存 → baseline commit` の順序を守るため、commit 前に一度保存する。
+ * - テストでは `save:false` を渡すことで副作用を抑止できる。
+ *
+ * @private
+ * @function _saveIfEnabled
+ * @param {Object} options - 実行オプション。
+ * @param {boolean} [options.save=true] - false の場合は保存をスキップする。
+ * @returns {*} saveUnifiedStorage の戻り値。保存しない場合は null。
+ */
+function _saveIfEnabled(options) {
+  if (options?.save === false) return null;
+  return saveUnifiedStorage(true);
+}
+
+/**
+ * オフライン継続候補を live shadow mode で評価し、pending candidate と baseline commit を冪等に作成する。
+ *
+ * 【詳細説明】
+ * - O2 が `continuity-candidate` を返した場合だけ O3 projection と O4 candidate store へ進む。
+ * - O3 で推定 debit が 0 の場合は、既に catch-up で同一スプールへ確定済み、または消費量不明のため
+ *   candidate を保存せず、baseline も進めない。
+ * - candidate 永続化の直後に保存し、その保存が例外なく終わった後で `commitObservationWindow()` を呼ぶ。
+ * - aggregator から呼ばれる shadow 経路なので、例外は返り値へ畳み、本流の帰属・消費処理を止めない。
+ *
+ * @function runInferredContinuityShadow
+ * @param {string} host - 対象ホスト名。
+ * @param {?Object} spool - 現在選択中の spool オブジェクト。
+ * @param {{save?:boolean}} [options] - テスト用オプション。
+ * @returns {{ok:boolean, reason:string, classification?:Object, projection?:Object, persist?:Object, commit?:Object, error?:string}}
+ *   shadow 評価結果。
+ * @example
+ * const result = runInferredContinuityShadow("printer-a", spool);
+ */
+export function runInferredContinuityShadow(host, spool, options = {}) {
+  try {
+    if (!host) return { ok: false, reason: "host_required" };
+    if (!spool || !spool.id) return { ok: false, reason: "spool_required" };
+
+    const classification = classifyHostAttribution(host);
+    if (classification?.classification !== ATTR_CLASS.CONTINUITY_CANDIDATE) {
+      return { ok: false, reason: classification?.classification || "not_continuity_candidate", classification };
+    }
+
+    const expectedAppSessionId = _currentAppSessionId(host);
+    const projection = buildInferredContinuityProjection(classification, spool, _historyForHost(host));
+    const persist = persistInferredCandidate(classification, projection);
+    if (!persist?.ok) {
+      return { ok: false, reason: persist?.reason || "candidate_not_persisted", classification, projection, persist };
+    }
+
+    _saveIfEnabled(options);
+    const persistedAt = Number(persist.record?.createdAt) || Number(persist.record?.updatedAt) || Date.now();
+    const commit = commitObservationWindow(host, {
+      windowId: classification.windowId,
+      expectedSequence: classification.currentSequence,
+      candidatePersistedAt: persistedAt,
+      candidateHash: persist.candidateHash,
+      expectedAppSessionId
+    });
+    if (commit?.ok) _saveIfEnabled(options);
+
+    return {
+      ok: !!commit?.ok,
+      reason: commit?.reason || "commit_failed",
+      classification,
+      projection,
+      persist,
+      commit
+    };
+  } catch (e) {
+    return { ok: false, reason: "shadow_failed", error: e?.message || String(e) };
+  }
+}

--- a/3dp_lib/dashboard_offline_observation.js
+++ b/3dp_lib/dashboard_offline_observation.js
@@ -184,7 +184,8 @@ function _buildObservation(host, { mountIntervalId = null, mountIntervalStatus =
  * 稼働中の観測を current へ記録する（baseline 非上書き。未設定初回のみ bootstrap）。
  * @function recordObservation
  * @param {string} host
- * @param {{mountIntervalId?:?string, mountIntervalStatus?:string}} [opts]
+ * @param {{mountIntervalId?:?string, mountIntervalStatus?:string, activeJobId?:?string,
+ *   printState?:?number, activePrinting?:boolean}} [opts]
  * @returns {?Object} current スナップショット
  */
 export function recordObservation(host, opts = {}) {

--- a/3dp_lib/dashboard_offline_projection.js
+++ b/3dp_lib/dashboard_offline_projection.js
@@ -11,7 +11,8 @@
  * - #411-O3 の純粋 projection として、O2 の continuity candidate を確定残量へ直接混ぜず、
  *   未帰属のオフライン完了分だけを推定 debit として集計する。
  * - 確定済み履歴と observation key を照合し、同一スプール確定済み・別スプール確定済み・
- *   履歴消失・未帰属を分離することで、二重減算と誤帰属を防ぐ。
+ *   履歴消失・未帰属・履歴曖昧性を分離することで、二重減算と誤帰属を防ぐ。
+ * - window 内に矛盾や曖昧性がある場合は projection 全体を fail-closed し、O4 永続化へ進ませない。
  * - spool.remainingLengthMm、mountHistory、usedLengthLog、filamentInfo などの確定台帳には
  *   一切書き込まない。UI・ライブ残量・不可逆操作への接続は O4/O5 以降で行う。
  *
@@ -20,9 +21,9 @@
  * - {@link evaluateCandidateObservationKey}：candidate の observation key 1件を履歴へ照合する。
  * - {@link buildInferredContinuityProjection}：candidate 全体から推定残量 projection を作る。
  *
- * @version 1.390.1244 (PR #411)
+ * @version 1.390.1246 (PR #413)
  * @since   1.390.1244 (PR #411)
- * @lastModified  2026-07-19 18:21:09
+ * @lastModified  2026-07-22 12:00:00
  * -----------------------------------------------------------
  * @todo
  * - O4 で candidate 永続化・状態遷移・親子同期へ接続する。
@@ -58,9 +59,14 @@ const CONTINUITY_CANDIDATE = "continuity-candidate";
  * @property {?string} spoolId - projection 対象スプール ID。
  * @property {?string} windowId - O1/O2 の ObservationWindow ID。
  * @property {?string} classification - O2 分類ラベル。
- * @property {number} confirmedRemainingMm - 確定台帳だけから見た残量 mm。
+ * @property {boolean} ok - O4 永続化へ進められる projection なら true。
+ * @property {string} status - `ok` / `not-continuity-candidate` / `contradicted` /
+ *   `unresolved` / `remaining-unknown` / `ambiguous-history` / `projection-spool-mismatch` のいずれか。
+ * @property {boolean} eligibleForPersistence - O4 candidate store へ保存可能なら true。
+ * @property {?number} confirmedRemainingMm - 確定台帳だけから見た残量 mm。不明な場合は null。
  * @property {number} inferredContinuityUsedMm - 未帰属かつ継続候補として推定 debit する消費量 mm。
- * @property {number} projectedRemainingMm - `confirmedRemainingMm - inferredContinuityUsedMm` の表示用推定残量 mm。
+ * @property {?number} projectedRemainingMm - `confirmedRemainingMm - inferredContinuityUsedMm` の表示用推定残量 mm。
+ *   確定残量が不明な場合は null。
  * @property {Array<CandidateDebitEvaluation>} candidateDebits - candidate key ごとの照合結果。
  * @property {Array<CandidateDebitEvaluation>} contradictions - 別スプール確定済みなど、推定と矛盾する key。
  * @property {Array<CandidateDebitEvaluation>} unresolved - 履歴消失・消費量不明など projection へ入れられない key。
@@ -85,55 +91,109 @@ function _nonNegativeMm(value) {
 }
 
 /**
+ * 確定残量として使える値を正規化する。
+ *
+ * 【詳細説明】
+ * - `remainingLengthMm` の `0` は実残量ゼロとして有効だが、null/undefined/NaN/負値は「不明」として扱う。
+ * - O5 の UI や不可逆操作 gate が「空」と「不明」を混同しないよう、不明値は null のまま返す。
+ *
+ * @private
+ * @function _remainingOrNull
+ * @param {*} value - spool.remainingLengthMm 相当の値。
+ * @returns {?number} 有効な 0 以上の数値。不明な場合は null。
+ */
+function _remainingOrNull(value) {
+  if (value == null || value === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+/**
  * observation key から lookup 用 Map を構築する。
  *
  * 【詳細説明】
  * - O1/O2 と同じ `jobObservationIdentity()` を使い、ID だけでなく開始/完了時刻・ファイル署名を
  *   含む複合 key で履歴行を検索できるようにする。
- * - 同一 key が複数ある場合は、最初に見つけた履歴行を保持する。重複がある時点で履歴側が
- *   既に曖昧なので、projection は台帳を書き換えず監査情報だけを返す。
+ * - 同一 key が複数ある場合は ambiguous として記録し、履歴配列順に依存した first-wins を避ける。
  *
  * @private
  * @function _historyByObservationKey
  * @param {Array<Object>} history - printStore.history 相当の履歴配列。
- * @returns {Map<string,Object>} observation key から履歴行への Map。
+ * @returns {Map<string,{status:string, entries:Array<Object>}>} observation key から履歴候補への Map。
  */
 function _historyByObservationKey(history) {
   const map = new Map();
   if (!Array.isArray(history)) return map;
   for (const entry of history) {
     const identity = jobObservationIdentity(entry);
-    if (!identity || !identity.key || map.has(identity.key)) continue;
-    map.set(identity.key, entry);
+    if (!identity || !identity.key) continue;
+    const current = map.get(identity.key);
+    if (!current) {
+      map.set(identity.key, { status: "unique", entries: [entry] });
+      continue;
+    }
+    current.status = "ambiguous";
+    current.entries.push(entry);
   }
   return map;
 }
 
 /**
- * 履歴行の確定帰属スプール ID 一覧を返す。
+ * 履歴 lookup レコードから一意の entry を取り出す。
  *
  * 【詳細説明】
- * - `filamentInfo[].spoolId` を最優先にし、配列にスプール情報が無い場合だけ `filamentId` を見る。
- * - `filamentId="none"` や空文字は確定スプールではないため除外する。
- * - 重複は Set で畳み、projection 側の二重判定を防ぐ。
+ * - 履歴に key が無い場合は missing、同一 key が複数ある場合は ambiguous を返す。
+ * - ambiguous は O3 window 全体の fail-closed 条件として扱う。
  *
  * @private
- * @function _confirmedSpoolIds
- * @param {Object} entry - 履歴行。
- * @returns {Array<string>} 確定帰属済みのスプール ID 一覧。
+ * @function _entryLookupState
+ * @param {?Object} lookup - `_historyByObservationKey()` の値、または後方互換用の履歴行。
+ * @returns {{status:string, entry:?Object, entries:Array<Object>}}
  */
-function _confirmedSpoolIds(entry) {
+function _entryLookupState(lookup) {
+  if (!lookup) return { status: "missing", entry: null, entries: [] };
+  if (lookup.status === "ambiguous") return { status: "ambiguous", entry: null, entries: lookup.entries || [] };
+  if (lookup.status === "unique") return { status: "unique", entry: lookup.entries?.[0] || null, entries: lookup.entries || [] };
+  return { status: "unique", entry: lookup, entries: [lookup] };
+}
+
+/**
+ * 値を有効な確定スプール ID として集合へ追加する。
+ *
+ * @private
+ * @function _addConfirmedId
+ * @param {Set<string>} ids - 追加先 Set。
+ * @param {*} value - スプール ID 候補値。
+ * @returns {void}
+ */
+function _addConfirmedId(ids, value) {
+  const id = value == null ? "" : String(value).trim();
+  if (id && id !== "none") ids.add(id);
+}
+
+/**
+ * 履歴行の確定帰属スプール情報を、矛盾検出付きで返す。
+ *
+ * 【詳細説明】
+ * - `filamentInfo[].spoolId` と `filamentId` の両方を同じ確定ソースとして集合化する。
+ * - 複数の spool ID が同じ履歴行に現れた場合は、確定ソース同士が競合しているため ambiguous とする。
+ *
+ * @private
+ * @function _confirmedSpoolState
+ * @param {Object} entry - 履歴行。
+ * @returns {{ids:Array<string>, ambiguous:boolean, reason:?string}} 確定スプール情報。
+ */
+function _confirmedSpoolState(entry) {
   const ids = new Set();
   const info = Array.isArray(entry?.filamentInfo) ? entry.filamentInfo : [];
-  for (const item of info) {
-    const id = item?.spoolId == null ? "" : String(item.spoolId).trim();
-    if (id && id !== "none") ids.add(id);
-  }
-  if (ids.size === 0) {
-    const id = entry?.filamentId == null ? "" : String(entry.filamentId).trim();
-    if (id && id !== "none") ids.add(id);
-  }
-  return [...ids];
+  for (const item of info) _addConfirmedId(ids, item?.spoolId);
+  _addConfirmedId(ids, entry?.filamentId);
+  const out = [...ids];
+  return {
+    ids: out,
+    ambiguous: out.length > 1,
+    reason: out.length > 1 ? "conflicting-confirmed-spool-fields" : null
+  };
 }
 
 /**
@@ -171,7 +231,7 @@ export function estimateHistoryEntryUsedMm(entry) {
  *
  * @function evaluateCandidateObservationKey
  * @param {string} observationKey - O2 candidate の observation key。
- * @param {?Object} entry - observation key に一致した履歴行。見つからない場合は null。
+ * @param {?Object} entry - observation key に一致した履歴行、または lookup レコード。見つからない場合は null。
  * @param {string} candidateSpoolId - O2 が提示した候補スプール ID。
  * @returns {CandidateDebitEvaluation} key 1件の projection 判定。
  * @example
@@ -179,7 +239,20 @@ export function estimateHistoryEntryUsedMm(entry) {
  */
 export function evaluateCandidateObservationKey(observationKey, entry, candidateSpoolId) {
   const candidateId = candidateSpoolId == null ? null : String(candidateSpoolId);
-  if (!entry) {
+  const lookup = _entryLookupState(entry);
+  if (lookup.status === "ambiguous") {
+    return {
+      observationKey,
+      status: "unresolved",
+      usedMm: 0,
+      candidateSpoolId: candidateId,
+      confirmedSpoolIds: [],
+      entry: null,
+      reason: "duplicate-observation-key"
+    };
+  }
+  const resolvedEntry = lookup.entry;
+  if (!resolvedEntry) {
     return {
       observationKey,
       status: "unresolved",
@@ -191,8 +264,20 @@ export function evaluateCandidateObservationKey(observationKey, entry, candidate
     };
   }
 
-  const usedMm = estimateHistoryEntryUsedMm(entry);
-  const confirmedSpoolIds = _confirmedSpoolIds(entry);
+  const usedMm = estimateHistoryEntryUsedMm(resolvedEntry);
+  const confirmedState = _confirmedSpoolState(resolvedEntry);
+  const confirmedSpoolIds = confirmedState.ids;
+  if (confirmedState.ambiguous) {
+    return {
+      observationKey,
+      status: "unresolved",
+      usedMm,
+      candidateSpoolId: candidateId,
+      confirmedSpoolIds,
+      entry: resolvedEntry,
+      reason: confirmedState.reason
+    };
+  }
   if (confirmedSpoolIds.includes(candidateId)) {
     return {
       observationKey,
@@ -200,7 +285,7 @@ export function evaluateCandidateObservationKey(observationKey, entry, candidate
       usedMm,
       candidateSpoolId: candidateId,
       confirmedSpoolIds,
-      entry,
+      entry: resolvedEntry,
       reason: "already-confirmed-on-candidate-spool"
     };
   }
@@ -211,7 +296,7 @@ export function evaluateCandidateObservationKey(observationKey, entry, candidate
       usedMm,
       candidateSpoolId: candidateId,
       confirmedSpoolIds,
-      entry,
+      entry: resolvedEntry,
       reason: "already-confirmed-on-other-spool"
     };
   }
@@ -222,7 +307,7 @@ export function evaluateCandidateObservationKey(observationKey, entry, candidate
       usedMm: 0,
       candidateSpoolId: candidateId,
       confirmedSpoolIds,
-      entry,
+      entry: resolvedEntry,
       reason: "usage-missing-or-zero"
     };
   }
@@ -232,7 +317,7 @@ export function evaluateCandidateObservationKey(observationKey, entry, candidate
     usedMm,
     candidateSpoolId: candidateId,
     confirmedSpoolIds,
-    entry,
+    entry: resolvedEntry,
     reason: "unattributed-usage"
   };
 }
@@ -242,8 +327,8 @@ export function evaluateCandidateObservationKey(observationKey, entry, candidate
  *
  * 【詳細説明】
  * - `classificationResult.classification` が `continuity-candidate` でない場合は推定 debit しない。
- * - `spool.remainingLengthMm` を `confirmedRemainingMm` として読み、未帰属 candidate の消費量だけを
- *   `inferredContinuityUsedMm` に集計する。
+ * - `spool.remainingLengthMm` が 0 以上の有限値の場合だけ `confirmedRemainingMm` として読み、
+ *   不明値は null として返す。
  * - `projectedRemainingMm` は表示・計画用の推定値であり、spool オブジェクトへは書き戻さない。
  * - 入力履歴に同一 observation key が既に候補スプールへ確定帰属している場合は対象外にし、
  *   別スプール確定済みなら contradictions に分離する。
@@ -258,7 +343,7 @@ export function evaluateCandidateObservationKey(observationKey, entry, candidate
  * const projection = buildInferredContinuityProjection(classification, spool, history);
  */
 export function buildInferredContinuityProjection(classificationResult, spool, history) {
-  const confirmedRemainingMm = _nonNegativeMm(spool?.remainingLengthMm);
+  const confirmedRemainingMm = _remainingOrNull(spool?.remainingLengthMm);
   const candidate = classificationResult?.candidate || null;
   const candidateSpoolId = candidate?.candidateSpoolId == null ? null : String(candidate.candidateSpoolId);
   const base = {
@@ -266,6 +351,9 @@ export function buildInferredContinuityProjection(classificationResult, spool, h
     spoolId: spool?.id == null ? candidateSpoolId : String(spool.id),
     windowId: classificationResult?.windowId ?? candidate?.windowId ?? null,
     classification: classificationResult?.classification ?? null,
+    ok: false,
+    status: "not-continuity-candidate",
+    eligibleForPersistence: false,
     confirmedRemainingMm,
     inferredContinuityUsedMm: 0,
     projectedRemainingMm: confirmedRemainingMm,
@@ -288,7 +376,7 @@ export function buildInferredContinuityProjection(classificationResult, spool, h
       confirmedSpoolIds: [String(spool.id)],
       entry: null,
       reason: "projection-spool-mismatch"
-    }] };
+    }], status: "projection-spool-mismatch" };
   }
 
   const byKey = _historyByObservationKey(history);
@@ -296,14 +384,28 @@ export function buildInferredContinuityProjection(classificationResult, spool, h
   const candidateDebits = keys.map(key => evaluateCandidateObservationKey(key, byKey.get(key) || null, candidateSpoolId));
   const contradictions = candidateDebits.filter(item => item.status === "confirmed-other-spool");
   const unresolved = candidateDebits.filter(item => item.status === "unresolved" || item.status === "no-usage");
-  const inferredContinuityUsedMm = candidateDebits
+  const rawInferredContinuityUsedMm = candidateDebits
     .filter(item => item.status === "inferred-debit")
     .reduce((sum, item) => sum + _nonNegativeMm(item.usedMm), 0);
+  const hasAmbiguousHistory = unresolved.some(item =>
+    item.reason === "duplicate-observation-key" || item.reason === "conflicting-confirmed-spool-fields"
+  );
+  let status = "ok";
+  if (contradictions.length > 0) status = "contradicted";
+  else if (hasAmbiguousHistory) status = "ambiguous-history";
+  else if (unresolved.length > 0) status = "unresolved";
+  else if (confirmedRemainingMm == null) status = "remaining-unknown";
+
+  const eligibleForPersistence = status === "ok" && rawInferredContinuityUsedMm > 0;
+  const inferredContinuityUsedMm = eligibleForPersistence ? rawInferredContinuityUsedMm : 0;
 
   return {
     ...base,
+    ok: eligibleForPersistence,
+    status,
+    eligibleForPersistence,
     inferredContinuityUsedMm,
-    projectedRemainingMm: Math.max(0, confirmedRemainingMm - inferredContinuityUsedMm),
+    projectedRemainingMm: confirmedRemainingMm == null ? null : Math.max(0, confirmedRemainingMm - inferredContinuityUsedMm),
     candidateDebits,
     contradictions,
     unresolved

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -27,9 +27,9 @@
  * - {@link loadPrintCurrent}：現ジョブ読込
  * - {@link savePrintCurrent}：現ジョブ保存
  *
-* @version 1.390.1246 (PR #413)
+* @version 1.390.1256 (PR #413)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-07-22 12:00:00
+* @lastModified 2026-07-25 11:15:54
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -819,9 +819,10 @@ export function saveUnifiedStorage(immediate = false) {
  */
 export async function saveUnifiedStorageDurably() {
   const expectedIdb = _idbInitialized && isIdbAvailable();
-  _flushStorage();
+  const queued = _flushStorage();
+  if (queued?.ok === false) return queued;
   if (!expectedIdb) {
-    return { ok: true, backend: "localStorage", reason: "saved" };
+    return queued || { ok: true, backend: "localStorage", reason: "saved" };
   }
   await flushIdb();
   if (!isIdbAvailable()) {
@@ -909,6 +910,7 @@ export function isEmptyHostShell(parsed) {
  * 実際のストレージ書き込みを行う内部関数。
  * IndexedDB が有効な場合はキューに追加し、無効な場合は localStorage へ書き込む。
  * @private
+ * @returns {{ok:boolean, backend:string, reason:string, error?:string}} 保存またはキュー投入の結果。
  */
 function _flushStorage() {
   _savePending = false;
@@ -963,6 +965,7 @@ function _flushStorage() {
       if (_enableStorageLog) {
         console.debug("[saveUnifiedStorage] IndexedDB キューに追加しました");
       }
+      return { ok: true, backend: "indexedDB", reason: "queued" };
     } else {
       // フォールバック: localStorage（per-host 分割形式）
       _writePerHostLocalStorage();
@@ -970,10 +973,17 @@ function _flushStorage() {
       if (_enableStorageLog) {
         console.debug("[saveUnifiedStorage] localStorage (per-host) に保存しました");
       }
+      return { ok: true, backend: "localStorage", reason: "saved" };
     }
   } catch (e) {
     console.warn("[saveUnifiedStorage] 保存に失敗しました:", e);
     logManager.add({ timestamp:getCurrentTimestamp(), level:"error", msg:`[saveUnifiedStorage] エラー: ${e.message}` });
+    return {
+      ok: false,
+      backend: (_idbInitialized && isIdbAvailable()) ? "indexedDB" : "localStorage",
+      reason: "local_storage_write_failed",
+      error: e?.message || String(e)
+    };
   }
 }
 

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -16,6 +16,7 @@
  * 【公開関数一覧】
  * - {@link setStorageLogEnabled}：ログ出力有効化
  * - {@link saveUnifiedStorage}：全データ保存
+ * - {@link saveUnifiedStorageDurably}：全データを耐久保存完了まで待つ
  * - {@link restoreUnifiedStorage}：全データ復元
  * - {@link restoreLegacyStoredData}：レガシーデータ読込
  * - {@link cleanupLegacy}：レガシー削除
@@ -26,9 +27,9 @@
  * - {@link loadPrintCurrent}：現ジョブ読込
  * - {@link savePrintCurrent}：現ジョブ保存
  *
-* @version 1.390.1245 (PR #412)
+* @version 1.390.1246 (PR #413)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-07-19 18:45:00
+* @lastModified 2026-07-22 12:00:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -799,6 +800,34 @@ export function saveUnifiedStorage(immediate = false) {
     _saveTimer = null;
     if (_savePending) _flushStorage();
   }, SAVE_THROTTLE_MS);
+}
+
+/**
+ * monitorData 全体を保存し、IndexedDB 利用時は transaction 完了まで待機する。
+ *
+ * 【詳細説明】
+ * - `saveUnifiedStorage(true)` は IndexedDB パスでは queue へ積むだけで即時復帰する。
+ * - candidate 保存後に observation baseline を進める経路では、candidate が実際に耐久保存されたことを
+ *   確認してから commit しないと、クラッシュ時に baseline だけ進む可能性がある。
+ * - IndexedDB が無効または未初期化の場合は localStorage 同期保存が完了した時点で成功とみなす。
+ * - IndexedDB flush 中にフォールバックへ切り替わった場合は、呼び出し元に失敗を返し、baseline commit を止める。
+ *
+ * @function saveUnifiedStorageDurably
+ * @returns {Promise<{ok:boolean, backend:string, reason:string}>} 耐久保存結果。
+ * @example
+ * const saved = await saveUnifiedStorageDurably();
+ */
+export async function saveUnifiedStorageDurably() {
+  const expectedIdb = _idbInitialized && isIdbAvailable();
+  _flushStorage();
+  if (!expectedIdb) {
+    return { ok: true, backend: "localStorage", reason: "saved" };
+  }
+  await flushIdb();
+  if (!isIdbAvailable()) {
+    return { ok: false, backend: "indexedDB", reason: "idb_flush_failed" };
+  }
+  return { ok: true, backend: "indexedDB", reason: "flushed" };
 }
 
 /**

--- a/3dp_lib/dashboard_storage_idb.js
+++ b/3dp_lib/dashboard_storage_idb.js
@@ -23,9 +23,9 @@
  * - {@link exportAllIdb}：全データを単一オブジェクトとして読み出し
  * - {@link importAllIdb}：単一オブジェクトから全データを書き込み
  *
- * @version 1.390.1245 (PR #412)
+ * @version 1.390.1246 (PR #413)
  * @since   1.390.787 (PR #366)
- * @lastModified 2026-07-19 18:45:00
+ * @lastModified 2026-07-22 12:00:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -212,7 +212,7 @@ export function getIdbCache() {
  * @param {any} value - 保存する値
  */
 export function queueSharedWrite(key, value) {
-  _pendingShared.set(key, value);
+  _pendingShared.set(key, _cloneForStorageQueue(value));
   _scheduleFlush();
 }
 
@@ -239,7 +239,7 @@ export function queueMachineWrite(hostname, machineData) {
     filtered.storedData = sd;
   }
 
-  _pendingMachines.set(hostname, filtered);
+  _pendingMachines.set(hostname, _cloneForStorageQueue(filtered));
   _scheduleFlush();
 }
 
@@ -414,6 +414,33 @@ function _txComplete(tx) {
     tx.onerror    = () => reject(tx.error);
     tx.onabort    = () => reject(tx.error || new Error("Transaction aborted"));
   });
+}
+
+/**
+ * IndexedDB キューへ積む値を保存時点のスナップショットへ複製する。
+ *
+ * 【詳細説明】
+ * - queueSharedWrite/queueMachineWrite は非同期 flush まで値を保持するため、参照をそのまま積むと
+ *   flush 前の monitorData 更新が「過去に積んだはずの保存境界」へ混入する。
+ * - candidate 保存後 baseline commit 前に耐久境界を作るには、キュー投入時点の値を clone する必要がある。
+ * - IndexedDB に保存する値は JSON 互換データが前提なので、structuredClone が使えない環境では
+ *   JSON round-trip で代替する。clone 不能な値は最後の安全策として元値を返す。
+ *
+ * @private
+ * @function _cloneForStorageQueue
+ * @param {*} value - キューへ積む保存値。
+ * @returns {*} キュー投入時点のスナップショット。
+ */
+function _cloneForStorageQueue(value) {
+  if (value == null) return value;
+  try {
+    if (typeof structuredClone === "function") return structuredClone(value);
+  } catch { /* JSON fallback へ進む */ }
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return value;
+  }
 }
 
 /**

--- a/tests/unit/dashboard_aggregator_relay_guard.test.js
+++ b/tests/unit/dashboard_aggregator_relay_guard.test.js
@@ -74,11 +74,15 @@ vi.mock("../../3dp_lib/dashboard_spool.js", () => ({
   addInferredSpool: vi.fn(),
 }));
 vi.mock("../../3dp_lib/dashboard_filament_ledger.js", () => ({
+  deriveSpoolRemaining: vi.fn(() => ({ remainingMm: 100000, verified: true, mode: "anchor", usedMm: 0 })),
   reconcileSpool: vi.fn(),
   recordFilamentEvent: vi.fn(),
   resolveFilamentEvent: vi.fn(),
   getOpenFilamentEvent: vi.fn(() => null),
   runoutGateHeld: vi.fn(() => false),
+}));
+vi.mock("../../3dp_lib/dashboard_offline_live_shadow.js", () => ({
+  runInferredContinuityShadow: vi.fn(async () => ({ ok: false, reason: "not_continuity_candidate" })),
 }));
 vi.mock("../../3dp_lib/dashboard_connection.js", () => ({
   getConnectionState: vi.fn(() => ({ state: "connected" })),
@@ -88,6 +92,7 @@ const { aggregatorUpdate } = await import("../../3dp_lib/dashboard_aggregator.js
 const { monitorData, ensureMachineData, setStoredDataForHost } =
   await import("../../3dp_lib/dashboard_data.js");
 const spoolMod = await import("../../3dp_lib/dashboard_spool.js");
+const liveShadowMod = await import("../../3dp_lib/dashboard_offline_live_shadow.js");
 
 /**
  * 印刷中ホストを実データ層にセットアップする。
@@ -142,6 +147,7 @@ describe("aggregatorUpdate のリレー子ガード", () => {
     expect(spoolMod.finalizeFilamentUsage).not.toHaveBeenCalled();
     expect(spoolMod.beginExternalPrint).not.toHaveBeenCalled();
     expect(spoolMod.autoCorrectCurrentSpool).not.toHaveBeenCalled();
+    expect(liveShadowMod.runInferredContinuityShadow).not.toHaveBeenCalled();
     // スプールオブジェクトが無変更（親配信値が権威のまま）
     expect(spool.remainingLengthMm).toBe(100000);
     expect(spool.currentJobStartLength).toBeNull();
@@ -159,5 +165,6 @@ describe("aggregatorUpdate のリレー子ガード", () => {
     // スプールを取得し、印刷中ジョブの基点を記録している（ガード誤適用の検出）
     expect(spoolMod.getCurrentSpool).toHaveBeenCalled();
     expect(spool.currentJobStartLength).not.toBeNull();
+    expect(liveShadowMod.runInferredContinuityShadow).toHaveBeenCalled();
   });
 });

--- a/tests/unit/dashboard_offline_candidate_store.test.js
+++ b/tests/unit/dashboard_offline_candidate_store.test.js
@@ -143,6 +143,22 @@ describe("persistInferredCandidate", () => {
     expect(mockMonitorData.inferredCandidateStore).toEqual({});
   });
 
+  it("同一 candidateHash の再評価で confidence と evidence を更新する", () => {
+    const first = persistInferredCandidate(cls(), proj(), { nowMs: 1000 });
+    const second = persistInferredCandidate(cls({
+      confidence: { level: "high", reasons: ["bounded", "same-spool"], contradictions: [] },
+      evidence: { sameMountedSpool: true, sequenceRefreshed: true }
+    }), proj(), { nowMs: 2000 });
+
+    expect(second.reason).toBe("updated");
+    expect(second.record).toBe(first.record);
+    expect(second.record.usedMm).toBe(3000);
+    expect(second.record.updatedAt).toBe(2000);
+    expect(second.record.confidence).toEqual({ level: "high", reasons: ["bounded", "same-spool"], contradictions: [] });
+    expect(second.record.evidence).toEqual({ sameMountedSpool: true, sequenceRefreshed: true });
+    expect(second.record.events).toHaveLength(1);
+  });
+
   it("推定 debit が 0 なら保存しない", () => {
     const r = persistInferredCandidate(cls(), proj({ inferredContinuityUsedMm: 0 }), { nowMs: 1000 });
     expect(r.ok).toBe(false);

--- a/tests/unit/dashboard_offline_candidate_store.test.js
+++ b/tests/unit/dashboard_offline_candidate_store.test.js
@@ -50,12 +50,14 @@ function cls(over = {}) {
 function proj(over = {}) {
   return {
     host: "k1",
-    eligibleForPersistence: true,
     inferredContinuityUsedMm: 3000,
     candidateDebits: [
       { observationKey: "kA", status: "inferred-debit", usedMm: 1000, reason: "unattributed-usage", confirmedSpoolIds: [] },
       { observationKey: "kB", status: "inferred-debit", usedMm: 2000, reason: "unattributed-usage", confirmedSpoolIds: [] }
     ],
+    ok: true,
+    status: "ok",
+    eligibleForPersistence: true,
     ...over
   };
 }
@@ -174,6 +176,13 @@ describe("persistInferredCandidate", () => {
     expect(r.collision).toBe(mockMonitorData.inferredCandidateStore[candidateHash]);
     expect(Object.keys(mockMonitorData.inferredCandidateStore)).toHaveLength(1);
     expect(mockMonitorData.inferredCandidateStore[candidateHash].windowId).toBe("k9|b1|c2");
+  });
+
+  it("O3 が persistence 不可なら推定 debit があっても保存しない", () => {
+    const r = persistInferredCandidate(cls(), proj({ eligibleForPersistence: false, status: "contradicted" }), { nowMs: 1000 });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("contradicted");
+    expect(mockMonitorData.inferredCandidateStore).toEqual({});
   });
 });
 

--- a/tests/unit/dashboard_offline_candidate_store.test.js
+++ b/tests/unit/dashboard_offline_candidate_store.test.js
@@ -126,7 +126,7 @@ describe("persistInferredCandidate", () => {
       }),
       { nowMs: 2000 }
     );
-    expect(second.reason).toBe("idempotent");
+    expect(second.reason).toBe("updated");
     expect(second.record).toBe(first.record);
     expect(second.record.usedMm).toBe(4500);
     expect(second.record.confidence.level).toBe("high");

--- a/tests/unit/dashboard_offline_candidate_store.test.js
+++ b/tests/unit/dashboard_offline_candidate_store.test.js
@@ -110,6 +110,28 @@ describe("persistInferredCandidate", () => {
     expect(second.record.events).toHaveLength(1);
   });
 
+  it.each([
+    INFERRED_CANDIDATE_STATUS.SUPERSEDED,
+    INFERRED_CANDIDATE_STATUS.REJECTED,
+    INFERRED_CANDIDATE_STATUS.CONFIRMED,
+    INFERRED_CANDIDATE_STATUS.REASSIGNED
+  ])("既存 candidate が %s の場合は同一 identity でも再利用しない", (status) => {
+    const first = persistInferredCandidate(cls(), proj(), { nowMs: 1000 });
+    const transition = transitionInferredCandidate(first.candidateHash, status, {
+      nowMs: 1500,
+      reason: "resolved-before-reevaluation",
+      assignedSpoolId: status === INFERRED_CANDIDATE_STATUS.REASSIGNED ? "S2" : null
+    });
+    const second = persistInferredCandidate(cls(), proj(), { nowMs: 2000 });
+
+    expect(transition.ok).toBe(true);
+    expect(second.ok).toBe(false);
+    expect(second.reason).toBe("candidate_not_pending");
+    expect(second.candidateHash).toBe(first.candidateHash);
+    expect(second.record).toBe(first.record);
+    expect(second.record.status).toBe(status);
+  });
+
   it("同一 candidateHash の再評価では使用量と根拠を同一 record 上で更新する", () => {
     const first = persistInferredCandidate(cls(), proj(), { nowMs: 1000 });
     const second = persistInferredCandidate(

--- a/tests/unit/dashboard_offline_live_shadow.test.js
+++ b/tests/unit/dashboard_offline_live_shadow.test.js
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => ({
     hostObservationCurrent: { k1: { appSessionId: "session-a" } },
     machines: { k1: { printStore: { history: [{ id: "job-a", materialUsedMm: 1200 }] } } }
   },
-  saveUnifiedStorage: vi.fn(() => { mocks.events.push("save"); }),
+  saveUnifiedStorage: vi.fn(async () => { mocks.events.push("save"); return { ok: true, backend: "indexedDB", reason: "flushed" }; }),
   classifyHostAttribution: vi.fn(),
   buildInferredContinuityProjection: vi.fn(),
   persistInferredCandidate: vi.fn(),
@@ -18,7 +18,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mocks.monitorData }));
-vi.mock("../../3dp_lib/dashboard_storage.js", () => ({ saveUnifiedStorage: mocks.saveUnifiedStorage }));
+vi.mock("../../3dp_lib/dashboard_storage.js", () => ({ saveUnifiedStorageDurably: mocks.saveUnifiedStorage }));
 vi.mock("../../3dp_lib/dashboard_offline_classifier.js", () => ({
   ATTR_CLASS: { CONTINUITY_CANDIDATE: "continuity-candidate" },
   classifyHostAttribution: mocks.classifyHostAttribution
@@ -62,7 +62,11 @@ beforeEach(() => {
   mocks.events.length = 0;
   mocks.monitorData.hostObservationCurrent = { k1: { appSessionId: "session-a" } };
   mocks.monitorData.machines = { k1: { printStore: { history: [{ id: "job-a", materialUsedMm: 1200 }] } } };
-  mocks.saveUnifiedStorage.mockClear();
+  mocks.saveUnifiedStorage.mockReset();
+  mocks.saveUnifiedStorage.mockImplementation(async () => {
+    mocks.events.push("save");
+    return { ok: true, backend: "indexedDB", reason: "flushed" };
+  });
   mocks.classifyHostAttribution.mockReset();
   mocks.buildInferredContinuityProjection.mockReset();
   mocks.persistInferredCandidate.mockReset();
@@ -70,9 +74,9 @@ beforeEach(() => {
 });
 
 describe("runInferredContinuityShadow", () => {
-  it("candidate を保存してから baseline commit し、commit 成功後に再保存する", () => {
+  it("candidate を耐久保存してから baseline commit し、commit 成功後に再保存する", async () => {
     const cls = classification();
-    const projection = { host: "k1", inferredContinuityUsedMm: 1200 };
+    const projection = { host: "k1", inferredContinuityUsedMm: 1200, eligibleForPersistence: true, status: "ok" };
     mocks.classifyHostAttribution.mockReturnValue(cls);
     mocks.buildInferredContinuityProjection.mockReturnValue(projection);
     mocks.persistInferredCandidate.mockImplementation(() => {
@@ -84,7 +88,7 @@ describe("runInferredContinuityShadow", () => {
       return { ok: true, reason: "committed" };
     });
 
-    const result = runInferredContinuityShadow("k1", { id: "S1", remainingLengthMm: 5000 });
+    const result = await runInferredContinuityShadow("k1", { id: "S1", remainingLengthMm: 5000 });
 
     expect(result.ok).toBe(true);
     expect(result.reason).toBe("committed");
@@ -99,10 +103,10 @@ describe("runInferredContinuityShadow", () => {
     expect(mocks.events).toEqual(["persist", "save", "commit", "save"]);
   });
 
-  it("O2 が continuity-candidate 以外なら projection と保存を実行しない", () => {
+  it("O2 が continuity-candidate 以外なら projection と保存を実行しない", async () => {
     mocks.classifyHostAttribution.mockReturnValue(classification({ classification: "no-offline-activity" }));
 
-    const result = runInferredContinuityShadow("k1", { id: "S1" });
+    const result = await runInferredContinuityShadow("k1", { id: "S1" });
 
     expect(result.ok).toBe(false);
     expect(result.reason).toBe("no-offline-activity");
@@ -111,12 +115,12 @@ describe("runInferredContinuityShadow", () => {
     expect(mocks.commitObservationWindow).not.toHaveBeenCalled();
   });
 
-  it("O4 が no_inferred_debit を返した場合は baseline を進めない", () => {
+  it("O4 が no_inferred_debit を返した場合は baseline を進めない", async () => {
     mocks.classifyHostAttribution.mockReturnValue(classification());
-    mocks.buildInferredContinuityProjection.mockReturnValue({ host: "k1", inferredContinuityUsedMm: 0 });
+    mocks.buildInferredContinuityProjection.mockReturnValue({ host: "k1", inferredContinuityUsedMm: 0, eligibleForPersistence: true, status: "ok" });
     mocks.persistInferredCandidate.mockReturnValue({ ok: false, reason: "no_inferred_debit", candidateHash: null, record: null });
 
-    const result = runInferredContinuityShadow("k1", { id: "S1" });
+    const result = await runInferredContinuityShadow("k1", { id: "S1" });
 
     expect(result.ok).toBe(false);
     expect(result.reason).toBe("no_inferred_debit");
@@ -124,10 +128,85 @@ describe("runInferredContinuityShadow", () => {
     expect(mocks.commitObservationWindow).not.toHaveBeenCalled();
   });
 
-  it("例外を shadow_failed に畳み、本流へ throw しない", () => {
+  it("O3 が persistence 不可なら O4 保存と baseline commit を実行しない", async () => {
+    mocks.classifyHostAttribution.mockReturnValue(classification());
+    mocks.buildInferredContinuityProjection.mockReturnValue({
+      host: "k1",
+      inferredContinuityUsedMm: 1200,
+      eligibleForPersistence: false,
+      status: "contradicted",
+      contradictions: [{ reason: "already-confirmed-on-other-spool" }]
+    });
+
+    const result = await runInferredContinuityShadow("k1", { id: "S1" });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("contradicted");
+    expect(mocks.persistInferredCandidate).not.toHaveBeenCalled();
+    expect(mocks.saveUnifiedStorage).not.toHaveBeenCalled();
+    expect(mocks.commitObservationWindow).not.toHaveBeenCalled();
+  });
+
+  it("candidate の耐久保存に失敗した場合は baseline commit へ進まない", async () => {
+    mocks.classifyHostAttribution.mockReturnValue(classification());
+    mocks.buildInferredContinuityProjection.mockReturnValue({
+      host: "k1",
+      inferredContinuityUsedMm: 1200,
+      eligibleForPersistence: true,
+      status: "ok"
+    });
+    mocks.persistInferredCandidate.mockImplementation(() => {
+      mocks.events.push("persist");
+      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000 } };
+    });
+    mocks.saveUnifiedStorage.mockImplementation(async () => {
+      mocks.events.push("save");
+      return { ok: false, backend: "indexedDB", reason: "idb_flush_failed" };
+    });
+
+    const result = await runInferredContinuityShadow("k1", { id: "S1" });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("idb_flush_failed");
+    expect(mocks.events).toEqual(["persist", "save"]);
+    expect(mocks.commitObservationWindow).not.toHaveBeenCalled();
+  });
+
+  it("baseline commit 後の耐久保存に失敗した場合は失敗として返す", async () => {
+    mocks.classifyHostAttribution.mockReturnValue(classification());
+    mocks.buildInferredContinuityProjection.mockReturnValue({
+      host: "k1",
+      inferredContinuityUsedMm: 1200,
+      eligibleForPersistence: true,
+      status: "ok"
+    });
+    mocks.persistInferredCandidate.mockImplementation(() => {
+      mocks.events.push("persist");
+      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000 } };
+    });
+    mocks.commitObservationWindow.mockImplementation(() => {
+      mocks.events.push("commit");
+      return { ok: true, reason: "committed" };
+    });
+    mocks.saveUnifiedStorage.mockImplementationOnce(async () => {
+      mocks.events.push("save");
+      return { ok: true, backend: "indexedDB", reason: "flushed" };
+    }).mockImplementationOnce(async () => {
+      mocks.events.push("save");
+      return { ok: false, backend: "indexedDB", reason: "idb_flush_failed" };
+    });
+
+    const result = await runInferredContinuityShadow("k1", { id: "S1" });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("idb_flush_failed");
+    expect(mocks.events).toEqual(["persist", "save", "commit", "save"]);
+  });
+
+  it("例外を shadow_failed に畳み、本流へ throw しない", async () => {
     mocks.classifyHostAttribution.mockImplementation(() => { throw new Error("classifier boom"); });
 
-    const result = runInferredContinuityShadow("k1", { id: "S1" });
+    const result = await runInferredContinuityShadow("k1", { id: "S1" });
 
     expect(result.ok).toBe(false);
     expect(result.reason).toBe("shadow_failed");

--- a/tests/unit/dashboard_offline_live_shadow.test.js
+++ b/tests/unit/dashboard_offline_live_shadow.test.js
@@ -104,6 +104,60 @@ describe("runInferredContinuityShadow", () => {
     expect(mocks.events).toEqual(["persist", "save", "commit", "save"]);
   });
 
+  it("耐久保存中に sequence だけ進んだ同一 window は最新 sequence で baseline commit する", async () => {
+    const before = classification({ currentSequence: 2 });
+    const after = classification({ currentSequence: 3 });
+    const projection = { host: "k1", inferredContinuityUsedMm: 1200, eligibleForPersistence: true, status: "ok" };
+    mocks.classifyHostAttribution.mockReturnValueOnce(before).mockReturnValueOnce(after);
+    mocks.buildInferredContinuityProjection.mockReturnValue(projection);
+    mocks.persistInferredCandidate.mockImplementation(() => {
+      mocks.events.push("persist");
+      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000 } };
+    });
+    mocks.commitObservationWindow.mockImplementation(() => {
+      mocks.events.push("commit");
+      return { ok: true, reason: "committed" };
+    });
+
+    const result = await runInferredContinuityShadow("k1", { id: "S1" });
+
+    expect(result.ok).toBe(true);
+    expect(mocks.commitObservationWindow).toHaveBeenCalledWith("k1", {
+      windowId: "k1|b1|c2",
+      expectedSequence: 3,
+      candidatePersistedAt: 1000,
+      candidateHash: "ic-1",
+      expectedAppSessionId: "session-a"
+    });
+    expect(mocks.events).toEqual(["persist", "save", "commit", "save"]);
+  });
+
+  it("耐久保存中に offline key 集合が変わった場合は baseline commit を止める", async () => {
+    const before = classification({ currentSequence: 2 });
+    const after = classification({
+      currentSequence: 3,
+      candidate: { ...classification().candidate, offlineObservationKeys: ["job-a", "job-b"] }
+    });
+    mocks.classifyHostAttribution.mockReturnValueOnce(before).mockReturnValueOnce(after);
+    mocks.buildInferredContinuityProjection.mockReturnValue({
+      host: "k1",
+      inferredContinuityUsedMm: 1200,
+      eligibleForPersistence: true,
+      status: "ok"
+    });
+    mocks.persistInferredCandidate.mockImplementation(() => {
+      mocks.events.push("persist");
+      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000 } };
+    });
+
+    const result = await runInferredContinuityShadow("k1", { id: "S1" });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("classification_changed_since_candidate_persisted");
+    expect(mocks.events).toEqual(["persist", "save"]);
+    expect(mocks.commitObservationWindow).not.toHaveBeenCalled();
+  });
+
   it("O2 が continuity-candidate 以外なら projection と保存を実行しない", async () => {
     mocks.classifyHostAttribution.mockReturnValue(classification({ classification: "no-offline-activity" }));
 

--- a/tests/unit/dashboard_offline_live_shadow.test.js
+++ b/tests/unit/dashboard_offline_live_shadow.test.js
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   classifyHostAttribution: vi.fn(),
   buildInferredContinuityProjection: vi.fn(),
   persistInferredCandidate: vi.fn(),
+  transitionInferredCandidate: vi.fn(),
   commitObservationWindow: vi.fn(),
   rollbackObservationWindowCommit: vi.fn()
 }));
@@ -28,6 +29,8 @@ vi.mock("../../3dp_lib/dashboard_offline_projection.js", () => ({
   buildInferredContinuityProjection: mocks.buildInferredContinuityProjection
 }));
 vi.mock("../../3dp_lib/dashboard_offline_candidate_store.js", () => ({
+  INFERRED_CANDIDATE_STATUS: { SUPERSEDED: "superseded" },
+  transitionInferredCandidate: mocks.transitionInferredCandidate,
   persistInferredCandidate: mocks.persistInferredCandidate
 }));
 vi.mock("../../3dp_lib/dashboard_offline_observation.js", () => ({
@@ -73,6 +76,11 @@ beforeEach(() => {
   mocks.classifyHostAttribution.mockReset();
   mocks.buildInferredContinuityProjection.mockReset();
   mocks.persistInferredCandidate.mockReset();
+  mocks.transitionInferredCandidate.mockReset();
+  mocks.transitionInferredCandidate.mockImplementation(() => {
+    mocks.events.push("supersede");
+    return { ok: true, reason: "transitioned", record: { status: "superseded" } };
+  });
   mocks.commitObservationWindow.mockReset();
   mocks.rollbackObservationWindowCommit.mockReset();
 });
@@ -135,7 +143,7 @@ describe("runInferredContinuityShadow", () => {
     expect(mocks.events).toEqual(["persist", "save", "commit", "save"]);
   });
 
-  it("耐久保存中に offline key 集合が変わった場合は baseline commit を止める", async () => {
+  it("耐久保存中に offline key 集合が変わった場合は candidate を supersede して baseline commit を止める", async () => {
     const before = classification({ currentSequence: 2 });
     const after = classification({
       currentSequence: 3,
@@ -157,7 +165,14 @@ describe("runInferredContinuityShadow", () => {
 
     expect(result.ok).toBe(false);
     expect(result.reason).toBe("classification_changed_since_candidate_persisted");
-    expect(mocks.events).toEqual(["persist", "save"]);
+    expect(result.supersede).toEqual({ ok: true, reason: "transitioned", record: { status: "superseded" } });
+    expect(mocks.events).toEqual(["persist", "save", "supersede", "save"]);
+    expect(mocks.transitionInferredCandidate).toHaveBeenCalledWith("ic-1", "superseded", {
+      actor: "system",
+      reason: "classification-changed-after-persist",
+      supersededBy: null,
+      nowMs: undefined
+    });
     expect(mocks.commitObservationWindow).not.toHaveBeenCalled();
   });
 
@@ -298,7 +313,39 @@ describe("runInferredContinuityShadow", () => {
       windowId: "k1|b1|c2",
       previousBaseline: { windowId: "before" }
     });
-    expect(mocks.events).toEqual(["persist", "save", "commit", "save", "rollback"]);
+    expect(result.rollbackSave).toEqual({ ok: true, backend: "indexedDB", reason: "flushed" });
+    expect(mocks.events).toEqual(["persist", "save", "commit", "save", "rollback", "save"]);
+  });
+
+  it("baseline commit が失敗した場合は保存済み candidate を supersede する", async () => {
+    mocks.classifyHostAttribution.mockReturnValue(classification());
+    mocks.buildInferredContinuityProjection.mockReturnValue({
+      host: "k1",
+      inferredContinuityUsedMm: 1200,
+      eligibleForPersistence: true,
+      status: "ok"
+    });
+    mocks.persistInferredCandidate.mockImplementation(() => {
+      mocks.events.push("persist");
+      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000 } };
+    });
+    mocks.commitObservationWindow.mockImplementation(() => {
+      mocks.events.push("commit");
+      return { ok: false, reason: "observation_changed_since_evaluation" };
+    });
+
+    const result = await runInferredContinuityShadow("k1", { id: "S1" });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("observation_changed_since_evaluation");
+    expect(result.supersede).toEqual({ ok: true, reason: "transitioned", record: { status: "superseded" } });
+    expect(mocks.transitionInferredCandidate).toHaveBeenCalledWith("ic-1", "superseded", {
+      actor: "system",
+      reason: "observation-commit-failed",
+      supersededBy: null,
+      nowMs: undefined
+    });
+    expect(mocks.events).toEqual(["persist", "save", "commit", "supersede", "save"]);
   });
 
   it("同一hostのshadowが実行中なら二重起動しない", async () => {

--- a/tests/unit/dashboard_offline_live_shadow.test.js
+++ b/tests/unit/dashboard_offline_live_shadow.test.js
@@ -32,6 +32,7 @@ vi.mock("../../3dp_lib/dashboard_offline_candidate_store.js", () => ({
 vi.mock("../../3dp_lib/dashboard_offline_observation.js", () => ({
   commitObservationWindow: mocks.commitObservationWindow
 }));
+vi.mock("../../3dp_lib/dashboard_time.js", () => ({ wallNowMs: () => 123456 }));
 
 const { runInferredContinuityShadow } = await import("../../3dp_lib/dashboard_offline_live_shadow.js");
 
@@ -126,6 +127,37 @@ describe("runInferredContinuityShadow", () => {
     expect(result.reason).toBe("no_inferred_debit");
     expect(mocks.saveUnifiedStorage).not.toHaveBeenCalled();
     expect(mocks.commitObservationWindow).not.toHaveBeenCalled();
+  });
+
+  it("candidate と baseline がともに idempotent の場合は耐久保存を追加実行しない", async () => {
+    mocks.classifyHostAttribution.mockReturnValue(classification());
+    mocks.buildInferredContinuityProjection.mockReturnValue({
+      host: "k1",
+      inferredContinuityUsedMm: 1200,
+      eligibleForPersistence: true,
+      status: "ok"
+    });
+    mocks.persistInferredCandidate.mockImplementation(() => {
+      mocks.events.push("persist");
+      return {
+        ok: true,
+        reason: "idempotent",
+        candidateHash: "ic-1",
+        record: { createdAt: 1000, updatedAt: 1000 },
+        idempotent: true
+      };
+    });
+    mocks.commitObservationWindow.mockImplementation(() => {
+      mocks.events.push("commit");
+      return { ok: true, reason: "idempotent", idempotent: true };
+    });
+
+    const result = await runInferredContinuityShadow("k1", { id: "S1" });
+
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe("idempotent");
+    expect(mocks.events).toEqual(["persist", "commit"]);
+    expect(mocks.saveUnifiedStorage).not.toHaveBeenCalled();
   });
 
   it("O3 が persistence 不可なら O4 保存と baseline commit を実行しない", async () => {

--- a/tests/unit/dashboard_offline_live_shadow.test.js
+++ b/tests/unit/dashboard_offline_live_shadow.test.js
@@ -1,0 +1,136 @@
+/**
+ * @fileoverview dashboard_offline_live_shadow.js（#413 live shadow 配線）の単体テスト
+ * aggregator から O2/O3/O4 を呼び、candidate 保存後だけ baseline commit へ進むことを検証する。
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  events: [],
+  monitorData: {
+    hostObservationCurrent: { k1: { appSessionId: "session-a" } },
+    machines: { k1: { printStore: { history: [{ id: "job-a", materialUsedMm: 1200 }] } } }
+  },
+  saveUnifiedStorage: vi.fn(() => { mocks.events.push("save"); }),
+  classifyHostAttribution: vi.fn(),
+  buildInferredContinuityProjection: vi.fn(),
+  persistInferredCandidate: vi.fn(),
+  commitObservationWindow: vi.fn()
+}));
+
+vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mocks.monitorData }));
+vi.mock("../../3dp_lib/dashboard_storage.js", () => ({ saveUnifiedStorage: mocks.saveUnifiedStorage }));
+vi.mock("../../3dp_lib/dashboard_offline_classifier.js", () => ({
+  ATTR_CLASS: { CONTINUITY_CANDIDATE: "continuity-candidate" },
+  classifyHostAttribution: mocks.classifyHostAttribution
+}));
+vi.mock("../../3dp_lib/dashboard_offline_projection.js", () => ({
+  buildInferredContinuityProjection: mocks.buildInferredContinuityProjection
+}));
+vi.mock("../../3dp_lib/dashboard_offline_candidate_store.js", () => ({
+  persistInferredCandidate: mocks.persistInferredCandidate
+}));
+vi.mock("../../3dp_lib/dashboard_offline_observation.js", () => ({
+  commitObservationWindow: mocks.commitObservationWindow
+}));
+
+const { runInferredContinuityShadow } = await import("../../3dp_lib/dashboard_offline_live_shadow.js");
+
+/**
+ * O2 classification fixture を作成する。
+ *
+ * @function classification
+ * @param {Object} [over] - 上書きする分類値。
+ * @returns {Object} classifyHostAttribution の戻り値相当。
+ */
+function classification(over = {}) {
+  return {
+    classification: "continuity-candidate",
+    host: "k1",
+    windowId: "k1|b1|c2",
+    currentSequence: 2,
+    candidate: {
+      candidateSpoolId: "S1",
+      candidateBaselineIntervalId: "iv1",
+      candidateCurrentIntervalId: "iv1",
+      offlineObservationKeys: ["job-a"]
+    },
+    ...over
+  };
+}
+
+beforeEach(() => {
+  mocks.events.length = 0;
+  mocks.monitorData.hostObservationCurrent = { k1: { appSessionId: "session-a" } };
+  mocks.monitorData.machines = { k1: { printStore: { history: [{ id: "job-a", materialUsedMm: 1200 }] } } };
+  mocks.saveUnifiedStorage.mockClear();
+  mocks.classifyHostAttribution.mockReset();
+  mocks.buildInferredContinuityProjection.mockReset();
+  mocks.persistInferredCandidate.mockReset();
+  mocks.commitObservationWindow.mockReset();
+});
+
+describe("runInferredContinuityShadow", () => {
+  it("candidate を保存してから baseline commit し、commit 成功後に再保存する", () => {
+    const cls = classification();
+    const projection = { host: "k1", inferredContinuityUsedMm: 1200 };
+    mocks.classifyHostAttribution.mockReturnValue(cls);
+    mocks.buildInferredContinuityProjection.mockReturnValue(projection);
+    mocks.persistInferredCandidate.mockImplementation(() => {
+      mocks.events.push("persist");
+      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000 } };
+    });
+    mocks.commitObservationWindow.mockImplementation(() => {
+      mocks.events.push("commit");
+      return { ok: true, reason: "committed" };
+    });
+
+    const result = runInferredContinuityShadow("k1", { id: "S1", remainingLengthMm: 5000 });
+
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe("committed");
+    expect(mocks.buildInferredContinuityProjection).toHaveBeenCalledWith(cls, { id: "S1", remainingLengthMm: 5000 }, mocks.monitorData.machines.k1.printStore.history);
+    expect(mocks.commitObservationWindow).toHaveBeenCalledWith("k1", {
+      windowId: "k1|b1|c2",
+      expectedSequence: 2,
+      candidatePersistedAt: 1000,
+      candidateHash: "ic-1",
+      expectedAppSessionId: "session-a"
+    });
+    expect(mocks.events).toEqual(["persist", "save", "commit", "save"]);
+  });
+
+  it("O2 が continuity-candidate 以外なら projection と保存を実行しない", () => {
+    mocks.classifyHostAttribution.mockReturnValue(classification({ classification: "no-offline-activity" }));
+
+    const result = runInferredContinuityShadow("k1", { id: "S1" });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("no-offline-activity");
+    expect(mocks.buildInferredContinuityProjection).not.toHaveBeenCalled();
+    expect(mocks.persistInferredCandidate).not.toHaveBeenCalled();
+    expect(mocks.commitObservationWindow).not.toHaveBeenCalled();
+  });
+
+  it("O4 が no_inferred_debit を返した場合は baseline を進めない", () => {
+    mocks.classifyHostAttribution.mockReturnValue(classification());
+    mocks.buildInferredContinuityProjection.mockReturnValue({ host: "k1", inferredContinuityUsedMm: 0 });
+    mocks.persistInferredCandidate.mockReturnValue({ ok: false, reason: "no_inferred_debit", candidateHash: null, record: null });
+
+    const result = runInferredContinuityShadow("k1", { id: "S1" });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("no_inferred_debit");
+    expect(mocks.saveUnifiedStorage).not.toHaveBeenCalled();
+    expect(mocks.commitObservationWindow).not.toHaveBeenCalled();
+  });
+
+  it("例外を shadow_failed に畳み、本流へ throw しない", () => {
+    mocks.classifyHostAttribution.mockImplementation(() => { throw new Error("classifier boom"); });
+
+    const result = runInferredContinuityShadow("k1", { id: "S1" });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("shadow_failed");
+    expect(result.error).toBe("classifier boom");
+  });
+});

--- a/tests/unit/dashboard_offline_live_shadow.test.js
+++ b/tests/unit/dashboard_offline_live_shadow.test.js
@@ -14,7 +14,8 @@ const mocks = vi.hoisted(() => ({
   classifyHostAttribution: vi.fn(),
   buildInferredContinuityProjection: vi.fn(),
   persistInferredCandidate: vi.fn(),
-  commitObservationWindow: vi.fn()
+  commitObservationWindow: vi.fn(),
+  rollbackObservationWindowCommit: vi.fn()
 }));
 
 vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mocks.monitorData }));
@@ -30,7 +31,8 @@ vi.mock("../../3dp_lib/dashboard_offline_candidate_store.js", () => ({
   persistInferredCandidate: mocks.persistInferredCandidate
 }));
 vi.mock("../../3dp_lib/dashboard_offline_observation.js", () => ({
-  commitObservationWindow: mocks.commitObservationWindow
+  commitObservationWindow: mocks.commitObservationWindow,
+  rollbackObservationWindowCommit: mocks.rollbackObservationWindowCommit
 }));
 vi.mock("../../3dp_lib/dashboard_time.js", () => ({ wallNowMs: () => 123456 }));
 
@@ -72,6 +74,7 @@ beforeEach(() => {
   mocks.buildInferredContinuityProjection.mockReset();
   mocks.persistInferredCandidate.mockReset();
   mocks.commitObservationWindow.mockReset();
+  mocks.rollbackObservationWindowCommit.mockReset();
 });
 
 describe("runInferredContinuityShadow", () => {
@@ -183,7 +186,7 @@ describe("runInferredContinuityShadow", () => {
     expect(mocks.commitObservationWindow).not.toHaveBeenCalled();
   });
 
-  it("candidate と baseline がともに idempotent の場合は耐久保存を追加実行しない", async () => {
+  it("candidate が idempotent でも commit 前に耐久保存を再試行する", async () => {
     mocks.classifyHostAttribution.mockReturnValue(classification());
     mocks.buildInferredContinuityProjection.mockReturnValue({
       host: "k1",
@@ -210,8 +213,8 @@ describe("runInferredContinuityShadow", () => {
 
     expect(result.ok).toBe(true);
     expect(result.reason).toBe("idempotent");
-    expect(mocks.events).toEqual(["persist", "commit"]);
-    expect(mocks.saveUnifiedStorage).not.toHaveBeenCalled();
+    expect(mocks.events).toEqual(["persist", "save", "commit"]);
+    expect(mocks.saveUnifiedStorage).toHaveBeenCalledTimes(1);
   });
 
   it("O3 が persistence 不可なら O4 保存と baseline commit を実行しない", async () => {
@@ -258,7 +261,7 @@ describe("runInferredContinuityShadow", () => {
     expect(mocks.commitObservationWindow).not.toHaveBeenCalled();
   });
 
-  it("baseline commit 後の耐久保存に失敗した場合は失敗として返す", async () => {
+  it("baseline commit 後の耐久保存に失敗した場合はbaselineを巻き戻して失敗として返す", async () => {
     mocks.classifyHostAttribution.mockReturnValue(classification());
     mocks.buildInferredContinuityProjection.mockReturnValue({
       host: "k1",
@@ -272,7 +275,11 @@ describe("runInferredContinuityShadow", () => {
     });
     mocks.commitObservationWindow.mockImplementation(() => {
       mocks.events.push("commit");
-      return { ok: true, reason: "committed" };
+      return { ok: true, reason: "committed", previousBaseline: { windowId: "before" } };
+    });
+    mocks.rollbackObservationWindowCommit.mockImplementation(() => {
+      mocks.events.push("rollback");
+      return { ok: true, reason: "rolled_back" };
     });
     mocks.saveUnifiedStorage.mockImplementationOnce(async () => {
       mocks.events.push("save");
@@ -286,7 +293,50 @@ describe("runInferredContinuityShadow", () => {
 
     expect(result.ok).toBe(false);
     expect(result.reason).toBe("idb_flush_failed");
-    expect(mocks.events).toEqual(["persist", "save", "commit", "save"]);
+    expect(result.rollback).toEqual({ ok: true, reason: "rolled_back" });
+    expect(mocks.rollbackObservationWindowCommit).toHaveBeenCalledWith("k1", {
+      windowId: "k1|b1|c2",
+      previousBaseline: { windowId: "before" }
+    });
+    expect(mocks.events).toEqual(["persist", "save", "commit", "save", "rollback"]);
+  });
+
+  it("同一hostのshadowが実行中なら二重起動しない", async () => {
+    let releaseSave;
+    const saveBlocker = new Promise((resolve) => { releaseSave = resolve; });
+    mocks.classifyHostAttribution.mockReturnValue(classification());
+    mocks.buildInferredContinuityProjection.mockReturnValue({
+      host: "k1",
+      inferredContinuityUsedMm: 1200,
+      eligibleForPersistence: true,
+      status: "ok"
+    });
+    mocks.persistInferredCandidate.mockImplementation(() => {
+      mocks.events.push("persist");
+      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000 } };
+    });
+    mocks.saveUnifiedStorage.mockImplementationOnce(async () => {
+      mocks.events.push("save-wait");
+      await saveBlocker;
+      return { ok: true, backend: "indexedDB", reason: "flushed" };
+    }).mockImplementation(async () => {
+      mocks.events.push("save");
+      return { ok: true, backend: "indexedDB", reason: "flushed" };
+    });
+    mocks.commitObservationWindow.mockImplementation(() => {
+      mocks.events.push("commit");
+      return { ok: true, reason: "committed" };
+    });
+
+    const first = runInferredContinuityShadow("k1", { id: "S1" });
+    await Promise.resolve();
+    const second = await runInferredContinuityShadow("k1", { id: "S1" });
+    releaseSave();
+    const firstResult = await first;
+
+    expect(second).toEqual({ ok: false, reason: "shadow_in_flight" });
+    expect(firstResult.ok).toBe(true);
+    expect(mocks.persistInferredCandidate).toHaveBeenCalledTimes(1);
   });
 
   it("例外を shadow_failed に畳み、本流へ throw しない", async () => {

--- a/tests/unit/dashboard_offline_live_shadow.test.js
+++ b/tests/unit/dashboard_offline_live_shadow.test.js
@@ -29,7 +29,7 @@ vi.mock("../../3dp_lib/dashboard_offline_projection.js", () => ({
   buildInferredContinuityProjection: mocks.buildInferredContinuityProjection
 }));
 vi.mock("../../3dp_lib/dashboard_offline_candidate_store.js", () => ({
-  INFERRED_CANDIDATE_STATUS: { SUPERSEDED: "superseded" },
+  INFERRED_CANDIDATE_STATUS: { PENDING: "pending", SUPERSEDED: "superseded" },
   transitionInferredCandidate: mocks.transitionInferredCandidate,
   persistInferredCandidate: mocks.persistInferredCandidate
 }));
@@ -93,7 +93,7 @@ describe("runInferredContinuityShadow", () => {
     mocks.buildInferredContinuityProjection.mockReturnValue(projection);
     mocks.persistInferredCandidate.mockImplementation(() => {
       mocks.events.push("persist");
-      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000 } };
+      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000, status: "pending" } };
     });
     mocks.commitObservationWindow.mockImplementation(() => {
       mocks.events.push("commit");
@@ -123,7 +123,7 @@ describe("runInferredContinuityShadow", () => {
     mocks.buildInferredContinuityProjection.mockReturnValue(projection);
     mocks.persistInferredCandidate.mockImplementation(() => {
       mocks.events.push("persist");
-      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000 } };
+      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000, status: "pending" } };
     });
     mocks.commitObservationWindow.mockImplementation(() => {
       mocks.events.push("commit");
@@ -158,7 +158,7 @@ describe("runInferredContinuityShadow", () => {
     });
     mocks.persistInferredCandidate.mockImplementation(() => {
       mocks.events.push("persist");
-      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000 } };
+      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000, status: "pending" } };
     });
 
     const result = await runInferredContinuityShadow("k1", { id: "S1" });
@@ -201,6 +201,34 @@ describe("runInferredContinuityShadow", () => {
     expect(mocks.commitObservationWindow).not.toHaveBeenCalled();
   });
 
+  it("O4 が非 pending の既存 candidate を返した場合は保存と baseline commit を実行しない", async () => {
+    mocks.classifyHostAttribution.mockReturnValue(classification());
+    mocks.buildInferredContinuityProjection.mockReturnValue({
+      host: "k1",
+      inferredContinuityUsedMm: 1200,
+      eligibleForPersistence: true,
+      status: "ok"
+    });
+    mocks.persistInferredCandidate.mockImplementation(() => {
+      mocks.events.push("persist");
+      return {
+        ok: true,
+        reason: "idempotent",
+        candidateHash: "ic-1",
+        record: { createdAt: 1000, status: "superseded" },
+        idempotent: true
+      };
+    });
+
+    const result = await runInferredContinuityShadow("k1", { id: "S1" });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("candidate_not_pending");
+    expect(mocks.events).toEqual(["persist"]);
+    expect(mocks.saveUnifiedStorage).not.toHaveBeenCalled();
+    expect(mocks.commitObservationWindow).not.toHaveBeenCalled();
+  });
+
   it("candidate が idempotent でも commit 前に耐久保存を再試行する", async () => {
     mocks.classifyHostAttribution.mockReturnValue(classification());
     mocks.buildInferredContinuityProjection.mockReturnValue({
@@ -215,7 +243,7 @@ describe("runInferredContinuityShadow", () => {
         ok: true,
         reason: "idempotent",
         candidateHash: "ic-1",
-        record: { createdAt: 1000, updatedAt: 1000 },
+        record: { createdAt: 1000, updatedAt: 1000, status: "pending" },
         idempotent: true
       };
     });
@@ -261,7 +289,7 @@ describe("runInferredContinuityShadow", () => {
     });
     mocks.persistInferredCandidate.mockImplementation(() => {
       mocks.events.push("persist");
-      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000 } };
+      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000, status: "pending" } };
     });
     mocks.saveUnifiedStorage.mockImplementation(async () => {
       mocks.events.push("save");
@@ -286,7 +314,7 @@ describe("runInferredContinuityShadow", () => {
     });
     mocks.persistInferredCandidate.mockImplementation(() => {
       mocks.events.push("persist");
-      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000 } };
+      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000, status: "pending" } };
     });
     mocks.commitObservationWindow.mockImplementation(() => {
       mocks.events.push("commit");
@@ -327,7 +355,7 @@ describe("runInferredContinuityShadow", () => {
     });
     mocks.persistInferredCandidate.mockImplementation(() => {
       mocks.events.push("persist");
-      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000 } };
+      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000, status: "pending" } };
     });
     mocks.commitObservationWindow.mockImplementation(() => {
       mocks.events.push("commit");
@@ -360,7 +388,7 @@ describe("runInferredContinuityShadow", () => {
     });
     mocks.persistInferredCandidate.mockImplementation(() => {
       mocks.events.push("persist");
-      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000 } };
+      return { ok: true, reason: "created", candidateHash: "ic-1", record: { createdAt: 1000, status: "pending" } };
     });
     mocks.saveUnifiedStorage.mockImplementationOnce(async () => {
       mocks.events.push("save-wait");

--- a/tests/unit/dashboard_offline_observation.test.js
+++ b/tests/unit/dashboard_offline_observation.test.js
@@ -101,6 +101,30 @@ describe("computeObservationWindow — 5000件切詰め境界（P0-1・実運用
     expect(w.bounded).toBe(true);
   });
 
+  it("★codex-P1(実経路): 再取得で古い脱落履歴に lastAt 超の finishTime が後付けされても offline へ再流入させない", () => {
+    // レビュアー指摘の実経路: baseline時に完了時刻なしで切詰め脱落した古い1000件へ、履歴再取得で
+    //   境界より新しい finishTime（複合キーも変化）が後付けされ current retained へ入るケース。新規印刷0件。
+    mockMonitorData.hostSpoolMap.h = "S1";
+    const baseHist = [];
+    for (let i = 1; i <= 1000; i++) baseHist.push({ id: String(i), printfinish: 1, filename: `f${i}.gcode`, materialUsedMm: 100 }); // 完了時刻なし
+    for (let i = 1001; i <= 6000; i++) baseHist.push({ id: String(i), printfinish: 1, filename: `f${i}.gcode`, materialUsedMm: 100, finishTime: BASE + i * 1000 });
+    setHistory("h", baseHist);
+    recordObservation("h", { mountIntervalStatus: "ok", mountIntervalId: "iv1" });
+    const w0 = computeObservationWindow("h");
+    commitObservationWindow("h", { windowId: w0.windowId, expectedSequence: w0.currentSequence, candidatePersistedAt: 1 });
+    expect(mockMonitorData.hostObservationWatermark.h.retainedRange.truncated).toBe(true); // 古い1000件は脱落
+    // 再取得: 古い1000件へ lastAt 超の finishTime を後付け（新規印刷なし＝総数不変）
+    const lastAt = BASE + 6000 * 1000;
+    const refetched = baseHist.map((e, idx) => idx < 1000 ? { ...e, finishTime: lastAt + (idx + 1) * 1000 } : e);
+    setHistory("h", refetched);
+    recordObservation("h", { mountIntervalStatus: "ok", mountIntervalId: "iv1" });
+    const w = computeObservationWindow("h");
+    expect(w.offlineObservationKeys).toEqual([]);        // 誤 offline 再流入なし
+    expect(w.bounded).toBe(false);
+    expect(w.windowKind).toBe("insufficient");
+    expect(w.reason).toBe("history-truncated-unverifiable");
+  });
+
   it("★codex-P1: truncated baseline＋完了時刻なしの差分を offline 確定しない（fail-closed）", () => {
     // Codex 指摘: 5000件切詰め後、完了時刻が無い/境界時刻が作れない古い履歴を offline 誤検出する。
     const key = (id) => JSON.stringify([id, 0, 0, `f${id}.gcode`]);

--- a/tests/unit/dashboard_offline_projection.test.js
+++ b/tests/unit/dashboard_offline_projection.test.js
@@ -133,6 +133,9 @@ describe("buildInferredContinuityProjection", () => {
     const result = buildInferredContinuityProjection(classification([keyOf(j1), keyOf(j2)]), spool, [j1, j2]);
 
     expect(result.confirmedRemainingMm).toBe(10_000);
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe("ok");
+    expect(result.eligibleForPersistence).toBe(true);
     expect(result.inferredContinuityUsedMm).toBe(3500);
     expect(result.projectedRemainingMm).toBe(6500);
     expect(result.candidateDebits.map(d => d.status)).toEqual(["inferred-debit", "inferred-debit"]);
@@ -164,8 +167,26 @@ describe("buildInferredContinuityProjection", () => {
 
     expect(result.inferredContinuityUsedMm).toBe(0);
     expect(result.projectedRemainingMm).toBe(9000);
+    expect(result.status).toBe("contradicted");
+    expect(result.eligibleForPersistence).toBe(false);
     expect(result.contradictions).toHaveLength(1);
     expect(result.contradictions[0].reason).toBe("already-confirmed-on-other-spool");
+  });
+
+  it("未帰属 job と別スプール確定 job が混在した window は全体を fail-closed する", () => {
+    const pending = job("411", 1000, 411);
+    const other = job("412", 4000, 412, { filamentInfo: [{ spoolId: "S2", usedMm: 4000 }] });
+    const result = buildInferredContinuityProjection(
+      classification([keyOf(pending), keyOf(other)]),
+      { id: "S1", remainingLengthMm: 9000 },
+      [pending, other]
+    );
+
+    expect(result.candidateDebits.map(d => d.status)).toEqual(["inferred-debit", "confirmed-other-spool"]);
+    expect(result.inferredContinuityUsedMm).toBe(0);
+    expect(result.projectedRemainingMm).toBe(9000);
+    expect(result.status).toBe("contradicted");
+    expect(result.eligibleForPersistence).toBe(false);
   });
 
   it("履歴消失と使用量不明は unresolved に分離し projected へ入れない", () => {
@@ -178,7 +199,53 @@ describe("buildInferredContinuityProjection", () => {
 
     expect(result.inferredContinuityUsedMm).toBe(0);
     expect(result.projectedRemainingMm).toBe(5000);
+    expect(result.status).toBe("unresolved");
+    expect(result.eligibleForPersistence).toBe(false);
     expect(result.unresolved.map(d => d.status)).toEqual(["no-usage", "unresolved"]);
+  });
+
+  it("確定残量が不明なら 0mm に丸めず persistence 不可にする", () => {
+    const entry = job("511", 1200, 511);
+    const result = buildInferredContinuityProjection(
+      classification([keyOf(entry)]),
+      { id: "S1", remainingLengthMm: null },
+      [entry]
+    );
+
+    expect(result.confirmedRemainingMm).toBe(null);
+    expect(result.projectedRemainingMm).toBe(null);
+    expect(result.inferredContinuityUsedMm).toBe(0);
+    expect(result.status).toBe("remaining-unknown");
+    expect(result.eligibleForPersistence).toBe(false);
+  });
+
+  it("同一 observation key が履歴に重複する場合は配列順に依存せず ambiguous として拒否する", () => {
+    const first = job("521", 1000, 521);
+    const duplicate = { ...first, filamentInfo: [{ spoolId: "S2", usedMm: 1000 }] };
+    const result = buildInferredContinuityProjection(
+      classification([keyOf(first)]),
+      { id: "S1", remainingLengthMm: 5000 },
+      [first, duplicate]
+    );
+
+    expect(result.inferredContinuityUsedMm).toBe(0);
+    expect(result.status).toBe("ambiguous-history");
+    expect(result.eligibleForPersistence).toBe(false);
+    expect(result.unresolved[0].reason).toBe("duplicate-observation-key");
+  });
+
+  it("filamentInfo と filamentId の確定スプールが競合する履歴は ambiguous として拒否する", () => {
+    const entry = job("531", 1000, 531, { filamentInfo: [{ spoolId: "S1", usedMm: 1000 }], filamentId: "S2" });
+    const result = buildInferredContinuityProjection(
+      classification([keyOf(entry)]),
+      { id: "S1", remainingLengthMm: 5000 },
+      [entry]
+    );
+
+    expect(result.inferredContinuityUsedMm).toBe(0);
+    expect(result.status).toBe("ambiguous-history");
+    expect(result.eligibleForPersistence).toBe(false);
+    expect(result.unresolved[0].reason).toBe("conflicting-confirmed-spool-fields");
   });
 
   it("continuity-candidate 以外の分類では推定 debit しない", () => {
@@ -192,6 +259,7 @@ describe("buildInferredContinuityProjection", () => {
     expect(result.inferredContinuityUsedMm).toBe(0);
     expect(result.candidateDebits).toEqual([]);
     expect(result.projectedRemainingMm).toBe(7000);
+    expect(result.eligibleForPersistence).toBe(false);
   });
 
   it("projection 対象 spool と candidate spool が違う場合は矛盾として debit しない", () => {
@@ -205,6 +273,8 @@ describe("buildInferredContinuityProjection", () => {
     expect(result.inferredContinuityUsedMm).toBe(0);
     expect(result.candidateDebits).toEqual([]);
     expect(result.contradictions[0].reason).toBe("projection-spool-mismatch");
+    expect(result.status).toBe("projection-spool-mismatch");
+    expect(result.eligibleForPersistence).toBe(false);
     expect(result.projectedRemainingMm).toBe(7000);
   });
 

--- a/tests/unit/dashboard_storage_durable.test.js
+++ b/tests/unit/dashboard_storage_durable.test.js
@@ -105,4 +105,26 @@ describe("saveUnifiedStorageDurably", () => {
 
     expect(result).toEqual({ ok: false, backend: "indexedDB", reason: "idb_flush_failed" });
   });
+
+  it("localStorage.setItem が例外なら ok=false を返す", async () => {
+    mocks.idbAvailable = false;
+    await initStorage();
+    const originalSetItem = globalThis.localStorage.setItem;
+    globalThis.localStorage.clear();
+    mocks.monitorData.machines.k1.storedData = { forceWrite: "quota-case" };
+    globalThis.localStorage.setItem = () => {
+      throw new DOMException("quota", "QuotaExceededError");
+    };
+
+    try {
+      const result = await saveUnifiedStorageDurably();
+
+      expect(result.ok).toBe(false);
+      expect(result.backend).toBe("localStorage");
+      expect(result.reason).toBe("local_storage_write_failed");
+      expect(result.error).toContain("quota");
+    } finally {
+      globalThis.localStorage.setItem = originalSetItem;
+    }
+  });
 });

--- a/tests/unit/dashboard_storage_durable.test.js
+++ b/tests/unit/dashboard_storage_durable.test.js
@@ -1,0 +1,108 @@
+/**
+ * @fileoverview dashboard_storage.js の耐久保存 API テスト
+ * O4 candidate 保存後に baseline commit へ進む前、IndexedDB flush 完了を待つ契約を検証する。
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+class LocalStorageStub {
+  constructor() { this._m = new Map(); }
+  getItem(k) { return this._m.has(k) ? this._m.get(k) : null; }
+  setItem(k, v) { this._m.set(String(k), String(v)); }
+  removeItem(k) { this._m.delete(k); }
+  clear() { this._m.clear(); }
+  key(i) { return Array.from(this._m.keys())[i] ?? null; }
+  get length() { return this._m.size; }
+}
+globalThis.localStorage = new LocalStorageStub();
+
+const mocks = vi.hoisted(() => ({
+  events: [],
+  idbAvailable: true,
+  monitorData: {
+    appSettings: {},
+    machines: {},
+    filamentSpools: [],
+    usageHistory: [],
+    filamentPresets: [],
+    userPresets: [],
+    hiddenPresets: [],
+    favoritePresets: [],
+    filamentInventory: [],
+    mountHistory: [],
+    mountHistorySeq: 0,
+    mountHistoryRejectedEvents: [],
+    hostObservationWatermark: {},
+    hostObservationCurrent: {},
+    inferredCandidateStore: {},
+    pendingUnattributedUsage: [],
+    pendingUnattributedUsageArchive: {},
+    ledgerRepairRequired: {},
+    filamentEventContext: {},
+    hostSpoolMap: {},
+    hostCameraToggle: {},
+    spoolSerialCounter: 0
+  },
+  queueSharedWrite: vi.fn((key) => { mocks.events.push(`queue:${key}`); }),
+  queueMachineWrite: vi.fn((host) => { mocks.events.push(`machine:${host}`); }),
+  flushIdb: vi.fn(async () => { mocks.events.push("flush"); })
+}));
+
+vi.mock("../../3dp_lib/dashboard_data.js", () => ({
+  monitorData: mocks.monitorData,
+  PLACEHOLDER_HOSTNAME: "_$_NO_MACHINE_$_",
+  ensureMachineData: vi.fn()
+}));
+vi.mock("../../3dp_lib/dashboard_filament_presets.js", () => ({ FILAMENT_PRESETS: [] }));
+vi.mock("../../3dp_lib/dashboard_log_util.js", () => ({ logManager: { add: vi.fn() } }));
+vi.mock("../../3dp_lib/dashboard_utils.js", () => ({ getCurrentTimestamp: () => 0 }));
+vi.mock("../../3dp_lib/dashboard_filament_ledger.js", () => ({ initLedgerAnchors: vi.fn(), quarantineInvalidMountEvents: vi.fn(() => 0) }));
+vi.mock("../../3dp_lib/dashboard_target_identity.js", () => ({ parseDest: vi.fn(), isIpLiteral: vi.fn(), extractHost: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_storage_idb.js", () => ({
+  initIdb: vi.fn(),
+  isIdbAvailable: () => mocks.idbAvailable,
+  getIdbCache: () => null,
+  queueSharedWrite: mocks.queueSharedWrite,
+  queueMachineWrite: mocks.queueMachineWrite,
+  flushIdb: mocks.flushIdb,
+  exportAllIdb: vi.fn(),
+  importAllIdb: vi.fn(),
+  setIdbDbName: vi.fn()
+}));
+
+const { initStorage, saveUnifiedStorageDurably } = await import("../../3dp_lib/dashboard_storage.js");
+
+beforeEach(async () => {
+  mocks.events.length = 0;
+  mocks.idbAvailable = true;
+  mocks.monitorData.machines = { k1: { storedData: {}, printStore: { history: [] }, runtimeData: { transient: true } } };
+  mocks.monitorData.inferredCandidateStore = { "ic-a": { candidateHash: "ic-a", usedMm: 1200 } };
+  mocks.monitorData.hostObservationWatermark = { k1: { observationSequence: 1 } };
+  mocks.queueSharedWrite.mockClear();
+  mocks.queueMachineWrite.mockClear();
+  mocks.flushIdb.mockClear();
+  mocks.flushIdb.mockImplementation(async () => { mocks.events.push("flush"); });
+  await initStorage();
+});
+
+describe("saveUnifiedStorageDurably", () => {
+  it("IndexedDB 使用時は queueSharedWrite 後に flushIdb 完了を待つ", async () => {
+    const result = await saveUnifiedStorageDurably();
+
+    expect(result).toEqual({ ok: true, backend: "indexedDB", reason: "flushed" });
+    expect(mocks.queueSharedWrite).toHaveBeenCalledWith("inferredCandidateStore", mocks.monitorData.inferredCandidateStore);
+    expect(mocks.queueSharedWrite).toHaveBeenCalledWith("hostObservationWatermark", mocks.monitorData.hostObservationWatermark);
+    expect(mocks.events.indexOf("queue:inferredCandidateStore")).toBeGreaterThanOrEqual(0);
+    expect(mocks.events[mocks.events.length - 1]).toBe("flush");
+  });
+
+  it("flush 中に IndexedDB が無効化された場合は失敗として返す", async () => {
+    mocks.flushIdb.mockImplementation(async () => {
+      mocks.events.push("flush");
+      mocks.idbAvailable = false;
+    });
+
+    const result = await saveUnifiedStorageDurably();
+
+    expect(result).toEqual({ ok: false, backend: "indexedDB", reason: "idb_flush_failed" });
+  });
+});


### PR DESCRIPTION
## Summary
- add a live shadow helper that runs O2/O3/O4 without mutating confirmed filament state
- persist inferred continuity candidates before committing the observation baseline
- wire the shadow flow after the existing offline catch-up path in the aggregator

## Testing
- npx vitest run tests/unit/dashboard_offline_live_shadow.test.js tests/unit/dashboard_offline_candidate_store.test.js tests/unit/dashboard_offline_projection.test.js tests/unit/dashboard_offline_classifier.test.js tests/unit/dashboard_offline_observation.test.js
- npx vitest run tests/integration --reporter=dot
- unit suite split into 4 chunks covering all 52 tests/unit files
- npx eslint 3dp_lib/dashboard_offline_live_shadow.js tests/unit/dashboard_offline_live_shadow.test.js
- npx eslint 3dp_lib/dashboard_aggregator.js
- git diff --check

Note: running the entire unit/full vitest suite as a single command timed out before reporting results in this Dropbox worktree, so the unit suite was verified in file chunks instead.