### PR TITLE
feat(filament): add inferred candidate decision core

### DIFF
--- a/3dp_lib/dashboard_inferred_candidate_decision.js
+++ b/3dp_lib/dashboard_inferred_candidate_decision.js
@@ -1,0 +1,469 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 推定 candidate Human Decision Core モジュール
+ * @file dashboard_inferred_candidate_decision.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * @author pumpCurry
+ * -----------------------------------------------------------
+ * @module dashboard_inferred_candidate_decision
+ *
+ * 【機能内容サマリ】
+ * - O5A として、pending inferredCandidate の Confirm / Reject / Reassign を提供する。
+ * - STAND ALONE と PARENT は確定台帳の権威として decision を実行できる。
+ * - SATELLITE は初期実装では閲覧専用とし、candidate/ledger へローカル書き込みしない。
+ * - Confirm/Reassign は台帳反映、candidate 状態遷移、耐久保存を一連の transaction として扱い、
+ *   保存失敗時はメモリ rollback と rollback 状態の耐久保存を試みる。
+ *
+ * 【公開関数一覧】
+ * - {@link canExecuteLedgerDecision}：この端末で O5 decision を実行できるか判定する
+ * - {@link confirmInferredCandidate}：candidate spool で推定使用量を確定する
+ * - {@link rejectInferredCandidate}：candidate を否認し、確定台帳には触れない
+ * - {@link reassignInferredCandidate}：別 spool へ再割当てして推定使用量を確定する
+ *
+ * @version 1.390.1261 (PR #414)
+ * @since   1.390.1261 (PR #414)
+ * @lastModified 2026-07-25 13:45:00
+ * -----------------------------------------------------------
+ * @todo
+ * - O5B でこの API を操作 UI と decision timeline へ接続する。
+ */
+
+"use strict";
+
+import { monitorData } from "./dashboard_data.js";
+import { saveUnifiedStorageDurably } from "./dashboard_storage.js";
+import {
+  INFERRED_CANDIDATE_STATUS,
+  transitionInferredCandidate
+} from "./dashboard_offline_candidate_store.js";
+import {
+  applyInferredCandidateLedger,
+  rollbackInferredCandidateLedger
+} from "./dashboard_inferred_candidate_ledger.js";
+import { wallNowMs } from "./dashboard_time.js";
+
+/**
+ * O5 decision 復旧要求を保存する monitorData field 名。
+ *
+ * @constant {string}
+ */
+const RECOVERY_FIELD = "inferredDecisionRecoveryRequired";
+
+/**
+ * Reject の理由として受け付ける短い識別子。
+ *
+ * @constant {Set<string>}
+ */
+const ALLOWED_REJECT_REASONS = new Set([
+  "not-same-spool",
+  "already-accounted",
+  "insufficient-evidence",
+  "operator-decision",
+  "other"
+]);
+
+/**
+ * JSON 互換オブジェクトを deep clone する。
+ *
+ * @private
+ * @function _clone
+ * @param {*} value - clone 対象。
+ * @returns {*} clone 済みの値。
+ */
+function _clone(value) {
+  if (typeof structuredClone === "function") return structuredClone(value);
+  return JSON.parse(JSON.stringify(value));
+}
+
+/**
+ * epoch ms の現在時刻を返す。
+ *
+ * @private
+ * @function _nowMs
+ * @param {{nowMs?:number}} [options] - clock 注入オプション。
+ * @returns {number} epoch ms。
+ */
+function _nowMs(options = {}) {
+  const injected = Number(options.nowMs);
+  if (Number.isFinite(injected) && injected > 0) return injected;
+  return wallNowMs();
+}
+
+/**
+ * リレー子端末かどうかを判定する。
+ *
+ * 【詳細説明】
+ * - 初期 O5 では SATELLITE/readonly 子は candidate を閲覧できるが、確定台帳の権威を持たない。
+ * - 既存 relay 実装では子端末を `window._3dpmonRelayChild === true` で表しているため、その
+ *   境界に合わせる。
+ *
+ * @private
+ * @function _isRelayChild
+ * @returns {boolean} リレー子端末なら true。
+ */
+function _isRelayChild() {
+  return typeof window !== "undefined" && window._3dpmonRelayChild === true;
+}
+
+/**
+ * candidate store を安全に取得する。
+ *
+ * @private
+ * @function _store
+ * @returns {Object.<string,Object>} inferredCandidateStore。
+ */
+function _store() {
+  if (!monitorData.inferredCandidateStore || typeof monitorData.inferredCandidateStore !== "object") {
+    monitorData.inferredCandidateStore = {};
+  }
+  return monitorData.inferredCandidateStore;
+}
+
+/**
+ * candidateHash から candidate record を取得する。
+ *
+ * @private
+ * @function _candidate
+ * @param {string} candidateHash - 対象 candidateHash。
+ * @returns {?Object} candidate record。存在しない場合は null。
+ */
+function _candidate(candidateHash) {
+  return candidateHash ? (_store()[candidateHash] || null) : null;
+}
+
+/**
+ * オブジェクト参照を保ったまま snapshot へ復元する。
+ *
+ * 【詳細説明】
+ * - candidate record は store 内の同じ参照を UI やテストが持つ可能性があるため、差し替えではなく
+ *   in-place で保存前状態へ戻す。
+ *
+ * @private
+ * @function _restoreObjectInPlace
+ * @param {Object} target - 復元対象。
+ * @param {Object} snapshot - 保存前 snapshot。
+ * @returns {void}
+ */
+function _restoreObjectInPlace(target, snapshot) {
+  for (const key of Object.keys(target)) delete target[key];
+  Object.assign(target, _clone(snapshot));
+}
+
+/**
+ * candidate が O5 decision 可能な pending record か検証する。
+ *
+ * 【詳細説明】
+ * - O5 は pending だけを確定入口として扱う。
+ * - confirmed/rejected/reassigned/superseded などの終端状態は、同一 hash/identity であっても
+ *   baseline や確定台帳へ再利用しない。
+ *
+ * @private
+ * @function _validatePendingCandidate
+ * @param {string} candidateHash - 対象 candidateHash。
+ * @returns {{ok:boolean, reason:string, record:?Object}} 検証結果。
+ */
+function _validatePendingCandidate(candidateHash) {
+  if (!candidateHash) return { ok: false, reason: "candidate_hash_required", record: null };
+  const record = _candidate(candidateHash);
+  if (!record) return { ok: false, reason: "candidate_not_found", record: null };
+  if (record.status !== INFERRED_CANDIDATE_STATUS.PENDING) {
+    return { ok: false, reason: "candidate_not_pending", record };
+  }
+  return { ok: true, reason: "candidate_pending", record };
+}
+
+/**
+ * rollback 後も耐久保存できない場合の復旧要求を monitorData へ記録する。
+ *
+ * 【詳細説明】
+ * - 保存失敗後のメモリ rollback は実施済みでも、その rollback 状態が耐久化できない場合は、
+ *   次回起動時に candidate と ledger の整合確認が必要になる。
+ * - O5B/O5C で UI 表示や起動時 reconciliation を追加できるよう、独立した recovery flag を残す。
+ *
+ * @private
+ * @function _markRecoveryRequired
+ * @param {Object} data - 復旧要求 metadata。
+ * @param {{nowMs?:number}} [options] - clock 注入オプション。
+ * @returns {Object} 保存した復旧要求。
+ */
+function _markRecoveryRequired(data, options = {}) {
+  monitorData[RECOVERY_FIELD] = {
+    ...data,
+    createdAt: _nowMs(options)
+  };
+  return monitorData[RECOVERY_FIELD];
+}
+
+/**
+ * decision 実行前の共通ガードを適用する。
+ *
+ * 【詳細説明】
+ * - SATELLITE/readonly 子は初期 O5 では閲覧専用であり、Confirm/Reject/Reassign を実行しない。
+ * - 未解決の recovery flag がある場合は、新しい確定操作を止め、先に整合復旧を要求する。
+ *
+ * @private
+ * @function _decisionGuard
+ * @param {string} candidateHash - 対象 candidateHash。
+ * @returns {?{ok:boolean,reason:string}} ガードに引っかかった場合の戻り値。問題なければ null。
+ */
+function _decisionGuard(candidateHash) {
+  if (!canExecuteLedgerDecision()) return { ok: false, reason: "decision_not_authorized", candidateHash };
+  if (monitorData[RECOVERY_FIELD]) return { ok: false, reason: "decision_recovery_required", candidateHash, recovery: monitorData[RECOVERY_FIELD] };
+  return null;
+}
+
+/**
+ * candidate 状態だけを保存前 snapshot へ戻す。
+ *
+ * @private
+ * @function _rollbackCandidateRecord
+ * @param {string} candidateHash - 対象 candidateHash。
+ * @param {Object} candidateSnapshot - 保存前 candidate snapshot。
+ * @returns {{ok:boolean,reason:string}} rollback 結果。
+ */
+function _rollbackCandidateRecord(candidateHash, candidateSnapshot) {
+  const record = _candidate(candidateHash);
+  if (!record) return { ok: false, reason: "candidate_missing_during_rollback" };
+  _restoreObjectInPlace(record, candidateSnapshot);
+  return { ok: true, reason: "candidate_rolled_back" };
+}
+
+/**
+ * 変更後に耐久保存し、失敗した場合は candidate と ledger を rollback する。
+ *
+ * 【詳細説明】
+ * - Confirm/Reassign は ledger と candidate の両方を変更するため、保存失敗時は両方を復元する。
+ * - Reject は ledgerSnapshot が null で、candidate 状態だけを復元する。
+ * - rollback 後の状態も再度耐久保存し、これに失敗した場合は recovery flag を残す。
+ *
+ * @private
+ * @function _saveDecisionOrRollback
+ * @param {Object} params - 保存と rollback に必要な値。
+ * @param {string} params.candidateHash - 対象 candidateHash。
+ * @param {string} params.action - decision 名。
+ * @param {?Object} params.ledgerSnapshot - ledger rollback snapshot。
+ * @param {Object} params.candidateSnapshot - candidate rollback snapshot。
+ * @param {Object} params.transition - candidate 状態遷移結果。
+ * @param {{save?:boolean,nowMs?:number}} [options] - 保存・clock オプション。
+ * @returns {Promise<{ok:boolean,reason:string,save?:Object,rollback?:Object,candidateRollback?:Object,rollbackSave?:Object,recovery?:Object}>}
+ *   保存または rollback の結果。
+ */
+async function _saveDecisionOrRollback(params, options = {}) {
+  const save = options.save === false
+    ? { ok: true, backend: "disabled", reason: "save_disabled" }
+    : await saveUnifiedStorageDurably();
+  if (!save || save.ok !== false) {
+    return { ok: true, reason: "decision_saved", save };
+  }
+
+  const rollback = params.ledgerSnapshot ? rollbackInferredCandidateLedger(params.ledgerSnapshot) : null;
+  const candidateRollback = _rollbackCandidateRecord(params.candidateHash, params.candidateSnapshot);
+  const rollbackSave = options.save === false
+    ? { ok: true, backend: "disabled", reason: "save_disabled" }
+    : await saveUnifiedStorageDurably();
+  if (rollbackSave && rollbackSave.ok === false) {
+    const recovery = _markRecoveryRequired({
+      candidateHash: params.candidateHash,
+      action: params.action,
+      reason: "rollback_durable_save_failed",
+      save,
+      rollback,
+      candidateRollback,
+      rollbackSave,
+      transition: params.transition
+    }, options);
+    return {
+      ok: false,
+      reason: "rollback_durable_save_failed",
+      save,
+      rollback,
+      candidateRollback,
+      rollbackSave,
+      recovery
+    };
+  }
+  return {
+    ok: false,
+    reason: save.reason || "decision_not_durably_saved",
+    save,
+    rollback,
+    candidateRollback,
+    rollbackSave
+  };
+}
+
+/**
+ * この端末で O5 の確定台帳 decision を実行できるか判定する。
+ *
+ * 【詳細説明】
+ * - STAND ALONE と PARENT は `window._3dpmonRelayChild !== true` なので true を返す。
+ * - SATELLITE/readonly 子は確定台帳の権威を持たないため false を返す。
+ * - 将来の O5C で SATELLITE から PARENT へ decision request を送る場合は、この関数または
+ *   UI 側の command routing を拡張する。
+ *
+ * @function canExecuteLedgerDecision
+ * @returns {boolean} ローカルで Confirm/Reject/Reassign を実行できる場合 true。
+ * @example
+ * if (canExecuteLedgerDecision()) enableConfirmButton();
+ */
+export function canExecuteLedgerDecision() {
+  return !_isRelayChild();
+}
+
+/**
+ * candidate spool のまま推定使用量を確定する。
+ *
+ * 【詳細説明】
+ * - pending candidate の observation key に対応する未帰属履歴を再検証し、spool.remainingLengthMm、
+ *   履歴 filamentInfo、spool.usedLengthLog を更新する。
+ * - candidate は `confirmed` へ遷移し、保存失敗時は ledger と candidate を保存前状態へ戻す。
+ *
+ * @function confirmInferredCandidate
+ * @param {string} candidateHash - 確定する candidateHash。
+ * @param {{actor?:string,nowMs?:number,save?:boolean}} [options] - 操作者・clock・保存オプション。
+ * @returns {Promise<Object>} decision 結果。
+ * @example
+ * const result = await confirmInferredCandidate("ic-abcd", { actor: "operator" });
+ */
+export async function confirmInferredCandidate(candidateHash, options = {}) {
+  const guard = _decisionGuard(candidateHash);
+  if (guard) return guard;
+  const pending = _validatePendingCandidate(candidateHash);
+  if (!pending.ok) return { ok: false, reason: pending.reason, candidateHash, record: pending.record };
+  const record = pending.record;
+  const candidateSnapshot = _clone(record);
+  const applied = applyInferredCandidateLedger(record, record.candidateSpoolId, {
+    nowMs: options.nowMs,
+    actor: options.actor || "user",
+    decisionType: "confirm",
+    originalCandidateSpoolId: record.candidateSpoolId
+  });
+  if (!applied.ok) return { ok: false, reason: applied.reason, candidateHash, record, applied };
+  const transition = transitionInferredCandidate(candidateHash, INFERRED_CANDIDATE_STATUS.CONFIRMED, {
+    nowMs: options.nowMs,
+    actor: options.actor || "user",
+    reason: "operator-confirmed"
+  });
+  if (!transition.ok) {
+    const rollback = rollbackInferredCandidateLedger(applied.snapshot);
+    return { ok: false, reason: transition.reason, candidateHash, record, applied, transition, rollback };
+  }
+  const saved = await _saveDecisionOrRollback({
+    candidateHash,
+    action: "confirm",
+    ledgerSnapshot: applied.snapshot,
+    candidateSnapshot,
+    transition
+  }, options);
+  if (!saved.ok) return { ok: false, reason: saved.reason, candidateHash, record: _candidate(candidateHash), applied, transition, ...saved };
+  return { ok: true, reason: "confirmed", candidateHash, record: transition.record, applied, transition, save: saved.save };
+}
+
+/**
+ * pending candidate を否認する。
+ *
+ * 【詳細説明】
+ * - Reject は確定台帳へ一切触れず、candidate status を `rejected` へ遷移するだけに留める。
+ * - 保存失敗時は candidate status を保存前状態へ戻し、rollback 状態の耐久保存を試みる。
+ *
+ * @function rejectInferredCandidate
+ * @param {string} candidateHash - 否認する candidateHash。
+ * @param {{actor?:string,reason?:string,note?:string,nowMs?:number,save?:boolean}} [options]
+ *   - 操作者・否認理由・clock・保存オプション。
+ * @returns {Promise<Object>} decision 結果。
+ * @example
+ * const result = await rejectInferredCandidate("ic-abcd", { reason: "not-same-spool" });
+ */
+export async function rejectInferredCandidate(candidateHash, options = {}) {
+  const guard = _decisionGuard(candidateHash);
+  if (guard) return guard;
+  const rejectReason = options.reason || "operator-decision";
+  if (!ALLOWED_REJECT_REASONS.has(rejectReason)) {
+    return { ok: false, reason: "invalid_reject_reason", candidateHash, rejectReason };
+  }
+  const pending = _validatePendingCandidate(candidateHash);
+  if (!pending.ok) return { ok: false, reason: pending.reason, candidateHash, record: pending.record };
+  const record = pending.record;
+  const candidateSnapshot = _clone(record);
+  const transition = transitionInferredCandidate(candidateHash, INFERRED_CANDIDATE_STATUS.REJECTED, {
+    nowMs: options.nowMs,
+    actor: options.actor || "user",
+    reason: rejectReason
+  });
+  if (!transition.ok) return { ok: false, reason: transition.reason, candidateHash, record, transition };
+  if (options.note) {
+    if (!Array.isArray(transition.record.events)) transition.record.events = [];
+    transition.record.events.push({
+      type: "decision-note",
+      at: _nowMs(options),
+      status: INFERRED_CANDIDATE_STATUS.REJECTED,
+      actor: options.actor || "user",
+      reason: rejectReason,
+      note: String(options.note)
+    });
+  }
+  const saved = await _saveDecisionOrRollback({
+    candidateHash,
+    action: "reject",
+    ledgerSnapshot: null,
+    candidateSnapshot,
+    transition
+  }, options);
+  if (!saved.ok) return { ok: false, reason: saved.reason, candidateHash, record: _candidate(candidateHash), transition, ...saved };
+  return { ok: true, reason: "rejected", candidateHash, record: transition.record, transition, save: saved.save };
+}
+
+/**
+ * pending candidate を別 spool へ再割当てして確定する。
+ *
+ * 【詳細説明】
+ * - Reassign は候補 spool ではなく operator が選んだ target spool へ使用量を反映する。
+ * - 確定先 spool の残量が不明、履歴が既に帰属済み、target spool が存在しない場合は fail-closed する。
+ * - 保存失敗時は ledger と candidate を保存前状態へ戻す。
+ *
+ * @function reassignInferredCandidate
+ * @param {string} candidateHash - 再割当てする candidateHash。
+ * @param {string} targetSpoolId - 再割当て先 spool ID。
+ * @param {{actor?:string,nowMs?:number,save?:boolean}} [options] - 操作者・clock・保存オプション。
+ * @returns {Promise<Object>} decision 結果。
+ * @example
+ * const result = await reassignInferredCandidate("ic-abcd", "spool-b");
+ */
+export async function reassignInferredCandidate(candidateHash, targetSpoolId, options = {}) {
+  const guard = _decisionGuard(candidateHash);
+  if (guard) return guard;
+  if (!targetSpoolId) return { ok: false, reason: "target_spool_required", candidateHash };
+  const pending = _validatePendingCandidate(candidateHash);
+  if (!pending.ok) return { ok: false, reason: pending.reason, candidateHash, record: pending.record };
+  const record = pending.record;
+  if (String(targetSpoolId) === String(record.candidateSpoolId)) {
+    return { ok: false, reason: "target_spool_same_as_candidate", candidateHash, record };
+  }
+  const candidateSnapshot = _clone(record);
+  const applied = applyInferredCandidateLedger(record, targetSpoolId, {
+    nowMs: options.nowMs,
+    actor: options.actor || "user",
+    decisionType: "reassign",
+    originalCandidateSpoolId: record.candidateSpoolId
+  });
+  if (!applied.ok) return { ok: false, reason: applied.reason, candidateHash, record, applied };
+  const transition = transitionInferredCandidate(candidateHash, INFERRED_CANDIDATE_STATUS.REASSIGNED, {
+    nowMs: options.nowMs,
+    actor: options.actor || "user",
+    reason: "operator-reassigned",
+    assignedSpoolId: String(targetSpoolId)
+  });
+  if (!transition.ok) {
+    const rollback = rollbackInferredCandidateLedger(applied.snapshot);
+    return { ok: false, reason: transition.reason, candidateHash, record, applied, transition, rollback };
+  }
+  const saved = await _saveDecisionOrRollback({
+    candidateHash,
+    action: "reassign",
+    ledgerSnapshot: applied.snapshot,
+    candidateSnapshot,
+    transition
+  }, options);
+  if (!saved.ok) return { ok: false, reason: saved.reason, candidateHash, record: _candidate(candidateHash), applied, transition, ...saved };
+  return { ok: true, reason: "reassigned", candidateHash, record: transition.record, applied, transition, save: saved.save };
+}

--- a/3dp_lib/dashboard_inferred_candidate_ledger.js
+++ b/3dp_lib/dashboard_inferred_candidate_ledger.js
@@ -1,0 +1,432 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 推定 candidate 確定台帳反映モジュール
+ * @file dashboard_inferred_candidate_ledger.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * @author pumpCurry
+ * -----------------------------------------------------------
+ * @module dashboard_inferred_candidate_ledger
+ *
+ * 【機能内容サマリ】
+ * - O5 Human Decision Layer で承認された inferredCandidate を、確定台帳へ反映する。
+ * - 確定残量、印刷履歴 filamentInfo、spool.usedLengthLog を同じ決定単位で更新する。
+ * - 保存失敗時にメモリ状態を元へ戻せるよう、反映前 snapshot と rollback API を提供する。
+ *
+ * 【公開関数一覧】
+ * - {@link applyInferredCandidateLedger}：pending candidate を指定スプールへ確定反映する
+ * - {@link rollbackInferredCandidateLedger}：確定反映前 snapshot へメモリ状態を戻す
+ *
+ * @version 1.390.1261 (PR #414)
+ * @since   1.390.1261 (PR #414)
+ * @lastModified 2026-07-25 13:45:00
+ * -----------------------------------------------------------
+ * @todo
+ * - O5B UI で decision timeline へ表示する詳細 event 文言を調整する。
+ */
+
+"use strict";
+
+import { monitorData } from "./dashboard_data.js";
+import { jobObservationIdentity } from "./dashboard_history_identity.js";
+import { buildOfflineFilamentInfo, getSpoolById, shouldLinkOfflineJob } from "./dashboard_spool.js";
+import { randomEventId, wallNowMs } from "./dashboard_time.js";
+
+/**
+ * 確定反映できる candidate debit の状態。
+ *
+ * @constant {string}
+ */
+const INFERRED_DEBIT_STATUS = "inferred-debit";
+
+/**
+ * O5 が spool.usedLengthLog へ追記する確定使用量 event の種別。
+ *
+ * @constant {string}
+ */
+export const INFERRED_DECISION_LEDGER_EVENT_TYPE = "inferred-continuity-confirmed";
+
+/**
+ * JSON 互換オブジェクトを deep clone する。
+ *
+ * 【詳細説明】
+ * - rollback 用 snapshot は monitorData の参照変異から独立している必要がある。
+ * - structuredClone が使える実行環境ではそれを優先し、テスト環境や古い WebView では JSON clone へ
+ *   フォールバックする。
+ *
+ * @private
+ * @function _clone
+ * @param {*} value - clone 対象。
+ * @returns {*} clone 済みの値。
+ */
+function _clone(value) {
+  if (typeof structuredClone === "function") return structuredClone(value);
+  return JSON.parse(JSON.stringify(value));
+}
+
+/**
+ * epoch ms の現在時刻を返す。
+ *
+ * 【詳細説明】
+ * - テストでは `options.nowMs` を注入し、実行環境では `wallNowMs()` を使う。
+ *
+ * @private
+ * @function _nowMs
+ * @param {{nowMs?:number}} [options] - clock 注入オプション。
+ * @returns {number} epoch ms。
+ */
+function _nowMs(options = {}) {
+  const injected = Number(options.nowMs);
+  if (Number.isFinite(injected) && injected > 0) return injected;
+  return wallNowMs();
+}
+
+/**
+ * 正の有限 mm 値へ正規化する。
+ *
+ * 【詳細説明】
+ * - candidate store や履歴から来る値は文字列化されている可能性があるため Number 化する。
+ * - 0 以下、NaN、Infinity は確定消費として扱わない。
+ *
+ * @private
+ * @function _positiveMm
+ * @param {*} value - mm 値候補。
+ * @returns {number} 正の有限値。不正値は 0。
+ */
+function _positiveMm(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/**
+ * 残量として使用可能な mm 値へ正規化する。
+ *
+ * 【詳細説明】
+ * - O5 の Confirm/Reassign は確定台帳を書き換えるため、残量不明の spool には適用しない。
+ * - null/undefined/空文字/NaN/負値は不明扱いで null を返す。
+ *
+ * @private
+ * @function _remainingOrNull
+ * @param {*} value - spool.remainingLengthMm 相当の値。
+ * @returns {?number} 0 以上の有限値。不明値は null。
+ */
+function _remainingOrNull(value) {
+  if (value == null || value === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+/**
+ * host の履歴配列を取得する。
+ *
+ * 【詳細説明】
+ * - O5 は `monitorData.machines[host].printStore.history` を確定対象として扱う。
+ * - 対象 host が無い場合や履歴配列が無い場合は null を返し、呼び出し元で fail-closed する。
+ *
+ * @private
+ * @function _historyForHost
+ * @param {string} host - 対象ホスト名。
+ * @returns {?Array<Object>} 履歴配列。存在しない場合は null。
+ */
+function _historyForHost(host) {
+  const history = monitorData.machines?.[host]?.printStore?.history;
+  return Array.isArray(history) ? history : null;
+}
+
+/**
+ * observation key から履歴 index を一意に引ける Map を作る。
+ *
+ * 【詳細説明】
+ * - O3 と同じ `jobObservationIdentity()` を使い、candidate の observationKey と履歴行を照合する。
+ * - fixture や旧保存データ向けに、履歴行が `observationKey` を直接持つ場合も補助キーとして採用する。
+ * - 同じ key が複数行へ一致した場合は ambiguous とし、履歴順に依存した first-wins を避ける。
+ *
+ * @private
+ * @function _historyIndexByObservationKey
+ * @param {Array<Object>} history - printStore.history 相当の履歴配列。
+ * @returns {Map<string,{status:string,indexes:Array<number>}>} observation key から履歴 index への Map。
+ */
+function _historyIndexByObservationKey(history) {
+  const map = new Map();
+  for (let index = 0; index < history.length; index++) {
+    const entry = history[index];
+    const keys = new Set();
+    const identity = jobObservationIdentity(entry);
+    if (identity?.key) keys.add(String(identity.key));
+    if (entry?.observationKey != null) keys.add(String(entry.observationKey));
+    if (entry?._observationKey != null) keys.add(String(entry._observationKey));
+    for (const key of keys) {
+      const current = map.get(key);
+      if (!current) {
+        map.set(key, { status: "unique", indexes: [index] });
+        continue;
+      }
+      current.status = "ambiguous";
+      current.indexes.push(index);
+    }
+  }
+  return map;
+}
+
+/**
+ * candidate record から確定対象 debit を抽出する。
+ *
+ * 【詳細説明】
+ * - O3 projection で `inferred-debit` と判定済みの行だけを確定対象にする。
+ * - 履歴へ書く usedMm は candidateDebits の値を使い、合計は candidate.usedMm と一致することを検証する。
+ *
+ * @private
+ * @function _candidateDebits
+ * @param {Object} candidateRecord - inferredCandidateStore の record。
+ * @returns {Array<Object>} 確定対象 debit 配列。
+ */
+function _candidateDebits(candidateRecord) {
+  return Array.isArray(candidateRecord?.candidateDebits)
+    ? candidateRecord.candidateDebits.filter(item => item?.status === INFERRED_DEBIT_STATUS)
+    : [];
+}
+
+/**
+ * candidate の合計使用量と debit 合計が安全に一致するか検証する。
+ *
+ * 【詳細説明】
+ * - candidate.usedMm と個別 debit の合計が大きくずれている場合は、保存済み candidate が壊れているか、
+ *   将来の形式変更で O5 が理解できないため fail-closed する。
+ *
+ * @private
+ * @function _validateDebitTotal
+ * @param {Object} candidateRecord - inferredCandidateStore の record。
+ * @param {Array<Object>} debits - 確定対象 debit 配列。
+ * @returns {{ok:boolean, usedMm:number, debitTotalMm:number, reason:?string}} 検証結果。
+ */
+function _validateDebitTotal(candidateRecord, debits) {
+  const usedMm = _positiveMm(candidateRecord?.usedMm);
+  const debitTotalMm = debits.reduce((sum, item) => sum + _positiveMm(item?.usedMm), 0);
+  if (usedMm <= 0) return { ok: false, usedMm, debitTotalMm, reason: "candidate_used_mm_missing" };
+  if (debits.length === 0 || debitTotalMm <= 0) {
+    return { ok: false, usedMm, debitTotalMm, reason: "candidate_debits_missing" };
+  }
+  if (Math.abs(usedMm - debitTotalMm) > 0.001) {
+    return { ok: false, usedMm, debitTotalMm, reason: "candidate_debit_total_mismatch" };
+  }
+  return { ok: true, usedMm, debitTotalMm, reason: null };
+}
+
+/**
+ * spool.usedLengthLog に同じ candidate の確定 event が既にあるか判定する。
+ *
+ * 【詳細説明】
+ * - O5 の decision は candidate status 側でも二重適用を防ぐが、台帳側でも同じ candidateHash の
+ *   確定 event が存在する場合は fail-closed し、残量の二重減算を防ぐ。
+ *
+ * @private
+ * @function _hasExistingDecisionEvent
+ * @param {Object} spool - 対象 spool。
+ * @param {string} candidateHash - candidateHash。
+ * @returns {boolean} 既存 event がある場合 true。
+ */
+function _hasExistingDecisionEvent(spool, candidateHash) {
+  const log = Array.isArray(spool?.usedLengthLog) ? spool.usedLengthLog : [];
+  return log.some(item =>
+    item
+    && item.type === INFERRED_DECISION_LEDGER_EVENT_TYPE
+    && item.candidateHash === candidateHash
+  );
+}
+
+/**
+ * history entry へ O5 確定 filamentInfo を upsert する。
+ *
+ * 【詳細説明】
+ * - 色だけの `filamentInfo` が1件ある場合は、その同じ行へ spool 情報を補完し、UI が2行表示に
+ *   ならないようにする。
+ * - spoolId 付きの既存帰属がある場合は呼び出し前 validation で拒否されるため、ここでは
+ *   未帰属履歴だけを更新する。
+ *
+ * @private
+ * @function _linkHistoryEntryToSpool
+ * @param {Object} entry - 更新対象履歴行。
+ * @param {Object} spool - 確定対象 spool。
+ * @param {number} usedMm - この履歴行に帰属させる使用量 mm。
+ * @param {Object} metadata - O5 decision の監査 metadata。
+ * @returns {void}
+ */
+function _linkHistoryEntryToSpool(entry, spool, usedMm, metadata) {
+  const info = {
+    ...buildOfflineFilamentInfo(spool, usedMm),
+    isOfflineInferred: false,
+    isInferredContinuityConfirmed: true,
+    candidateHash: metadata.candidateHash,
+    decisionType: metadata.decisionType,
+    originalCandidateSpoolId: metadata.originalCandidateSpoolId ?? null,
+    confirmedAt: metadata.createdAt,
+    confirmedBy: metadata.actor
+  };
+  const prev = Array.isArray(entry.filamentInfo) ? entry.filamentInfo : [];
+  if (prev.length === 1 && prev[0] && !prev[0].spoolId) {
+    Object.assign(prev[0], info);
+    entry.filamentInfo = prev;
+  } else {
+    entry.filamentInfo = [...prev, info];
+  }
+  entry.filamentId = spool.id;
+}
+
+/**
+ * snapshot 内の spool オブジェクトへ保存前状態を復元する。
+ *
+ * 【詳細説明】
+ * - monitorData 内の spool 配列要素参照を保つため、配列要素を差し替えずにプロパティを復元する。
+ * - 既存プロパティを一度削除してから snapshot を代入し、保存失敗中に追加された O5 専用フィールドも
+ *   残らないようにする。
+ *
+ * @private
+ * @function _restoreObjectInPlace
+ * @param {Object} target - 復元対象オブジェクト。
+ * @param {Object} snapshot - 保存前 snapshot。
+ * @returns {void}
+ */
+function _restoreObjectInPlace(target, snapshot) {
+  for (const key of Object.keys(target)) delete target[key];
+  Object.assign(target, _clone(snapshot));
+}
+
+/**
+ * pending candidate を指定スプールへ確定反映する。
+ *
+ * 【詳細説明】
+ * - O5 Decision Core が Confirm/Reassign のために呼ぶ低レベル API。
+ * - この関数はメモリ上の台帳だけを更新し、保存は行わない。保存失敗時は戻り値の snapshot を
+ *   {@link rollbackInferredCandidateLedger} へ渡して復元する。
+ * - 確定対象は `candidateDebits[].status === "inferred-debit"` の履歴だけであり、既に spoolId や
+ *   filamentId を持つ履歴は二重帰属防止のため拒否する。
+ *
+ * @function applyInferredCandidateLedger
+ * @param {Object} candidateRecord - inferredCandidateStore の pending candidate record。
+ * @param {string} targetSpoolId - 確定先 spool ID。Confirm では candidateSpoolId、Reassign では再割当先。
+ * @param {{nowMs?:number, actor?:string, decisionType?:string, originalCandidateSpoolId?:?string, eventId?:string}} [options]
+ *   - decision metadata。
+ * @returns {{ok:boolean, reason:string, snapshot:?Object, spool:?Object, historyEntries?:Array<Object>, event?:Object}}
+ *   反映結果。保存失敗 rollback に必要な snapshot を含む。
+ * @example
+ * const applied = applyInferredCandidateLedger(record, record.candidateSpoolId);
+ */
+export function applyInferredCandidateLedger(candidateRecord, targetSpoolId, options = {}) {
+  if (!candidateRecord?.candidateHash) return { ok: false, reason: "candidate_required", snapshot: null, spool: null };
+  const host = candidateRecord.host;
+  if (!host) return { ok: false, reason: "candidate_host_missing", snapshot: null, spool: null };
+  const spool = getSpoolById(targetSpoolId);
+  if (!spool) return { ok: false, reason: "target_spool_not_found", snapshot: null, spool: null };
+  const remaining = _remainingOrNull(spool.remainingLengthMm);
+  if (remaining == null) return { ok: false, reason: "confirmed_remaining_unknown", snapshot: null, spool };
+  if (_hasExistingDecisionEvent(spool, candidateRecord.candidateHash)) {
+    return { ok: false, reason: "candidate_ledger_event_exists", snapshot: null, spool };
+  }
+
+  const history = _historyForHost(host);
+  if (!history) return { ok: false, reason: "history_not_found", snapshot: null, spool };
+  const debits = _candidateDebits(candidateRecord);
+  const total = _validateDebitTotal(candidateRecord, debits);
+  if (!total.ok) return { ok: false, reason: total.reason, snapshot: null, spool };
+
+  const byKey = _historyIndexByObservationKey(history);
+  const updates = [];
+  const seenIndexes = new Set();
+  for (const debit of debits) {
+    const key = String(debit.observationKey ?? "");
+    const lookup = byKey.get(key);
+    if (!lookup) return { ok: false, reason: "history_entry_missing", snapshot: null, spool, observationKey: key };
+    if (lookup.status !== "unique" || lookup.indexes.length !== 1) {
+      return { ok: false, reason: "history_observation_ambiguous", snapshot: null, spool, observationKey: key };
+    }
+    const index = lookup.indexes[0];
+    if (seenIndexes.has(index)) {
+      return { ok: false, reason: "candidate_debits_duplicate_history_entry", snapshot: null, spool, observationKey: key };
+    }
+    seenIndexes.add(index);
+    const entry = history[index];
+    if (!shouldLinkOfflineJob(entry)) {
+      return { ok: false, reason: "history_already_attributed", snapshot: null, spool, observationKey: key };
+    }
+    const usedMm = _positiveMm(debit.usedMm);
+    if (usedMm <= 0) return { ok: false, reason: "candidate_debit_used_mm_missing", snapshot: null, spool, observationKey: key };
+    updates.push({ index, entry, debit, usedMm });
+  }
+
+  const snapshot = {
+    candidateHash: candidateRecord.candidateHash,
+    spoolId: spool.id,
+    spool: _clone(spool),
+    host,
+    historyEntries: updates.map(item => ({ index: item.index, entry: _clone(item.entry) }))
+  };
+  const now = _nowMs(options);
+  const actor = options.actor || "user";
+  const decisionType = options.decisionType || "confirm";
+  const metadata = {
+    candidateHash: candidateRecord.candidateHash,
+    decisionType,
+    originalCandidateSpoolId: options.originalCandidateSpoolId ?? candidateRecord.candidateSpoolId ?? null,
+    createdAt: now,
+    actor
+  };
+
+  for (const item of updates) {
+    _linkHistoryEntryToSpool(item.entry, spool, item.usedMm, metadata);
+  }
+
+  spool.remainingLengthMm = Math.max(0, remaining - total.usedMm);
+  if (!Array.isArray(spool.usedLengthLog)) spool.usedLengthLog = [];
+  const event = {
+    eventId: options.eventId || randomEventId("icd"),
+    type: INFERRED_DECISION_LEDGER_EVENT_TYPE,
+    candidateHash: candidateRecord.candidateHash,
+    host,
+    spoolId: spool.id,
+    originalCandidateSpoolId: metadata.originalCandidateSpoolId,
+    decisionType,
+    actor,
+    usedMm: total.usedMm,
+    observationKeys: Array.isArray(candidateRecord.observationKeys) ? candidateRecord.observationKeys.map(String).sort() : [],
+    createdAt: now
+  };
+  spool.usedLengthLog.push(event);
+
+  return {
+    ok: true,
+    reason: "ledger_applied",
+    snapshot,
+    spool,
+    historyEntries: updates.map(item => item.entry),
+    event
+  };
+}
+
+/**
+ * 確定反映前 snapshot へメモリ台帳を戻す。
+ *
+ * 【詳細説明】
+ * - Confirm/Reassign 後の耐久保存に失敗した場合、Decision Core がこの関数で spool と履歴を
+ *   保存前状態へ戻す。
+ * - rollback 自体はメモリ操作であり、呼び出し元が再度 `saveUnifiedStorageDurably()` を実行して
+ *   rollback 状態を耐久化する。
+ *
+ * @function rollbackInferredCandidateLedger
+ * @param {?Object} snapshot - {@link applyInferredCandidateLedger} が返した snapshot。
+ * @returns {{ok:boolean, reason:string}} rollback 結果。
+ * @example
+ * const rollback = rollbackInferredCandidateLedger(applied.snapshot);
+ */
+export function rollbackInferredCandidateLedger(snapshot) {
+  if (!snapshot?.spoolId || !snapshot?.host) return { ok: false, reason: "snapshot_required" };
+  const spool = getSpoolById(snapshot.spoolId);
+  const history = _historyForHost(snapshot.host);
+  if (!spool || !history) return { ok: false, reason: "rollback_target_missing" };
+  _restoreObjectInPlace(spool, snapshot.spool);
+  for (const item of snapshot.historyEntries || []) {
+    if (!Number.isInteger(item.index) || item.index < 0 || item.index >= history.length) {
+      return { ok: false, reason: "rollback_history_index_missing" };
+    }
+    _restoreObjectInPlace(history[item.index], item.entry);
+  }
+  return { ok: true, reason: "rolled_back" };
+}

--- a/tests/unit/dashboard_inferred_candidate_decision.test.js
+++ b/tests/unit/dashboard_inferred_candidate_decision.test.js
@@ -1,0 +1,312 @@
+/**
+ * @fileoverview dashboard_inferred_candidate_decision.js（#414-O5A Decision Core）の単体テスト
+ * Confirm / Reject / Reassign が pending candidate だけを入口にし、保存失敗時に rollback することを検証する。
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  monitorData: {
+    machines: {},
+    filamentSpools: [],
+    inferredCandidateStore: {}
+  },
+  saveUnifiedStorageDurably: vi.fn(async () => ({ ok: true, backend: "test", reason: "saved" })),
+  eventSeq: 0
+}));
+
+vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mocks.monitorData }));
+vi.mock("../../3dp_lib/dashboard_storage.js", () => ({ saveUnifiedStorageDurably: mocks.saveUnifiedStorageDurably }));
+vi.mock("../../3dp_lib/dashboard_time.js", () => ({
+  wallNowMs: () => 10000,
+  randomEventId: (prefix = "evt") => `${prefix}-${++mocks.eventSeq}`
+}));
+vi.mock("../../3dp_lib/dashboard_filament_inventory.js", () => ({ consumeInventory: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_ui.js", () => ({ updateStoredDataToDOM: vi.fn() }));
+vi.mock("../../3dp_lib/dashboard_printmanager.js", () => ({
+  updateHistoryList: vi.fn(),
+  loadHistory: vi.fn(() => []),
+  saveHistory: vi.fn()
+}));
+vi.mock("../../3dp_lib/dashboard_connection.js", () => ({ getDisplayBaseUrl: vi.fn(() => "") }));
+vi.mock("../../3dp_lib/dashboard_client_sync.js", () => ({
+  sendRelayFilament: vi.fn(),
+  getRelayMode: vi.fn(() => "standalone")
+}));
+vi.mock("../../3dp_lib/dashboard_filament_ledger.js", () => ({
+  appendMountEvent: vi.fn(),
+  appendUnmountEvent: vi.fn(),
+  appendReanchorEvent: vi.fn(),
+  reconcileSpool: vi.fn(),
+  getOpenFilamentEvent: vi.fn(() => null),
+  resolveFilamentEvent: vi.fn(),
+  deriveSpoolRemaining: vi.fn(),
+  getOpenMountInterval: vi.fn(() => null),
+  getMountIntervalStatus: vi.fn(() => "none")
+}));
+vi.mock("../../3dp_lib/dashboard_utils.js", () => ({
+  normalizeJobId: (id) => (id == null || id === "" || String(id) === "0" ? null : String(id))
+}));
+
+const {
+  INFERRED_CANDIDATE_STATUS
+} = await import("../../3dp_lib/dashboard_offline_candidate_store.js");
+const {
+  canExecuteLedgerDecision,
+  confirmInferredCandidate,
+  rejectInferredCandidate,
+  reassignInferredCandidate
+} = await import("../../3dp_lib/dashboard_inferred_candidate_decision.js");
+
+/**
+ * observation key を持つ履歴 fixture を作る。
+ *
+ * @function job
+ * @param {string} key - observation key。
+ * @param {number} usedMm - 使用量 mm。
+ * @param {Object} [over] - 上書き値。
+ * @returns {Object} 履歴行 fixture。
+ */
+function job(key, usedMm, over = {}) {
+  return {
+    id: key,
+    observationKey: key,
+    printfinish: 1,
+    materialUsedMm: usedMm,
+    filename: `${key}.gcode`,
+    ...over
+  };
+}
+
+/**
+ * spool fixture を作る。
+ *
+ * @function spool
+ * @param {string} id - spool ID。
+ * @param {number|null} remainingLengthMm - 残量 mm。
+ * @returns {Object} spool fixture。
+ */
+function spool(id, remainingLengthMm) {
+  return {
+    id,
+    serialNo: `${id}-serial`,
+    name: `${id} spool`,
+    colorName: "black",
+    filamentColor: "#000000",
+    material: "PLA",
+    printCount: 2,
+    remainingLengthMm,
+    usedLengthLog: []
+  };
+}
+
+/**
+ * candidate fixture を作る。
+ *
+ * @function candidate
+ * @param {Object} [over] - 上書き値。
+ * @returns {Object} inferredCandidateStore record fixture。
+ */
+function candidate(over = {}) {
+  return {
+    candidateHash: "ic-a",
+    host: "k1",
+    windowId: "win-a",
+    candidateSpoolId: "S1",
+    observationKeys: ["kA", "kB"],
+    candidateDebits: [
+      { observationKey: "kA", status: "inferred-debit", usedMm: 1000, reason: "unattributed-usage", confirmedSpoolIds: [] },
+      { observationKey: "kB", status: "inferred-debit", usedMm: 2000, reason: "unattributed-usage", confirmedSpoolIds: [] }
+    ],
+    usedMm: 3000,
+    confidence: { level: "high" },
+    evidence: { sameMountedSpool: true },
+    status: INFERRED_CANDIDATE_STATUS.PENDING,
+    events: [{ type: "created", at: 9000, status: INFERRED_CANDIDATE_STATUS.PENDING, usedMm: 3000 }],
+    ...over
+  };
+}
+
+beforeEach(() => {
+  mocks.saveUnifiedStorageDurably.mockReset();
+  mocks.saveUnifiedStorageDurably.mockResolvedValue({ ok: true, backend: "test", reason: "saved" });
+  mocks.eventSeq = 0;
+  delete globalThis.window;
+  mocks.monitorData.machines = {
+    k1: {
+      storedData: {},
+      runtimeData: {},
+      printStore: { history: [job("kA", 1000), job("kB", 2000)] }
+    }
+  };
+  mocks.monitorData.filamentSpools = [spool("S1", 10000), spool("S2", 8000)];
+  mocks.monitorData.inferredCandidateStore = { "ic-a": candidate() };
+  delete mocks.monitorData.inferredDecisionRecoveryRequired;
+});
+
+describe("canExecuteLedgerDecision", () => {
+  it("standalone / parent 相当では decision を許可する", () => {
+    expect(canExecuteLedgerDecision()).toBe(true);
+  });
+
+  it("satellite / readonly 子では decision を禁止する", async () => {
+    globalThis.window = { _3dpmonRelayChild: true };
+
+    const result = await confirmInferredCandidate("ic-a", { nowMs: 11000 });
+
+    expect(canExecuteLedgerDecision()).toBe(false);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("decision_not_authorized");
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(10000);
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+});
+
+describe("confirmInferredCandidate", () => {
+  it("pending candidate を確定し、残量・履歴・usedLengthLog・candidate status を更新して保存する", async () => {
+    const result = await confirmInferredCandidate("ic-a", { actor: "operator", nowMs: 11000 });
+
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe("confirmed");
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(7000);
+    expect(mocks.monitorData.filamentSpools[0].usedLengthLog[0]).toMatchObject({
+      type: "inferred-continuity-confirmed",
+      candidateHash: "ic-a",
+      spoolId: "S1",
+      usedMm: 3000,
+      decisionType: "confirm",
+      actor: "operator"
+    });
+    const history = mocks.monitorData.machines.k1.printStore.history;
+    expect(history[0].filamentId).toBe("S1");
+    expect(history[0].filamentInfo[0]).toMatchObject({
+      spoolId: "S1",
+      usedMm: 1000,
+      isInferredContinuityConfirmed: true,
+      candidateHash: "ic-a"
+    });
+    expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.CONFIRMED);
+    expect(mocks.saveUnifiedStorageDurably).toHaveBeenCalledTimes(1);
+  });
+
+  it("pending 以外の candidate は台帳にも保存にも進めない", async () => {
+    mocks.monitorData.inferredCandidateStore["ic-a"].status = INFERRED_CANDIDATE_STATUS.SUPERSEDED;
+
+    const result = await confirmInferredCandidate("ic-a", { nowMs: 11000 });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("candidate_not_pending");
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(10000);
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+
+  it("対象 spool の確定残量が不明なら fail-closed する", async () => {
+    mocks.monitorData.filamentSpools[0].remainingLengthMm = null;
+
+    const result = await confirmInferredCandidate("ic-a", { nowMs: 11000 });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("confirmed_remaining_unknown");
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+
+  it("履歴が既に帰属済みなら二重反映しない", async () => {
+    mocks.monitorData.machines.k1.printStore.history[0].filamentInfo = [{ spoolId: "S9", usedMm: 1000 }];
+
+    const result = await confirmInferredCandidate("ic-a", { nowMs: 11000 });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("history_already_attributed");
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(10000);
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+
+  it("保存失敗時は ledger と candidate を rollback し、rollback 状態を保存する", async () => {
+    mocks.saveUnifiedStorageDurably
+      .mockResolvedValueOnce({ ok: false, backend: "indexedDB", reason: "idb_fail" })
+      .mockResolvedValueOnce({ ok: true, backend: "indexedDB", reason: "rollback_saved" });
+
+    const result = await confirmInferredCandidate("ic-a", { actor: "operator", nowMs: 11000 });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("idb_fail");
+    expect(result.rollback).toEqual({ ok: true, reason: "rolled_back" });
+    expect(result.candidateRollback).toEqual({ ok: true, reason: "candidate_rolled_back" });
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(10000);
+    expect(mocks.monitorData.filamentSpools[0].usedLengthLog).toEqual([]);
+    expect(mocks.monitorData.machines.k1.printStore.history[0].filamentId).toBeUndefined();
+    expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.PENDING);
+    expect(mocks.saveUnifiedStorageDurably).toHaveBeenCalledTimes(2);
+  });
+
+  it("rollback 状態も保存できない場合は recovery flag を残す", async () => {
+    mocks.saveUnifiedStorageDurably
+      .mockResolvedValueOnce({ ok: false, backend: "indexedDB", reason: "idb_fail" })
+      .mockResolvedValueOnce({ ok: false, backend: "indexedDB", reason: "rollback_fail" });
+
+    const result = await confirmInferredCandidate("ic-a", { nowMs: 11000 });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("rollback_durable_save_failed");
+    expect(mocks.monitorData.inferredDecisionRecoveryRequired).toMatchObject({
+      candidateHash: "ic-a",
+      action: "confirm",
+      reason: "rollback_durable_save_failed"
+    });
+  });
+});
+
+describe("rejectInferredCandidate", () => {
+  it("candidate を rejected に遷移し、確定台帳は変更しない", async () => {
+    const result = await rejectInferredCandidate("ic-a", {
+      actor: "operator",
+      reason: "not-same-spool",
+      note: "Operator saw a spool swap.",
+      nowMs: 11000
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe("rejected");
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(10000);
+    expect(mocks.monitorData.filamentSpools[0].usedLengthLog).toEqual([]);
+    expect(mocks.monitorData.machines.k1.printStore.history[0].filamentId).toBeUndefined();
+    expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.REJECTED);
+    expect(mocks.monitorData.inferredCandidateStore["ic-a"].events.at(-1)).toMatchObject({
+      type: "decision-note",
+      note: "Operator saw a spool swap."
+    });
+    expect(mocks.saveUnifiedStorageDurably).toHaveBeenCalledTimes(1);
+  });
+
+  it("未知の reject reason は拒否する", async () => {
+    const result = await rejectInferredCandidate("ic-a", { reason: "bad-reason" });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("invalid_reject_reason");
+    expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.PENDING);
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+});
+
+describe("reassignInferredCandidate", () => {
+  it("別 spool へ再割当てし、その spool の残量・履歴・candidate status を更新する", async () => {
+    const result = await reassignInferredCandidate("ic-a", "S2", { actor: "operator", nowMs: 11000 });
+
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe("reassigned");
+    expect(mocks.monitorData.filamentSpools.find(s => s.id === "S1").remainingLengthMm).toBe(10000);
+    expect(mocks.monitorData.filamentSpools.find(s => s.id === "S2").remainingLengthMm).toBe(5000);
+    expect(mocks.monitorData.machines.k1.printStore.history[1].filamentId).toBe("S2");
+    expect(mocks.monitorData.inferredCandidateStore["ic-a"]).toMatchObject({
+      status: INFERRED_CANDIDATE_STATUS.REASSIGNED,
+      assignedSpoolId: "S2"
+    });
+  });
+
+  it("candidate spool と同じ target は reassign として扱わない", async () => {
+    const result = await reassignInferredCandidate("ic-a", "S1", { nowMs: 11000 });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("target_spool_same_as_candidate");
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add O5A decision core APIs for confirming, rejecting, and reassigning inferred continuity candidates.
- Keep Satellite/relay child mode read-only via canExecuteLedgerDecision(), while Standalone and Parent can execute ledger decisions.
- Apply confirmed decisions to spool remaining, print history filamentInfo, and spool usedLengthLog with durable-save rollback and recovery flag handling.
- Add focused unit coverage for success paths, non-pending fail-closed behavior, Satellite guard, already-attributed history, and durable-save rollback.

## Tests
- npx vitest run tests/unit/dashboard_inferred_candidate_decision.test.js tests/unit/dashboard_offline_candidate_store.test.js tests/unit/dashboard_offline_live_shadow.test.js
- npx eslint 3dp_lib/dashboard_inferred_candidate_decision.js 3dp_lib/dashboard_inferred_candidate_ledger.js
- npx vitest run