### PR TITLE
Add O5 inferred candidate center UI

### DIFF
--- a/3dp_lib/dashboard_filament_manager.js
+++ b/3dp_lib/dashboard_filament_manager.js
@@ -14,13 +14,14 @@
  * - スプール一覧（状態バッジ・フィルタ付き）
  * - 使用履歴（種別フィルタ付き）
  * - 集計レポート
+ * - 推定 candidate の確認・否認・再割当て
  *
  * 【公開関数一覧】
  * - {@link showFilamentManager}：管理モーダルを開く
  *
-* @version 1.390.1110 (PR #380)
+* @version 1.390.1262 (PR #415)
 * @since   1.390.228 (PR #102)
-* @lastModified 2026-06-12 12:00:00
+* @lastModified 2026-07-25 14:25:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -73,6 +74,7 @@ import {
 } from "./dashboard_filament_presets.js";
 import { saveUnifiedStorage } from "./dashboard_storage.js";
 import { createFilamentPreview } from "./dashboard_filament_view.js";
+import { createInferredCandidateCenterContent } from "./dashboard_inferred_candidate_ui.js";
 import { showAlert } from "./dashboard_notification_manager.js";
 import { showConfirmDialog } from "./dashboard_ui_confirm.js";
 import { createEmptyState } from "./dashboard_ui_components.js";
@@ -2708,13 +2710,14 @@ export function showFilamentManager(activeIdx = 0, hostname) {
     "ダッシュボード",
     "在庫・プリセット",
     "スプール一覧",
+    "推定候補",
     "使用履歴",
     "集計レポート"
   ];
 
   let switchTab = () => {};
 
-  // エディタ（非表示タブ、index 5）
+  // エディタ（非表示タブ、最後尾）
   const editTab = createEditorContent(() => {
     registered.render();
     switchTab(SPOOL_LIST_IDX);
@@ -2723,14 +2726,15 @@ export function showFilamentManager(activeIdx = 0, hostname) {
   // ダッシュボード（Tab 0）
   const dashboardTab = createDashboardContent(hostname, idx => switchTab(idx));
 
-  // 使用履歴（Tab 3）
+  // 使用履歴（Tab 4）
   const historyEl = createHistoryContent();
 
-  // contents 配列：0=ダッシュボード, 1=在庫プリセット, 2=スプール一覧, 3=使用履歴, 4=レポート, 5=エディタ(非表示)
+  // contents 配列：0=ダッシュボード, 1=在庫プリセット, 2=スプール一覧, 3=推定候補, 4=使用履歴, 5=レポート, 6=エディタ(非表示)
   const contents = [
     dashboardTab.el,
     null, // 在庫プリセット（後で設定）
     null, // スプール一覧（後で設定）
+    null, // 推定候補（後で設定）
     historyEl,
     createReportContent(),
     editTab.el
@@ -2745,9 +2749,17 @@ export function showFilamentManager(activeIdx = 0, hostname) {
 
   // 在庫・プリセット（Tab 1）
   const invPresetTab = createInventoryPresetContent(hostname, idx => switchTab(idx), () => registered.render());
+  const candidateCenter = createInferredCandidateCenterContent({
+    host: null,
+    onAfterDecision: () => {
+      try { registered.render(); } catch { /* noop */ }
+      try { dashboardTab.render(); } catch { /* noop */ }
+    }
+  });
 
   contents[1] = invPresetTab.el;
   contents[SPOOL_LIST_IDX] = registered.el;
+  contents[3] = candidateCenter.el;
 
   const contentWrap = document.createElement("div");
   contentWrap.className = "fm-content-wrap";
@@ -2769,6 +2781,7 @@ export function showFilamentManager(activeIdx = 0, hostname) {
     });
     // ダッシュボードタブに切り替えた場合は再描画
     if (idx === 0) dashboardTab.render();
+    if (idx === 3) candidateCenter.render();
   };
 
   // 可視タブボタンの生成（エディタタブは非表示）
@@ -2800,6 +2813,7 @@ export function showFilamentManager(activeIdx = 0, hostname) {
     }
     try { registered.render(); } catch { /* noop */ }
     try { dashboardTab.render(); } catch { /* noop */ }
+    try { candidateCenter.render(); } catch { /* noop */ }
   };
 }
 
@@ -2937,4 +2951,3 @@ async function _showCustomPresetDialog(onComplete, existing = null) {
   saveUnifiedStorage();
   if (onComplete) onComplete();
 }
-

--- a/3dp_lib/dashboard_inferred_candidate_ui.js
+++ b/3dp_lib/dashboard_inferred_candidate_ui.js
@@ -1,0 +1,630 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 推定 candidate 操作 UI モジュール
+ * @file dashboard_inferred_candidate_ui.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * @author pumpCurry
+ * -----------------------------------------------------------
+ * @module dashboard_inferred_candidate_ui
+ *
+ * 【機能内容サマリ】
+ * - O5B Candidate Center として pending/処理済み candidate の一覧、詳細、監査 timeline を描画する。
+ * - Confirm / Reject / Reassign の操作ダイアログを提供し、実更新は Decision Core へ委譲する。
+ * - SATELLITE/readonly 子では一覧・詳細だけを表示し、確定操作ボタンは disabled にする。
+ *
+ * 【公開関数一覧】
+ * - {@link createInferredCandidateCenterContent}：フィラメント管理モーダル用 Candidate Center を生成する
+ *
+ * @version 1.390.1262 (PR #415)
+ * @since   1.390.1262 (PR #415)
+ * @lastModified 2026-07-25 14:25:00
+ * -----------------------------------------------------------
+ * @todo
+ * - O5C で Satellite から Parent へ decision request を送る RPC UI を追加する。
+ */
+
+"use strict";
+
+import { monitorData } from "./dashboard_data.js";
+import {
+  confirmInferredCandidate,
+  rejectInferredCandidate,
+  reassignInferredCandidate
+} from "./dashboard_inferred_candidate_decision.js";
+import {
+  INFERRED_CANDIDATE_FILTER,
+  INFERRED_CANDIDATE_SORT,
+  buildInferredCandidateViewModel,
+  countPendingInferredCandidates,
+  listInferredCandidateViewModels
+} from "./dashboard_inferred_candidate_view.js";
+import { showAlert } from "./dashboard_notification_manager.js";
+import { showConfirmDialog } from "./dashboard_ui_confirm.js";
+import { createEmptyState } from "./dashboard_ui_components.js";
+
+/**
+ * Reject UI で選べる理由。
+ *
+ * @constant {Array<{value:string,label:string}>}
+ */
+const REJECT_OPTIONS = Object.freeze([
+  { value: "already-accounted", label: "Already handled" },
+  { value: "not-same-spool", label: "Wrong detection" },
+  { value: "operator-decision", label: "Operator decision" },
+  { value: "other", label: "Other" }
+]);
+
+/**
+ * reason code と日本語表示の対応表。
+ *
+ * @constant {Object.<string,string>}
+ */
+const REASON_LABELS = Object.freeze({
+  candidate_not_found: "候補が見つかりません",
+  candidate_not_pending: "候補はすでに処理済みです",
+  candidate_hash_required: "候補IDが不正です",
+  decision_not_authorized: "この端末では操作できません。親端末で実行してください",
+  decision_recovery_required: "整合性確認が必要です",
+  target_spool_required: "再割当て先スプールを選択してください",
+  target_spool_same_as_candidate: "候補スプールと同じため再割当てできません",
+  target_spool_not_found: "対象スプールが見つかりません",
+  confirmed_remaining_unknown: "確定残量が不明なため処理できません",
+  history_entry_missing: "対象履歴が不足しています",
+  history_observation_ambiguous: "対象履歴が曖昧です",
+  history_already_attributed: "履歴がすでに別スプールへ確定されています",
+  candidate_ledger_event_exists: "この候補はすでに台帳へ反映されています",
+  invalid_reject_reason: "否認理由が不正です",
+  rollback_durable_save_failed: "復旧状態の保存に失敗しました"
+});
+
+/**
+ * warning code と日本語表示の対応表。
+ *
+ * @constant {Object.<string,string>}
+ */
+const WARNING_LABELS = Object.freeze({
+  "history-ambiguous": "対象履歴が曖昧です",
+  "history-missing": "対象履歴の一部が見つかりません",
+  "history-already-attributed": "対象履歴が既に帰属済みです",
+  "spool-missing": "候補スプールが見つかりません",
+  "remaining-unknown": "確定残量が不明です",
+  "remaining-insufficient": "確定残量が推定消費量より少ない状態です",
+  "low-confidence": "信頼度が低い候補です",
+  "decision-recovery-required": "整合性確認が必要です",
+  "relay-readonly": "この端末は閲覧専用です"
+});
+
+/**
+ * ダイアログ内 form ID の単調カウンタ。
+ *
+ * @private
+ * @type {number}
+ */
+let _dialogSeq = 0;
+
+/**
+ * DOM 要素を作成する。
+ *
+ * @private
+ * @function _el
+ * @param {string} tagName - タグ名。
+ * @param {string} [className=""] - className。
+ * @param {string} [text=""] - textContent。
+ * @returns {HTMLElement} 作成した要素。
+ */
+function _el(tagName, className = "", text = "") {
+  const el = document.createElement(tagName);
+  if (className) el.className = className;
+  if (text) el.textContent = text;
+  return el;
+}
+
+/**
+ * reason code を UI 表示へ変換する。
+ *
+ * @private
+ * @function _reasonLabel
+ * @param {?string} reason - reason code。
+ * @returns {string} 表示文。
+ */
+function _reasonLabel(reason) {
+  return REASON_LABELS[reason] || reason || "処理に失敗しました";
+}
+
+/**
+ * HTML 属性/本文へ入れる文字列を escape する。
+ *
+ * @private
+ * @function _escapeHtml
+ * @param {*} value - escape 対象。
+ * @returns {string} HTML escape 済み文字列。
+ */
+function _escapeHtml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * 操作者情報を生成する。
+ *
+ * 【詳細説明】
+ * - 現時点では認証基盤がないため local-user を固定値として渡す。
+ * - Decision Core 側は文字列 actor を監査 event に保存し、将来のロール/ユーザーID化へ備える。
+ *
+ * @private
+ * @function _actor
+ * @returns {string} actor ID。
+ */
+function _actor() {
+  return "local-user";
+}
+
+/**
+ * ボタンを disabled にしながら非同期操作を実行する。
+ *
+ * @private
+ * @function _withBusy
+ * @param {HTMLElement} root - 操作中にボタンを無効化する範囲。
+ * @param {Function} task - 実行する async function。
+ * @returns {Promise<*>} task の戻り値。
+ */
+async function _withBusy(root, task) {
+  const buttons = [...root.querySelectorAll("button, select")];
+  buttons.forEach(button => { button.disabled = true; });
+  try {
+    return await task();
+  } finally {
+    buttons.forEach(button => { button.disabled = false; });
+  }
+}
+
+/**
+ * 状態 badge を生成する。
+ *
+ * @private
+ * @function _statusBadge
+ * @param {Object} vm - candidate ViewModel。
+ * @returns {HTMLElement} badge。
+ */
+function _statusBadge(vm) {
+  const badge = _el("span", `ic-status ic-status-${vm.status}`, vm.statusLabel);
+  return badge;
+}
+
+/**
+ * 色 swatch を生成する。
+ *
+ * @private
+ * @function _swatch
+ * @param {string} color - CSS color。
+ * @returns {HTMLElement} swatch。
+ */
+function _swatch(color) {
+  const swatch = _el("span", "ic-color-swatch");
+  if (color) swatch.style.background = color;
+  return swatch;
+}
+
+/**
+ * key/value 行を生成する。
+ *
+ * @private
+ * @function _kv
+ * @param {string} label - ラベル。
+ * @param {string} value - 値。
+ * @returns {HTMLElement} 行。
+ */
+function _kv(label, value) {
+  const row = _el("div", "ic-kv");
+  row.append(_el("span", "ic-kv-label", label), _el("span", "ic-kv-value", value));
+  return row;
+}
+
+/**
+ * warning chips を生成する。
+ *
+ * @private
+ * @function _warningChips
+ * @param {Array<string>} codes - warning code 配列。
+ * @returns {HTMLElement} chips wrapper。
+ */
+function _warningChips(codes) {
+  const wrap = _el("div", "ic-warning-row");
+  for (const code of codes) {
+    wrap.appendChild(_el("span", "ic-warning-chip", WARNING_LABELS[code] || code));
+  }
+  return wrap;
+}
+
+/**
+ * active spool の選択肢を返す。
+ *
+ * @private
+ * @function _selectableSpools
+ * @param {Object} vm - candidate ViewModel。
+ * @returns {Array<Object>} 選択可能 spool 配列。
+ */
+function _selectableSpools(vm) {
+  return (monitorData.filamentSpools || [])
+    .filter(spool => spool && !spool.deleted && !spool.isDeleted && String(spool.id) !== String(vm.candidateSpoolId));
+}
+
+/**
+ * Confirm 操作の確認ダイアログを表示する。
+ *
+ * @private
+ * @function _confirmAction
+ * @param {Object} vm - candidate ViewModel。
+ * @returns {Promise<boolean>} 実行する場合 true。
+ */
+async function _confirmAction(vm) {
+  const body = _el("div", "ic-confirm-summary");
+  body.append(
+    _kv("対象", vm.candidateSpoolName),
+    _kv("推定消費", vm.usedDisplay),
+    _kv("確定残量", vm.confirmedRemainingDisplay),
+    _kv("確定後", vm.projectedRemainingDisplay),
+    _kv("対象ジョブ", `${vm.jobCount}件`)
+  );
+  const ok = await showConfirmDialog({
+    level: "warn",
+    title: "フィラメント消費を確定",
+    html: body.outerHTML,
+    confirmText: "この内容で確定",
+    cancelText: "キャンセル"
+  });
+  return ok === true;
+}
+
+/**
+ * Reject 操作用ダイアログを表示して入力を取得する。
+ *
+ * @private
+ * @function _rejectAction
+ * @returns {Promise<?{reason:string,note:string}>} 入力結果。キャンセル時は null。
+ */
+async function _rejectAction() {
+  const formId = `ic-reject-${++_dialogSeq}`;
+  const options = REJECT_OPTIONS
+    .map(item => `<option value="${_escapeHtml(item.value)}">${_escapeHtml(item.label)}</option>`)
+    .join("");
+  const ok = await showConfirmDialog({
+    level: "warn",
+    title: "候補を否認",
+    html:
+      `<form id="${formId}" class="ic-dialog-form">` +
+      `<label>Reason<select name="reason">${options}</select></label>` +
+      `<label>Note<textarea name="note" rows="3"></textarea></label>` +
+      `</form>`,
+    confirmText: "否認する",
+    cancelText: "キャンセル"
+  });
+  if (ok !== true) return null;
+  const form = document.getElementById(formId);
+  return {
+    reason: form?.elements?.reason?.value || "operator-decision",
+    note: form?.elements?.note?.value || ""
+  };
+}
+
+/**
+ * Reassign 操作用ダイアログを表示して target spool を取得する。
+ *
+ * @private
+ * @function _reassignAction
+ * @param {Object} vm - candidate ViewModel。
+ * @returns {Promise<?string>} target spool ID。キャンセル時は null。
+ */
+async function _reassignAction(vm) {
+  const spools = _selectableSpools(vm);
+  if (spools.length === 0) {
+    showAlert("再割当て可能なスプールがありません", "warn");
+    return null;
+  }
+  const formId = `ic-reassign-${++_dialogSeq}`;
+  const options = spools.map(spool => {
+    const remaining = Number.isFinite(Number(spool.remainingLengthMm))
+      ? `${Math.round(Number(spool.remainingLengthMm)).toLocaleString()} mm`
+      : "残量不明";
+    const label = `${spool.name || spool.id} / ${spool.materialName || spool.material || ""} / ${remaining}`;
+    return `<option value="${_escapeHtml(spool.id)}">${_escapeHtml(label)}</option>`;
+  }).join("");
+  const ok = await showConfirmDialog({
+    level: "warn",
+    title: "別スプールへ再割当て",
+    html:
+      `<form id="${formId}" class="ic-dialog-form">` +
+      `<label>Spool<select name="targetSpoolId">${options}</select></label>` +
+      `</form>`,
+    confirmText: "再割当てして確定",
+    cancelText: "キャンセル"
+  });
+  if (ok !== true) return null;
+  const form = document.getElementById(formId);
+  return form?.elements?.targetSpoolId?.value || null;
+}
+
+/**
+ * decision 結果を通知し、必要なら再描画する。
+ *
+ * @private
+ * @function _handleDecisionResult
+ * @param {Object} result - Decision Core の戻り値。
+ * @param {Function} render - 再描画関数。
+ * @param {Function} [onAfterDecision] - 外部再描画 hook。
+ * @returns {void}
+ */
+function _handleDecisionResult(result, render, onAfterDecision) {
+  if (result?.ok) {
+    const label = result.reason === "confirmed" ? "確定しました"
+      : result.reason === "reassigned" ? "再割当てを確定しました"
+        : result.reason === "rejected" ? "否認しました"
+          : "処理しました";
+    showAlert(label, "success");
+    try { onAfterDecision?.(result); } catch { /* noop */ }
+    render();
+    return;
+  }
+  showAlert(_reasonLabel(result?.reason), "error");
+  render();
+}
+
+/**
+ * 詳細 modal の action buttons を生成する。
+ *
+ * @private
+ * @function _appendActionButtons
+ * @param {HTMLElement} wrap - ボタン追加先。
+ * @param {Object} vm - candidate ViewModel。
+ * @param {Function} render - 再描画関数。
+ * @param {Function} close - modal close 関数。
+ * @param {Function} [onAfterDecision] - 外部再描画 hook。
+ * @returns {void}
+ */
+function _appendActionButtons(wrap, vm, render, close, onAfterDecision) {
+  const readonlyNote = vm.readOnlyReason ? _el("div", "ic-readonly-note", "この端末はSatellite/閲覧専用です。親端末で操作してください。") : null;
+  if (readonlyNote) wrap.appendChild(readonlyNote);
+
+  const confirmBtn = _el("button", "ic-action-primary", "Confirm");
+  confirmBtn.disabled = !vm.canConfirm;
+  confirmBtn.addEventListener("click", async () => {
+    await _withBusy(wrap, async () => {
+      if (!await _confirmAction(vm)) return;
+      const result = await confirmInferredCandidate(vm.candidateHash, { actor: _actor() });
+      _handleDecisionResult(result, render, onAfterDecision);
+      if (result?.ok) close();
+    });
+  });
+
+  const rejectBtn = _el("button", "ic-action-secondary", "Reject");
+  rejectBtn.disabled = !vm.canReject;
+  rejectBtn.addEventListener("click", async () => {
+    await _withBusy(wrap, async () => {
+      const input = await _rejectAction();
+      if (!input) return;
+      const result = await rejectInferredCandidate(vm.candidateHash, { actor: _actor(), reason: input.reason, note: input.note });
+      _handleDecisionResult(result, render, onAfterDecision);
+      if (result?.ok) close();
+    });
+  });
+
+  const reassignBtn = _el("button", "ic-action-secondary", "Reassign");
+  reassignBtn.disabled = !vm.canReassign;
+  reassignBtn.addEventListener("click", async () => {
+    await _withBusy(wrap, async () => {
+      const targetSpoolId = await _reassignAction(vm);
+      if (!targetSpoolId) return;
+      const result = await reassignInferredCandidate(vm.candidateHash, targetSpoolId, { actor: _actor() });
+      _handleDecisionResult(result, render, onAfterDecision);
+      if (result?.ok) close();
+    });
+  });
+
+  wrap.append(confirmBtn, rejectBtn, reassignBtn);
+}
+
+/**
+ * candidate 詳細 modal を表示する。
+ *
+ * @private
+ * @function _showDetail
+ * @param {Object} vm - candidate ViewModel。
+ * @param {Function} render - 再描画関数。
+ * @param {Function} [onAfterDecision] - 外部再描画 hook。
+ * @returns {void}
+ */
+function _showDetail(vm, render, onAfterDecision) {
+  const overlay = _el("div", "ic-detail-overlay");
+  const modal = _el("div", "ic-detail-modal");
+  const header = _el("div", "ic-detail-header");
+  header.append(_el("span", "", "推定候補詳細"));
+  const closeBtn = _el("button", "ic-icon-button", "\u00D7");
+  closeBtn.addEventListener("click", () => overlay.remove());
+  header.appendChild(closeBtn);
+  modal.appendChild(header);
+
+  const body = _el("div", "ic-detail-body");
+  const summary = _el("section", "ic-detail-section");
+  summary.append(
+    _statusBadge(vm),
+    _kv("プリンタ", vm.hostLabel),
+    _kv("候補スプール", vm.candidateSpoolName),
+    _kv("推定消費", vm.usedDisplay),
+    _kv("確定残量", vm.confirmedRemainingDisplay),
+    _kv("確定後", vm.projectedRemainingDisplay),
+    _kv("信頼度", vm.confidenceLabel)
+  );
+  if (vm.warningCodes.length) summary.appendChild(_warningChips(vm.warningCodes));
+  body.appendChild(summary);
+
+  const jobs = _el("section", "ic-detail-section");
+  jobs.appendChild(_el("h4", "", "対象ジョブ"));
+  const jobTable = _el("table", "ic-detail-table");
+  const jobHead = document.createElement("thead");
+  jobHead.innerHTML = "<tr><th>ファイル</th><th>使用量</th><th>帰属</th></tr>";
+  const jobBody = document.createElement("tbody");
+  for (const job of vm.jobs) {
+    const tr = document.createElement("tr");
+    tr.append(_el("td", "", job.filename), _el("td", "", job.usedDisplay), _el("td", "", job.attributionState));
+    jobBody.appendChild(tr);
+  }
+  jobTable.append(jobHead, jobBody);
+  jobs.appendChild(jobTable);
+  body.appendChild(jobs);
+
+  const audit = _el("section", "ic-detail-section");
+  audit.appendChild(_el("h4", "", "根拠・監査"));
+  audit.append(
+    _kv("Candidate Hash", vm.candidateHash),
+    _kv("Window ID", vm.windowId || "--"),
+    _kv("Baseline Interval", vm.candidateBaselineIntervalId || "--"),
+    _kv("Current Interval", vm.candidateCurrentIntervalId || "--")
+  );
+  const timeline = _el("div", "ic-timeline");
+  for (const event of vm.events) {
+    const row = _el("div", "ic-timeline-row");
+    row.append(_el("span", "ic-timeline-type", event.type || "event"), _el("span", "ic-timeline-meta", `${event.status || ""} ${event.reason || ""}`.trim()));
+    timeline.appendChild(row);
+  }
+  audit.appendChild(timeline);
+  body.appendChild(audit);
+  modal.appendChild(body);
+
+  const actions = _el("div", "ic-detail-actions");
+  _appendActionButtons(actions, vm, render, () => overlay.remove(), onAfterDecision);
+  modal.appendChild(actions);
+  overlay.appendChild(modal);
+  document.body.appendChild(overlay);
+}
+
+/**
+ * 一覧 table row を生成する。
+ *
+ * @private
+ * @function _row
+ * @param {Object} vm - candidate ViewModel。
+ * @param {Function} render - 再描画関数。
+ * @param {Function} [onAfterDecision] - 外部再描画 hook。
+ * @returns {HTMLTableRowElement} table row。
+ */
+function _row(vm, render, onAfterDecision) {
+  const tr = document.createElement("tr");
+  const statusTd = document.createElement("td");
+  statusTd.appendChild(_statusBadge(vm));
+  const spoolTd = document.createElement("td");
+  spoolTd.append(_swatch(vm.candidateSpoolColor), document.createTextNode(vm.candidateSpoolName));
+  const afterTd = document.createElement("td");
+  afterTd.textContent = `${vm.confirmedRemainingDisplay} → ${vm.projectedRemainingDisplay}`;
+  const openBtn = _el("button", "ic-open-button", "Open");
+  openBtn.addEventListener("click", () => _showDetail(buildInferredCandidateViewModel(monitorData.inferredCandidateStore?.[vm.candidateHash] || vm), render, onAfterDecision));
+  const actionTd = document.createElement("td");
+  actionTd.appendChild(openBtn);
+  tr.append(
+    statusTd,
+    _el("td", "", vm.hostLabel),
+    spoolTd,
+    _el("td", "", vm.usedDisplay),
+    afterTd,
+    _el("td", "", vm.confidenceLabel),
+    _el("td", "", String(vm.jobCount)),
+    _el("td", "", vm.createdAtDisplay),
+    actionTd
+  );
+  return tr;
+}
+
+/**
+ * Candidate Center 本体を生成する。
+ *
+ * 【詳細説明】
+ * - フィラメント管理モーダル内の1タブとして使用する。
+ * - filter/sort/refresh は表示モデルを作り直すだけで、candidate store や台帳は変更しない。
+ * - detail modal の Confirm/Reject/Reassign は Decision Core を呼び、成功後に一覧を再描画する。
+ *
+ * @function createInferredCandidateCenterContent
+ * @param {{host?:?string,onAfterDecision?:Function}} [options] - 初期 host と外部再描画 hook。
+ * @returns {{el:HTMLElement,render:Function}} タブ要素と再描画関数。
+ * @example
+ * const center = createInferredCandidateCenterContent();
+ */
+export function createInferredCandidateCenterContent(options = {}) {
+  const root = _el("div", "filament-manager-content ic-center");
+  const toolbar = _el("div", "ic-toolbar");
+  const count = _el("span", "ic-count");
+  const statusSelect = document.createElement("select");
+  for (const [value, label] of [
+    [INFERRED_CANDIDATE_FILTER.PENDING, "Pending"],
+    [INFERRED_CANDIDATE_FILTER.CONFIRMED, "Confirmed"],
+    [INFERRED_CANDIDATE_FILTER.REJECTED, "Rejected"],
+    [INFERRED_CANDIDATE_FILTER.REASSIGNED, "Reassigned"],
+    [INFERRED_CANDIDATE_FILTER.SUPERSEDED, "Superseded"],
+    [INFERRED_CANDIDATE_FILTER.ALL, "All"]
+  ]) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = label;
+    statusSelect.appendChild(option);
+  }
+  const sortSelect = document.createElement("select");
+  for (const [value, label] of [
+    [INFERRED_CANDIDATE_SORT.NEWEST, "Newest"],
+    [INFERRED_CANDIDATE_SORT.OLDEST, "Oldest"],
+    [INFERRED_CANDIDATE_SORT.CONFIDENCE, "Confidence"],
+    [INFERRED_CANDIDATE_SORT.PRINTER, "Printer"],
+    [INFERRED_CANDIDATE_SORT.SPOOL, "Spool"]
+  ]) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = label;
+    sortSelect.appendChild(option);
+  }
+  const refreshBtn = _el("button", "ic-open-button", "Refresh");
+  toolbar.append(count, statusSelect, sortSelect, refreshBtn);
+  const body = _el("div", "ic-list-wrap");
+  root.append(toolbar, body);
+
+  /**
+   * Candidate Center の一覧表示を最新 store から再構築する。
+   *
+   * 【詳細説明】
+   * - フィルタ・ソート・host 条件を ViewModel 層へ渡し、表示対象だけを描画する。
+   * - 表示対象がない場合は共通 empty state を表示し、候補がある場合はテーブル行を再生成する。
+   *
+   * @function render
+   * @returns {void} 戻り値はない。
+   */
+  function render() {
+    const models = listInferredCandidateViewModels({
+      status: statusSelect.value,
+      sort: sortSelect.value,
+      host: options.host || null
+    });
+    count.textContent = `Pending ${countPendingInferredCandidates(options.host || null)} / Total ${listInferredCandidateViewModels({ status: INFERRED_CANDIDATE_FILTER.ALL, host: options.host || null }).length}`;
+    body.innerHTML = "";
+    if (models.length === 0) {
+      body.appendChild(createEmptyState({
+        icon: "候補",
+        title: "表示対象の候補はありません",
+        message: "pending candidate が作成されるとここに表示されます"
+      }));
+      return;
+    }
+    const table = _el("table", "ic-table");
+    const thead = document.createElement("thead");
+    thead.innerHTML = "<tr><th>状態</th><th>プリンタ</th><th>候補スプール</th><th>推定消費</th><th>残量</th><th>信頼度</th><th>ジョブ</th><th>作成</th><th>操作</th></tr>";
+    const tbody = document.createElement("tbody");
+    for (const vm of models) tbody.appendChild(_row(vm, render, options.onAfterDecision));
+    table.append(thead, tbody);
+    body.appendChild(table);
+  }
+
+  statusSelect.addEventListener("change", render);
+  sortSelect.addEventListener("change", render);
+  refreshBtn.addEventListener("click", render);
+  render();
+  return { el: root, render };
+}

--- a/3dp_lib/dashboard_inferred_candidate_view.js
+++ b/3dp_lib/dashboard_inferred_candidate_view.js
@@ -1,0 +1,426 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 推定 candidate 表示モデル生成モジュール
+ * @file dashboard_inferred_candidate_view.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * @author pumpCurry
+ * -----------------------------------------------------------
+ * @module dashboard_inferred_candidate_view
+ *
+ * 【機能内容サマリ】
+ * - inferredCandidateStore の保存レコードから O5 UI 用 ViewModel を生成する。
+ * - status filter、sort、pending count、残量差分、履歴照合警告を read-only で計算する。
+ * - UI が candidate record や確定台帳を直接変更しないための表示専用境界を提供する。
+ *
+ * 【公開関数一覧】
+ * - {@link buildInferredCandidateViewModel}：candidate record 1件を表示モデルへ変換する
+ * - {@link listInferredCandidateViewModels}：candidate 一覧表示モデルを生成する
+ * - {@link countPendingInferredCandidates}：pending candidate 件数を返す
+ *
+ * @version 1.390.1262 (PR #415)
+ * @since   1.390.1262 (PR #415)
+ * @lastModified 2026-07-25 14:25:00
+ * -----------------------------------------------------------
+ * @todo
+ * - O5C で recovery flag の起動時 reconciliation 結果を警告表示へ接続する。
+ */
+
+"use strict";
+
+import { monitorData } from "./dashboard_data.js";
+import { jobObservationIdentity } from "./dashboard_history_identity.js";
+import { canExecuteLedgerDecision } from "./dashboard_inferred_candidate_decision.js";
+import { INFERRED_CANDIDATE_STATUS } from "./dashboard_offline_candidate_store.js";
+import { formatFilamentAmount, formatSpoolDisplayId } from "./dashboard_spool.js";
+
+/**
+ * Candidate Center の status filter。
+ *
+ * @enum {string}
+ */
+export const INFERRED_CANDIDATE_FILTER = Object.freeze({
+  PENDING: "pending",
+  CONFIRMED: "confirmed",
+  REJECTED: "rejected",
+  REASSIGNED: "reassigned",
+  SUPERSEDED: "superseded",
+  ALL: "all"
+});
+
+/**
+ * Candidate Center の sort key。
+ *
+ * @enum {string}
+ */
+export const INFERRED_CANDIDATE_SORT = Object.freeze({
+  NEWEST: "newest",
+  OLDEST: "oldest",
+  CONFIDENCE: "confidence",
+  PRINTER: "printer",
+  SPOOL: "spool"
+});
+
+/**
+ * confidence level の表示順位。
+ *
+ * @private
+ * @constant {Object.<string,number>}
+ */
+const CONFIDENCE_RANK = Object.freeze({
+  high: 3,
+  medium: 2,
+  low: 1
+});
+
+/**
+ * status label の表示テキスト。
+ *
+ * @private
+ * @constant {Object.<string,string>}
+ */
+const STATUS_LABELS = Object.freeze({
+  pending: "Pending",
+  confirmed: "Confirmed",
+  rejected: "Rejected",
+  reassigned: "Reassigned",
+  superseded: "Superseded"
+});
+
+/**
+ * confidence label の表示テキスト。
+ *
+ * @private
+ * @constant {Object.<string,string>}
+ */
+const CONFIDENCE_LABELS = Object.freeze({
+  high: "High",
+  medium: "Medium",
+  low: "Low"
+});
+
+/**
+ * monitorData の candidate store を取得する。
+ *
+ * @private
+ * @function _store
+ * @returns {Object.<string,Object>} candidateHash をキーにした store。
+ */
+function _store() {
+  return monitorData.inferredCandidateStore && typeof monitorData.inferredCandidateStore === "object"
+    ? monitorData.inferredCandidateStore
+    : {};
+}
+
+/**
+ * active な spool 配列から対象 spool を取得する。
+ *
+ * @private
+ * @function _spoolById
+ * @param {?string} spoolId - spool ID。
+ * @returns {?Object} spool。存在しない場合は null。
+ */
+function _spoolById(spoolId) {
+  if (!spoolId) return null;
+  const id = String(spoolId);
+  return (monitorData.filamentSpools || []).find(spool =>
+    spool && String(spool.id) === id && !spool.deleted && !spool.isDeleted
+  ) || null;
+}
+
+/**
+ * host の表示名を返す。
+ *
+ * @private
+ * @function _hostLabel
+ * @param {?string} host - host key。
+ * @returns {string} UI 表示名。
+ */
+function _hostLabel(host) {
+  if (!host) return "--";
+  const machine = monitorData.machines?.[host];
+  return machine?.storedData?.hostname?.rawValue
+    || machine?.storedData?.model?.rawValue
+    || host;
+}
+
+/**
+ * mm 値を UI 表示用文字列へ変換する。
+ *
+ * @private
+ * @function _formatMm
+ * @param {*} mm - mm 値。
+ * @param {?Object} [spool=null] - spool context。
+ * @returns {string} 表示文字列。
+ */
+function _formatMm(mm, spool = null) {
+  const n = Number(mm);
+  if (!Number.isFinite(n)) return "--";
+  try {
+    return formatFilamentAmount(n, spool).display;
+  } catch {
+    return `${Math.round(n).toLocaleString()} mm`;
+  }
+}
+
+/**
+ * epoch ms を短い日時文字列へ変換する。
+ *
+ * @private
+ * @function _formatTime
+ * @param {*} epochMs - epoch ms。
+ * @returns {string} 表示文字列。
+ */
+function _formatTime(epochMs) {
+  const n = Number(epochMs);
+  if (!Number.isFinite(n) || n <= 0) return "--";
+  try {
+    return new Date(n).toLocaleString("ja-JP", { hour12: false });
+  } catch {
+    return "--";
+  }
+}
+
+/**
+ * 履歴配列を取得する。
+ *
+ * @private
+ * @function _historyForHost
+ * @param {?string} host - host key。
+ * @returns {Array<Object>} printStore.history 相当の配列。
+ */
+function _historyForHost(host) {
+  const history = monitorData.machines?.[host]?.printStore?.history;
+  return Array.isArray(history) ? history : [];
+}
+
+/**
+ * 履歴行の候補 observation key を列挙する。
+ *
+ * @private
+ * @function _entryObservationKeys
+ * @param {Object} entry - 履歴行。
+ * @returns {Array<string>} observation key 候補。
+ */
+function _entryObservationKeys(entry) {
+  const keys = new Set();
+  const identity = jobObservationIdentity(entry);
+  if (identity?.key) keys.add(String(identity.key));
+  if (entry?.observationKey != null) keys.add(String(entry.observationKey));
+  if (entry?._observationKey != null) keys.add(String(entry._observationKey));
+  return [...keys];
+}
+
+/**
+ * observation key から履歴候補への Map を作る。
+ *
+ * @private
+ * @function _historyByObservationKey
+ * @param {Array<Object>} history - printStore.history 相当の配列。
+ * @returns {Map<string,{status:string,entries:Array<Object>}>} key lookup。
+ */
+function _historyByObservationKey(history) {
+  const map = new Map();
+  for (const entry of history) {
+    for (const key of _entryObservationKeys(entry)) {
+      const current = map.get(key);
+      if (!current) {
+        map.set(key, { status: "unique", entries: [entry] });
+      } else {
+        current.status = "ambiguous";
+        current.entries.push(entry);
+      }
+    }
+  }
+  return map;
+}
+
+/**
+ * 履歴行が確定帰属済みか判定する。
+ *
+ * @private
+ * @function _historyAttributionState
+ * @param {?Object} entry - 履歴行。
+ * @returns {string} `missing` / `attributed` / `pending`。
+ */
+function _historyAttributionState(entry) {
+  if (!entry) return "missing";
+  const info = Array.isArray(entry.filamentInfo) ? entry.filamentInfo : [];
+  if (info.some(item => item && item.spoolId)) return "attributed";
+  if (entry.filamentId) return "attributed";
+  return "pending";
+}
+
+/**
+ * candidate に紐づく履歴表示モデルを作る。
+ *
+ * @private
+ * @function _jobViewModels
+ * @param {Object} record - candidate record。
+ * @param {?Object} spool - candidate spool。
+ * @returns {{jobs:Array<Object>,warningCodes:Array<string>}} 履歴表示モデルと警告。
+ */
+function _jobViewModels(record, spool) {
+  const history = _historyForHost(record.host);
+  const byKey = _historyByObservationKey(history);
+  const warnings = new Set();
+  const debits = Array.isArray(record.candidateDebits) ? record.candidateDebits : [];
+  const jobs = debits.map(debit => {
+    const key = String(debit?.observationKey ?? "");
+    const lookup = byKey.get(key);
+    let entry = null;
+    let lookupStatus = "missing";
+    if (lookup?.status === "unique" && lookup.entries.length === 1) {
+      entry = lookup.entries[0];
+      lookupStatus = "unique";
+    } else if (lookup?.status === "ambiguous") {
+      lookupStatus = "ambiguous";
+      warnings.add("history-ambiguous");
+    } else {
+      warnings.add("history-missing");
+    }
+    const attributionState = _historyAttributionState(entry);
+    if (attributionState === "attributed") warnings.add("history-already-attributed");
+    const usedMm = Number(debit?.usedMm);
+    return {
+      observationKey: key,
+      status: debit?.status || "unknown",
+      lookupStatus,
+      filename: entry?.filename || entry?.file || entry?.name || key,
+      usedMm: Number.isFinite(usedMm) ? usedMm : 0,
+      usedDisplay: Number.isFinite(usedMm) ? _formatMm(usedMm, spool) : "--",
+      attributionState,
+      reason: debit?.reason || null
+    };
+  });
+  return { jobs, warningCodes: [...warnings] };
+}
+
+/**
+ * candidate record 1件を表示モデルへ変換する。
+ *
+ * 【詳細説明】
+ * - inferredCandidateStore の生 record と monitorData の spool/history を read-only に参照する。
+ * - 操作可否は candidate status と `canExecuteLedgerDecision()` で決める。
+ * - warningCodes は O4 保存後に履歴や spool が変化した場合の UI 警告として使う。
+ *
+ * @function buildInferredCandidateViewModel
+ * @param {Object} record - inferredCandidateStore の candidate record。
+ * @param {{canExecute?:boolean}} [options] - テスト用の操作可否注入。
+ * @returns {Object} O5 UI 用 ViewModel。
+ * @example
+ * const vm = buildInferredCandidateViewModel(record);
+ */
+export function buildInferredCandidateViewModel(record, options = {}) {
+  const candidateHash = record?.candidateHash || "";
+  const status = record?.status || "unknown";
+  const spool = _spoolById(record?.candidateSpoolId);
+  const usedMm = Number(record?.usedMm);
+  const confirmedRemainingMm = spool && Number.isFinite(Number(spool.remainingLengthMm))
+    ? Number(spool.remainingLengthMm)
+    : null;
+  const projectedRemainingMm = confirmedRemainingMm == null || !Number.isFinite(usedMm)
+    ? null
+    : Math.max(0, confirmedRemainingMm - usedMm);
+  const confidenceLevel = record?.confidence?.level || "unknown";
+  const jobData = _jobViewModels(record || {}, spool);
+  const warnings = new Set(jobData.warningCodes);
+  if (!spool) warnings.add("spool-missing");
+  if (confirmedRemainingMm == null) warnings.add("remaining-unknown");
+  if (confirmedRemainingMm != null && Number.isFinite(usedMm) && confirmedRemainingMm < usedMm) {
+    warnings.add("remaining-insufficient");
+  }
+  if (confidenceLevel === "low") warnings.add("low-confidence");
+  if (monitorData.inferredDecisionRecoveryRequired) warnings.add("decision-recovery-required");
+  const canExecute = options.canExecute ?? canExecuteLedgerDecision();
+  if (!canExecute) warnings.add("relay-readonly");
+  const isPending = status === INFERRED_CANDIDATE_STATUS.PENDING;
+
+  return {
+    candidateHash,
+    status,
+    statusLabel: STATUS_LABELS[status] || status,
+    host: record?.host || null,
+    hostLabel: _hostLabel(record?.host),
+    candidateSpoolId: record?.candidateSpoolId || null,
+    candidateSpoolName: spool ? `${formatSpoolDisplayId(spool)} ${spool.name || ""}`.trim() : (record?.candidateSpoolId || "--"),
+    candidateSpoolColor: spool?.filamentColor || spool?.color || "",
+    usedMm: Number.isFinite(usedMm) ? usedMm : 0,
+    usedDisplay: Number.isFinite(usedMm) ? _formatMm(usedMm, spool) : "--",
+    confirmedRemainingMm,
+    confirmedRemainingDisplay: confirmedRemainingMm == null ? "--" : _formatMm(confirmedRemainingMm, spool),
+    projectedRemainingMm,
+    projectedRemainingDisplay: projectedRemainingMm == null ? "--" : _formatMm(projectedRemainingMm, spool),
+    confidenceLevel,
+    confidenceLabel: CONFIDENCE_LABELS[confidenceLevel] || confidenceLevel,
+    confidenceRank: CONFIDENCE_RANK[confidenceLevel] || 0,
+    jobCount: jobData.jobs.length,
+    jobs: jobData.jobs,
+    createdAt: Number(record?.createdAt) || 0,
+    createdAtDisplay: _formatTime(record?.createdAt),
+    updatedAt: Number(record?.updatedAt) || 0,
+    updatedAtDisplay: _formatTime(record?.updatedAt),
+    windowId: record?.windowId || "",
+    candidateBaselineIntervalId: record?.candidateBaselineIntervalId || "",
+    candidateCurrentIntervalId: record?.candidateCurrentIntervalId || "",
+    observationKeys: Array.isArray(record?.observationKeys) ? record.observationKeys.map(String) : [],
+    confidence: record?.confidence || null,
+    evidence: record?.evidence || null,
+    events: Array.isArray(record?.events) ? record.events.map(event => ({ ...event })) : [],
+    canConfirm: canExecute && isPending,
+    canReject: canExecute && isPending,
+    canReassign: canExecute && isPending,
+    readOnlyReason: canExecute ? null : "relay-readonly",
+    warningCodes: [...warnings].sort()
+  };
+}
+
+/**
+ * candidate 一覧表示モデルを生成する。
+ *
+ * 【詳細説明】
+ * - status filter が `all` 以外の場合は対象状態だけを返す。
+ * - host が指定された場合はその host の candidate だけを返す。
+ * - sort は UI の選択値に従い、安定した tie-break として candidateHash を最後に使う。
+ *
+ * @function listInferredCandidateViewModels
+ * @param {{status?:string,sort?:string,host?:?string,canExecute?:boolean}} [options] - filter/sort 条件。
+ * @returns {Array<Object>} ViewModel 配列。
+ * @example
+ * const pending = listInferredCandidateViewModels({ status: "pending" });
+ */
+export function listInferredCandidateViewModels(options = {}) {
+  const statusFilter = options.status || INFERRED_CANDIDATE_FILTER.PENDING;
+  const sort = options.sort || INFERRED_CANDIDATE_SORT.NEWEST;
+  const host = options.host || null;
+  const models = Object.values(_store())
+    .filter(record => record && typeof record === "object")
+    .filter(record => !host || record.host === host)
+    .filter(record => statusFilter === INFERRED_CANDIDATE_FILTER.ALL || record.status === statusFilter)
+    .map(record => buildInferredCandidateViewModel(record, { canExecute: options.canExecute }));
+
+  models.sort((a, b) => {
+    if (sort === INFERRED_CANDIDATE_SORT.OLDEST) return (a.createdAt - b.createdAt) || a.candidateHash.localeCompare(b.candidateHash);
+    if (sort === INFERRED_CANDIDATE_SORT.CONFIDENCE) return (b.confidenceRank - a.confidenceRank) || (b.createdAt - a.createdAt);
+    if (sort === INFERRED_CANDIDATE_SORT.PRINTER) return a.hostLabel.localeCompare(b.hostLabel) || (b.createdAt - a.createdAt);
+    if (sort === INFERRED_CANDIDATE_SORT.SPOOL) return a.candidateSpoolName.localeCompare(b.candidateSpoolName) || (b.createdAt - a.createdAt);
+    return (b.createdAt - a.createdAt) || a.candidateHash.localeCompare(b.candidateHash);
+  });
+  return models;
+}
+
+/**
+ * pending candidate 件数を返す。
+ *
+ * @function countPendingInferredCandidates
+ * @param {?string} [host=null] - host を指定するとその host だけを数える。
+ * @returns {number} pending candidate 件数。
+ * @example
+ * const count = countPendingInferredCandidates();
+ */
+export function countPendingInferredCandidates(host = null) {
+  return listInferredCandidateViewModels({
+    status: INFERRED_CANDIDATE_FILTER.PENDING,
+    host,
+    canExecute: true
+  }).length;
+}

--- a/3dp_panel.css
+++ b/3dp_panel.css
@@ -3901,3 +3901,242 @@ body.relay-readonly textarea {
   color: var(--color-text);
   width: 100%;
 }
+
+/* ---------------------------------------------------------------
+   O5 Candidate Center
+--------------------------------------------------------------- */
+.ic-center {
+  gap: var(--space-2);
+}
+.ic-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+  flex-wrap: wrap;
+}
+.ic-toolbar select,
+.ic-dialog-form select,
+.ic-dialog-form textarea {
+  border: 1px solid var(--color-input-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-input-bg);
+  color: var(--color-text-primary);
+  font-size: var(--font-sm);
+  padding: var(--space-1);
+}
+.ic-count {
+  font-size: var(--font-sm);
+  font-weight: bold;
+}
+.ic-list-wrap {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+.ic-table,
+.ic-detail-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.ic-table th,
+.ic-table td,
+.ic-detail-table th,
+.ic-detail-table td {
+  border: 1px solid var(--color-border);
+  padding: var(--space-1);
+  font-size: var(--font-sm);
+  vertical-align: top;
+}
+.ic-table th,
+.ic-detail-table th {
+  background: var(--color-table-header);
+}
+.ic-table tr:hover td {
+  background: var(--color-table-hover);
+}
+.ic-status {
+  display: inline-block;
+  border-radius: var(--radius-full);
+  padding: 1px var(--space-2);
+  font-size: var(--font-xs);
+  font-weight: bold;
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+}
+.ic-status-pending {
+  background: var(--color-warning-bg);
+  color: var(--color-warning-text);
+}
+.ic-status-confirmed,
+.ic-status-reassigned {
+  background: var(--color-success-bg);
+  color: var(--color-success-text);
+}
+.ic-status-rejected,
+.ic-status-superseded {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+}
+.ic-color-swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  margin-right: var(--space-1);
+  vertical-align: middle;
+  background: var(--color-bg-tertiary);
+}
+.ic-open-button,
+.ic-action-primary,
+.ic-action-secondary,
+.ic-icon-button {
+  border: 1px solid var(--color-input-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  font-size: var(--font-sm);
+  padding: var(--space-1) var(--space-2);
+}
+.ic-action-primary {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-text-inverse);
+  font-weight: bold;
+}
+.ic-open-button:hover,
+.ic-action-secondary:hover,
+.ic-icon-button:hover {
+  background: var(--color-table-hover);
+}
+.ic-action-primary:disabled,
+.ic-action-secondary:disabled,
+.ic-open-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+.ic-detail-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-modal-sub);
+  background: var(--color-overlay);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.ic-detail-modal {
+  width: min(900px, 94vw);
+  max-height: 88vh;
+  background: var(--color-modal-bg);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-modal);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.ic-detail-header,
+.ic-detail-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+.ic-detail-header {
+  justify-content: space-between;
+  font-weight: bold;
+}
+.ic-detail-actions {
+  justify-content: flex-end;
+  border-bottom: none;
+  border-top: 1px solid var(--color-border);
+  flex-wrap: wrap;
+}
+.ic-detail-body {
+  padding: var(--space-3);
+  overflow: auto;
+}
+.ic-detail-section {
+  margin-bottom: var(--space-3);
+}
+.ic-detail-section h4 {
+  margin: 0 0 var(--space-1);
+  font-size: var(--font-base);
+}
+.ic-kv {
+  display: grid;
+  grid-template-columns: minmax(120px, 180px) minmax(0, 1fr);
+  gap: var(--space-2);
+  padding: 2px 0;
+  font-size: var(--font-sm);
+}
+.ic-kv-label {
+  color: var(--color-text-secondary);
+}
+.ic-kv-value {
+  overflow-wrap: anywhere;
+}
+.ic-warning-row {
+  display: flex;
+  gap: var(--space-1);
+  flex-wrap: wrap;
+  margin-top: var(--space-2);
+}
+.ic-warning-chip,
+.ic-readonly-note {
+  border: 1px solid var(--color-warning);
+  border-radius: var(--radius-sm);
+  background: var(--color-warning-bg);
+  color: var(--color-warning-text);
+  font-size: var(--font-xs);
+  padding: 2px var(--space-2);
+}
+.ic-readonly-note {
+  flex-basis: 100%;
+}
+.ic-timeline {
+  border-left: 2px solid var(--color-border);
+  margin-top: var(--space-2);
+  padding-left: var(--space-2);
+}
+.ic-timeline-row {
+  display: flex;
+  gap: var(--space-2);
+  font-size: var(--font-sm);
+  padding: 2px 0;
+}
+.ic-timeline-type {
+  font-weight: bold;
+}
+.ic-timeline-meta {
+  color: var(--color-text-secondary);
+}
+.ic-dialog-form {
+  display: grid;
+  gap: var(--space-2);
+}
+.ic-dialog-form label {
+  display: grid;
+  gap: var(--space-1);
+  font-size: var(--font-sm);
+}
+.ic-dialog-form textarea {
+  min-height: 72px;
+  resize: vertical;
+}
+
+@media (max-width: 720px) {
+  .ic-table {
+    min-width: 760px;
+  }
+  .ic-detail-modal {
+    width: 96vw;
+    max-height: 92vh;
+  }
+  .ic-kv {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+}

--- a/tests/unit/dashboard_inferred_candidate_ui.test.js
+++ b/tests/unit/dashboard_inferred_candidate_ui.test.js
@@ -1,0 +1,170 @@
+/**
+ * @fileoverview dashboard_inferred_candidate_ui.js（#415-O5B Candidate Center UI）の単体テスト
+ * 一覧・詳細・操作ボタンが ViewModel と Decision Core に正しく接続されることを検証する。
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  monitorData: {
+    filamentSpools: [],
+    inferredCandidateStore: {}
+  },
+  vm: null,
+  confirmInferredCandidate: vi.fn(async () => ({ ok: true, reason: "confirmed" })),
+  rejectInferredCandidate: vi.fn(async () => ({ ok: true, reason: "rejected" })),
+  reassignInferredCandidate: vi.fn(async () => ({ ok: true, reason: "reassigned" })),
+  showConfirmDialog: vi.fn(async () => true),
+  showAlert: vi.fn()
+}));
+
+vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mocks.monitorData }));
+vi.mock("../../3dp_lib/dashboard_inferred_candidate_decision.js", () => ({
+  confirmInferredCandidate: mocks.confirmInferredCandidate,
+  rejectInferredCandidate: mocks.rejectInferredCandidate,
+  reassignInferredCandidate: mocks.reassignInferredCandidate
+}));
+vi.mock("../../3dp_lib/dashboard_inferred_candidate_view.js", () => ({
+  INFERRED_CANDIDATE_FILTER: {
+    PENDING: "pending",
+    CONFIRMED: "confirmed",
+    REJECTED: "rejected",
+    REASSIGNED: "reassigned",
+    SUPERSEDED: "superseded",
+    ALL: "all"
+  },
+  INFERRED_CANDIDATE_SORT: {
+    NEWEST: "newest",
+    OLDEST: "oldest",
+    CONFIDENCE: "confidence",
+    PRINTER: "printer",
+    SPOOL: "spool"
+  },
+  buildInferredCandidateViewModel: vi.fn(() => mocks.vm),
+  countPendingInferredCandidates: vi.fn(() => mocks.vm?.status === "pending" ? 1 : 0),
+  listInferredCandidateViewModels: vi.fn(() => mocks.vm ? [mocks.vm] : [])
+}));
+vi.mock("../../3dp_lib/dashboard_notification_manager.js", () => ({ showAlert: mocks.showAlert }));
+vi.mock("../../3dp_lib/dashboard_ui_confirm.js", () => ({ showConfirmDialog: mocks.showConfirmDialog }));
+vi.mock("../../3dp_lib/dashboard_ui_components.js", () => ({
+  createEmptyState: ({ title }) => {
+    const el = document.createElement("div");
+    el.className = "state-empty";
+    el.textContent = title || "";
+    return el;
+  }
+}));
+
+const { createInferredCandidateCenterContent } = await import("../../3dp_lib/dashboard_inferred_candidate_ui.js");
+
+/**
+ * ViewModel fixture を作る。
+ *
+ * @function vm
+ * @param {Object} over - 上書き値。
+ * @returns {Object} Candidate ViewModel。
+ */
+function vm(over = {}) {
+  return {
+    candidateHash: "ic-a",
+    status: "pending",
+    statusLabel: "Pending",
+    hostLabel: "K1 Max",
+    candidateSpoolId: "S1",
+    candidateSpoolName: "PLA Red",
+    candidateSpoolColor: "red",
+    usedDisplay: "3,000 mm",
+    confirmedRemainingDisplay: "10,000 mm",
+    projectedRemainingDisplay: "7,000 mm",
+    confidenceLabel: "High",
+    jobCount: 2,
+    jobs: [
+      { filename: "a.gcode", usedDisplay: "1,000 mm", attributionState: "pending" },
+      { filename: "b.gcode", usedDisplay: "2,000 mm", attributionState: "pending" }
+    ],
+    createdAtDisplay: "2026/7/25 14:00:00",
+    windowId: "win-a",
+    candidateBaselineIntervalId: "iv-a",
+    candidateCurrentIntervalId: "iv-a",
+    events: [{ type: "created", status: "pending", reason: "" }],
+    warningCodes: [],
+    canConfirm: true,
+    canReject: true,
+    canReassign: true,
+    readOnlyReason: null,
+    ...over
+  };
+}
+
+/**
+ * 非同期イベントハンドラの完了を待ってから検証する。
+ *
+ * @function waitForAssertion
+ * @param {Function} assertion - 成功するまで再試行する検証関数。
+ * @returns {Promise<void>} 検証成功で解決する Promise。
+ */
+async function waitForAssertion(assertion) {
+  let lastError = null;
+  for (let i = 0; i < 20; i++) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+  }
+  throw lastError;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  mocks.vm = vm();
+  mocks.monitorData.filamentSpools = [
+    { id: "S2", name: "PLA Blue", material: "PLA", remainingLengthMm: 8000 }
+  ];
+  mocks.monitorData.inferredCandidateStore = { "ic-a": { candidateHash: "ic-a" } };
+  mocks.confirmInferredCandidate.mockClear();
+  mocks.rejectInferredCandidate.mockClear();
+  mocks.reassignInferredCandidate.mockClear();
+  mocks.showConfirmDialog.mockClear();
+  mocks.showConfirmDialog.mockResolvedValue(true);
+  mocks.showAlert.mockClear();
+});
+
+describe("createInferredCandidateCenterContent", () => {
+  it("candidate 一覧から詳細を開き、Confirm は Decision Core を呼ぶ", async () => {
+    const center = createInferredCandidateCenterContent();
+    document.body.appendChild(center.el);
+
+    center.el.querySelector("tbody .ic-open-button").click();
+    expect(document.querySelector(".ic-detail-modal")).toBeTruthy();
+    document.querySelector(".ic-action-primary").click();
+
+    await waitForAssertion(() => {
+      expect(mocks.confirmInferredCandidate).toHaveBeenCalledWith("ic-a", { actor: "local-user" });
+      expect(mocks.showAlert).toHaveBeenCalledWith("確定しました", "success");
+    });
+  });
+
+  it("閲覧専用 ViewModel では操作ボタンを disabled にし Decision Core を呼ばない", async () => {
+    mocks.vm = vm({
+      canConfirm: false,
+      canReject: false,
+      canReassign: false,
+      readOnlyReason: "relay-readonly",
+      warningCodes: ["relay-readonly"]
+    });
+    const center = createInferredCandidateCenterContent();
+    document.body.appendChild(center.el);
+
+    center.el.querySelector("tbody .ic-open-button").click();
+    const confirm = document.querySelector(".ic-action-primary");
+    confirm.click();
+    await Promise.resolve();
+
+    expect(confirm.disabled).toBe(true);
+    expect(document.querySelector(".ic-readonly-note").textContent).toContain("親端末");
+    expect(mocks.confirmInferredCandidate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/dashboard_inferred_candidate_view.test.js
+++ b/tests/unit/dashboard_inferred_candidate_view.test.js
@@ -1,0 +1,138 @@
+/**
+ * @fileoverview dashboard_inferred_candidate_view.js（#415-O5B ViewModel）の単体テスト
+ * Candidate Store から UI 表示モデルを read-only に生成することを検証する。
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  monitorData: {
+    machines: {},
+    filamentSpools: [],
+    inferredCandidateStore: {}
+  },
+  canExecute: true
+}));
+
+vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mocks.monitorData }));
+vi.mock("../../3dp_lib/dashboard_inferred_candidate_decision.js", () => ({
+  canExecuteLedgerDecision: () => mocks.canExecute
+}));
+vi.mock("../../3dp_lib/dashboard_spool.js", () => ({
+  formatFilamentAmount: (mm) => ({ display: `${Math.round(Number(mm)).toLocaleString()} mm` }),
+  formatSpoolDisplayId: (spool) => `#${spool.serialNo || spool.id}`
+}));
+
+const {
+  INFERRED_CANDIDATE_FILTER,
+  INFERRED_CANDIDATE_SORT,
+  buildInferredCandidateViewModel,
+  countPendingInferredCandidates,
+  listInferredCandidateViewModels
+} = await import("../../3dp_lib/dashboard_inferred_candidate_view.js");
+
+/**
+ * candidate fixture を作る。
+ *
+ * @function record
+ * @param {string} hash - candidateHash。
+ * @param {Object} over - 上書き値。
+ * @returns {Object} candidate record。
+ */
+function record(hash, over = {}) {
+  return {
+    candidateHash: hash,
+    status: "pending",
+    host: "k1",
+    candidateSpoolId: "S1",
+    usedMm: 3000,
+    confidence: { level: "high" },
+    evidence: { sameMountedSpool: true },
+    observationKeys: ["kA", "kB"],
+    candidateDebits: [
+      { observationKey: "kA", status: "inferred-debit", usedMm: 1000 },
+      { observationKey: "kB", status: "inferred-debit", usedMm: 2000 }
+    ],
+    createdAt: 2000,
+    updatedAt: 3000,
+    events: [{ type: "created", status: "pending" }],
+    ...over
+  };
+}
+
+beforeEach(() => {
+  mocks.canExecute = true;
+  mocks.monitorData.machines = {
+    k1: {
+      storedData: { hostname: { rawValue: "K1 Max" } },
+      printStore: {
+        history: [
+          { id: "A", observationKey: "kA", printfinish: 1, materialUsedMm: 1000, filename: "a.gcode" },
+          { id: "B", observationKey: "kB", printfinish: 1, materialUsedMm: 2000, filename: "b.gcode" }
+        ]
+      }
+    }
+  };
+  mocks.monitorData.filamentSpools = [
+    { id: "S1", serialNo: 12, name: "PLA Red", remainingLengthMm: 10000, filamentColor: "red" },
+    { id: "S2", serialNo: 13, name: "PLA Blue", remainingLengthMm: 8000, filamentColor: "blue" }
+  ];
+  mocks.monitorData.inferredCandidateStore = {
+    "ic-new": record("ic-new", { createdAt: 3000 }),
+    "ic-old": record("ic-old", { createdAt: 1000, status: "confirmed" })
+  };
+  delete mocks.monitorData.inferredDecisionRecoveryRequired;
+});
+
+describe("buildInferredCandidateViewModel", () => {
+  it("pending candidate の残量差分・履歴・操作可否を生成する", () => {
+    const vm = buildInferredCandidateViewModel(mocks.monitorData.inferredCandidateStore["ic-new"]);
+
+    expect(vm.statusLabel).toBe("Pending");
+    expect(vm.hostLabel).toBe("K1 Max");
+    expect(vm.candidateSpoolName).toContain("PLA Red");
+    expect(vm.usedDisplay).toBe("3,000 mm");
+    expect(vm.confirmedRemainingMm).toBe(10000);
+    expect(vm.projectedRemainingMm).toBe(7000);
+    expect(vm.jobCount).toBe(2);
+    expect(vm.jobs.map(job => job.filename)).toEqual(["a.gcode", "b.gcode"]);
+    expect(vm.canConfirm).toBe(true);
+    expect(vm.warningCodes).toEqual([]);
+  });
+
+  it("Satellite相当では閲覧専用 warning と操作不可を返す", () => {
+    mocks.canExecute = false;
+
+    const vm = buildInferredCandidateViewModel(mocks.monitorData.inferredCandidateStore["ic-new"]);
+
+    expect(vm.canConfirm).toBe(false);
+    expect(vm.canReject).toBe(false);
+    expect(vm.canReassign).toBe(false);
+    expect(vm.readOnlyReason).toBe("relay-readonly");
+    expect(vm.warningCodes).toContain("relay-readonly");
+  });
+
+  it("O4保存後に履歴が帰属済みになった場合は警告へ出す", () => {
+    mocks.monitorData.machines.k1.printStore.history[0].filamentInfo = [{ spoolId: "S9" }];
+
+    const vm = buildInferredCandidateViewModel(mocks.monitorData.inferredCandidateStore["ic-new"]);
+
+    expect(vm.warningCodes).toContain("history-already-attributed");
+  });
+});
+
+describe("listInferredCandidateViewModels", () => {
+  it("status filter と sort を適用する", () => {
+    const pending = listInferredCandidateViewModels({
+      status: INFERRED_CANDIDATE_FILTER.PENDING,
+      sort: INFERRED_CANDIDATE_SORT.NEWEST
+    });
+    const allOldest = listInferredCandidateViewModels({
+      status: INFERRED_CANDIDATE_FILTER.ALL,
+      sort: INFERRED_CANDIDATE_SORT.OLDEST
+    });
+
+    expect(pending.map(vm => vm.candidateHash)).toEqual(["ic-new"]);
+    expect(allOldest.map(vm => vm.candidateHash)).toEqual(["ic-old", "ic-new"]);
+    expect(countPendingInferredCandidates()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add O5B Candidate Center view-model and UI modules for inferred filament candidates.
- Wire the Candidate Center into the Filament Manager modal as a new tab.
- Keep SATELLITE/read-only devices view-only while STANDALONE/PARENT-capable nodes can call the O5 decision core.
- Add unit tests for candidate view-model formatting/filtering and UI decision wiring.

## Safety Notes
- The UI delegates all ledger mutations to the O5 decision core; it does not write confirmed ledger state directly.
- SATELLITE/read-only candidates show details and timeline but disable Confirm/Reject/Reassign controls.
- Reassign options exclude the current candidate spool.

## Verification
- `npx vitest run tests/unit/dashboard_inferred_candidate_view.test.js tests/unit/dashboard_inferred_candidate_ui.test.js`
- `npx vitest run tests/unit/dashboard_inferred_candidate_view.test.js tests/unit/dashboard_inferred_candidate_ui.test.js tests/unit/dashboard_inferred_candidate_decision.test.js tests/unit/dashboard_offline_candidate_store.test.js tests/unit/dashboard_offline_live_shadow.test.js`
- `npx eslint 3dp_lib/dashboard_inferred_candidate_view.js 3dp_lib/dashboard_inferred_candidate_ui.js 3dp_lib/dashboard_filament_manager.js tests/unit/dashboard_inferred_candidate_view.test.js tests/unit/dashboard_inferred_candidate_ui.test.js` (0 errors; existing warnings remain)
- `npx vitest run`