### PR TITLE
Relay O5 inferred candidate decisions

### DIFF
--- a/3dp_lib/dashboard_client_sync.js
+++ b/3dp_lib/dashboard_client_sync.js
@@ -12,6 +12,7 @@
  * - relay-snapshot / relay-delta の受信と monitorData への反映
  *   （フィラメント共有状態は親権威の全置換 + mountHistory 同期）
  * - satellite モードでのコマンド/フィラメント操作の送信（操作は親へ RPC 委譲）
+ * - O5 inferred candidate decision request を Parent へ送信
  * - 初回接続は常に readonly。?relay=satellite 要求時は自動昇格リクエスト（PIN 保護）
  *
  * 【公開関数一覧】
@@ -20,9 +21,9 @@
  * - {@link sendRelayCommand}：親経由でプリンタにコマンド送信
  * - {@link sendRelayFilament}：親経由でフィラメント操作
  *
- * @version 1.390.1245 (PR #412)
+ * @version 1.390.1263 (PR #416)
  * @since   1.390.820 (PR #367)
- * @lastModified 2026-07-19 18:45:00
+ * @lastModified 2026-07-25 20:55:00
  * -----------------------------------------------------------
  */
 
@@ -35,7 +36,7 @@ import {
   markAllKeysDirty,
   PLACEHOLDER_HOSTNAME
 } from "./dashboard_data.js";
-import { normalizeTimeZone } from "./dashboard_time.js";
+import { normalizeTimeZone, wallNowMs } from "./dashboard_time.js";
 
 /** dashboard_ui の updateStoredDataToDOM を遅延解決（重い UI 連鎖を import 時に巻き込まない） */
 let _updateStoredDataToDOM = null;
@@ -769,7 +770,7 @@ let _lastRelayAlertMs = 0;
  * @returns {void}
  */
 function _alertRelayBlocked(reason) {
-  const now = Date.now();
+  const now = wallNowMs();
   if (now - _lastRelayAlertMs < 1500) return;
   _lastRelayAlertMs = now;
   import("./dashboard_notification_manager.js").then(({ showAlert }) => {
@@ -962,7 +963,8 @@ function _notifyModeChange(kind) {
  * @param {string} action - 操作種別
  *   ("mount" | "unmount" | "addSpoolFromPreset" | "mountNewSpoolFromPreset" |
  *    "updateSpool" | "deleteSpool" | "restoreSpool" |
- *    "confirmInferredSpool" | "revertInferredSpool")
+ *    "confirmInferredSpool" | "revertInferredSpool" |
+ *    "confirmInferredCandidate" | "rejectInferredCandidate" | "reassignInferredCandidate")
  * @param {Object} data - 操作データ（action ごとのペイロード）
  * @returns {boolean} 送信できた場合 true
  */
@@ -988,7 +990,7 @@ export function sendRelayFilament(action, data) {
   //   在庫±や mount 等の冪等・意図的反復操作は対象外（正当な連続操作を殺さない）。
   if (_NON_IDEMPOTENT_FILAMENT.has(action)) {
     const key = `${action}:${JSON.stringify(data)}`;
-    const now = Date.now();
+    const now = wallNowMs();
     const prev = _recentFilamentSends.get(key);
     if (prev && now - prev < 1500) {
       console.warn(`[client-sync] 二重送信を抑止: ${action}`);
@@ -1004,9 +1006,10 @@ export function sendRelayFilament(action, data) {
   //   子側 payload は変更せず、送信用のコピーへ付与する。
   let sendData = data;
   if (_NON_IDEMPOTENT_FILAMENT.has(action)) {
-    const opId = (typeof crypto !== "undefined" && crypto.randomUUID)
-      ? crypto.randomUUID()
-      : `op_${Date.now()}_${Math.floor(performance.now())}`;
+    const cryptoApi = typeof globalThis !== "undefined" ? globalThis.crypto : null;
+    const opId = (cryptoApi && typeof cryptoApi.randomUUID === "function")
+      ? cryptoApi.randomUUID()
+      : `op_${wallNowMs()}_${Math.floor(performance.now())}`;
     sendData = { ...data, _opId: opId };
   }
   _relayWs.send(JSON.stringify({
@@ -1023,6 +1026,7 @@ export function sendRelayFilament(action, data) {
  */
 const _NON_IDEMPOTENT_FILAMENT = new Set([
   "addSpool", "addSpoolFromPreset", "mountNewSpoolFromPreset", "confirmInferredSpool",
+  "confirmInferredCandidate", "rejectInferredCandidate", "reassignInferredCandidate",
   "importUserPresets"
 ]);
 

--- a/3dp_lib/dashboard_inferred_candidate_decision.js
+++ b/3dp_lib/dashboard_inferred_candidate_decision.js
@@ -10,22 +10,23 @@
  * 【機能内容サマリ】
  * - O5A として、pending inferredCandidate の Confirm / Reject / Reassign を提供する。
  * - STAND ALONE と PARENT は確定台帳の権威として decision を実行できる。
- * - SATELLITE は初期実装では閲覧専用とし、candidate/ledger へローカル書き込みしない。
+ * - SATELLITE はローカル candidate/ledger を書かず、Parent へ decision request を送る。
  * - Confirm/Reassign は台帳反映、candidate 状態遷移、耐久保存を一連の transaction として扱い、
  *   保存失敗時はメモリ rollback と rollback 状態の耐久保存を試みる。
  *
  * 【公開関数一覧】
  * - {@link canExecuteLedgerDecision}：この端末で O5 decision を実行できるか判定する
+ * - {@link canSubmitLedgerDecision}：この端末から O5 decision を送信できるか判定する
  * - {@link confirmInferredCandidate}：candidate spool で推定使用量を確定する
  * - {@link rejectInferredCandidate}：candidate を否認し、確定台帳には触れない
  * - {@link reassignInferredCandidate}：別 spool へ再割当てして推定使用量を確定する
  *
- * @version 1.390.1261 (PR #414)
+ * @version 1.390.1263 (PR #416)
  * @since   1.390.1261 (PR #414)
- * @lastModified 2026-07-25 13:45:00
+ * @lastModified 2026-07-25 20:55:00
  * -----------------------------------------------------------
  * @todo
- * - O5B でこの API を操作 UI と decision timeline へ接続する。
+ * - none
  */
 
 "use strict";
@@ -40,6 +41,7 @@ import {
   applyInferredCandidateLedger,
   rollbackInferredCandidateLedger
 } from "./dashboard_inferred_candidate_ledger.js";
+import { getRelayMode, sendRelayFilament } from "./dashboard_client_sync.js";
 import { wallNowMs } from "./dashboard_time.js";
 
 /**
@@ -103,6 +105,23 @@ function _nowMs(options = {}) {
  */
 function _isRelayChild() {
   return typeof window !== "undefined" && window._3dpmonRelayChild === true;
+}
+
+/**
+ * Satellite から Parent へ O5 decision request を送れる状態か判定する。
+ *
+ * 【詳細説明】
+ * - `window._3dpmonRelayChild === true` だけでは readonly 子も含むため、relay mode が
+ *   `satellite` に昇格済みの場合だけ true にする。
+ * - 初回 snapshot 未受信や WebSocket 未接続の細かい条件は `sendRelayFilament()` 側で
+ *   最終ゲートされるため、ここでは UI の大まかな操作可否だけを返す。
+ *
+ * @private
+ * @function _canRequestLedgerDecision
+ * @returns {boolean} Parent へ decision request を送れる可能性がある場合 true。
+ */
+function _canRequestLedgerDecision() {
+  return _isRelayChild() && getRelayMode() === "satellite";
 }
 
 /**
@@ -213,6 +232,37 @@ function _decisionGuard(candidateHash) {
 }
 
 /**
+ * Satellite から Parent へ O5 decision request を送信する。
+ *
+ * 【詳細説明】
+ * - Satellite は確定台帳の権威を持たないため、ローカル candidate/ledger を変更しない。
+ * - 送信後の実結果は Parent の耐久保存後に relay-delta / snapshot で還流する。
+ * - `sendRelayFilament()` が readonly・未接続・初回 snapshot 未受信を fail-closed する。
+ *
+ * @private
+ * @function _requestLedgerDecision
+ * @param {string} action - 親へ送る O5 decision action。
+ * @param {string} candidateHash - 対象 candidateHash。
+ * @param {Object} payload - 追加 payload。
+ * @param {{actor?:string}} [options] - 操作者オプション。
+ * @returns {{ok:boolean,reason:string,relayed?:boolean,action:string,candidateHash:string}}
+ *   request 送信結果。
+ */
+function _requestLedgerDecision(action, candidateHash, payload = {}, options = {}) {
+  if (!candidateHash) return { ok: false, reason: "candidate_hash_required", action, candidateHash };
+  if (!_canRequestLedgerDecision()) {
+    return { ok: false, reason: "decision_not_authorized", action, candidateHash };
+  }
+  const sent = sendRelayFilament(action, {
+    candidateHash,
+    actor: options.actor || "satellite-user",
+    ...payload
+  });
+  if (!sent) return { ok: false, reason: "decision_request_not_sent", action, candidateHash };
+  return { ok: true, reason: "decision_requested", relayed: true, action, candidateHash };
+}
+
+/**
  * candidate 状態だけを保存前 snapshot へ戻す。
  *
  * @private
@@ -311,6 +361,24 @@ export function canExecuteLedgerDecision() {
 }
 
 /**
+ * この端末から O5 decision を送信できるか判定する。
+ *
+ * 【詳細説明】
+ * - STAND ALONE / PARENT はローカル実行できるため true。
+ * - SATELLITE はローカル実行はできないが、relay mode が `satellite` なら Parent へ request
+ *   を送れるため true。
+ * - readonly 子は request も送れないため false。
+ *
+ * @function canSubmitLedgerDecision
+ * @returns {boolean} UI 上で Confirm/Reject/Reassign を有効にできる場合 true。
+ * @example
+ * if (canSubmitLedgerDecision()) enableDecisionButtons();
+ */
+export function canSubmitLedgerDecision() {
+  return canExecuteLedgerDecision() || _canRequestLedgerDecision();
+}
+
+/**
  * candidate spool のまま推定使用量を確定する。
  *
  * 【詳細説明】
@@ -326,6 +394,9 @@ export function canExecuteLedgerDecision() {
  * const result = await confirmInferredCandidate("ic-abcd", { actor: "operator" });
  */
 export async function confirmInferredCandidate(candidateHash, options = {}) {
+  if (_isRelayChild()) {
+    return _requestLedgerDecision("confirmInferredCandidate", candidateHash, {}, options);
+  }
   const guard = _decisionGuard(candidateHash);
   if (guard) return guard;
   const pending = _validatePendingCandidate(candidateHash);
@@ -375,6 +446,16 @@ export async function confirmInferredCandidate(candidateHash, options = {}) {
  * const result = await rejectInferredCandidate("ic-abcd", { reason: "not-same-spool" });
  */
 export async function rejectInferredCandidate(candidateHash, options = {}) {
+  if (_isRelayChild()) {
+    const rejectReason = options.reason || "operator-decision";
+    if (!ALLOWED_REJECT_REASONS.has(rejectReason)) {
+      return { ok: false, reason: "invalid_reject_reason", candidateHash, rejectReason };
+    }
+    return _requestLedgerDecision("rejectInferredCandidate", candidateHash, {
+      reason: rejectReason,
+      note: options.note || ""
+    }, options);
+  }
   const guard = _decisionGuard(candidateHash);
   if (guard) return guard;
   const rejectReason = options.reason || "operator-decision";
@@ -430,6 +511,12 @@ export async function rejectInferredCandidate(candidateHash, options = {}) {
  * const result = await reassignInferredCandidate("ic-abcd", "spool-b");
  */
 export async function reassignInferredCandidate(candidateHash, targetSpoolId, options = {}) {
+  if (_isRelayChild()) {
+    if (!targetSpoolId) return { ok: false, reason: "target_spool_required", candidateHash };
+    return _requestLedgerDecision("reassignInferredCandidate", candidateHash, {
+      targetSpoolId: String(targetSpoolId)
+    }, options);
+  }
   const guard = _decisionGuard(candidateHash);
   if (guard) return guard;
   if (!targetSpoolId) return { ok: false, reason: "target_spool_required", candidateHash };

--- a/3dp_lib/dashboard_inferred_candidate_ui.js
+++ b/3dp_lib/dashboard_inferred_candidate_ui.js
@@ -10,17 +10,17 @@
  * 【機能内容サマリ】
  * - O5B Candidate Center として pending/処理済み candidate の一覧、詳細、監査 timeline を描画する。
  * - Confirm / Reject / Reassign の操作ダイアログを提供し、実更新は Decision Core へ委譲する。
- * - SATELLITE/readonly 子では一覧・詳細だけを表示し、確定操作ボタンは disabled にする。
+ * - SATELLITE 子では Parent へ decision request を送り、readonly 子では操作ボタンを disabled にする。
  *
  * 【公開関数一覧】
  * - {@link createInferredCandidateCenterContent}：フィラメント管理モーダル用 Candidate Center を生成する
  *
- * @version 1.390.1262 (PR #415)
+ * @version 1.390.1263 (PR #416)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-07-25 14:25:00
+ * @lastModified 2026-07-25 20:55:00
  * -----------------------------------------------------------
  * @todo
- * - O5C で Satellite から Parent へ decision request を送る RPC UI を追加する。
+ * - none
  */
 
 "use strict";
@@ -64,6 +64,7 @@ const REASON_LABELS = Object.freeze({
   candidate_not_pending: "候補はすでに処理済みです",
   candidate_hash_required: "候補IDが不正です",
   decision_not_authorized: "この端末では操作できません。親端末で実行してください",
+  decision_request_not_sent: "親端末へ送信できません。接続と同期状態を確認してください",
   decision_recovery_required: "整合性確認が必要です",
   target_spool_required: "再割当て先スプールを選択してください",
   target_spool_same_as_candidate: "候補スプールと同じため再割当てできません",
@@ -363,7 +364,8 @@ function _handleDecisionResult(result, render, onAfterDecision) {
     const label = result.reason === "confirmed" ? "確定しました"
       : result.reason === "reassigned" ? "再割当てを確定しました"
         : result.reason === "rejected" ? "否認しました"
-          : "処理しました";
+          : result.reason === "decision_requested" ? "親端末へ送信しました"
+            : "処理しました";
     showAlert(label, "success");
     try { onAfterDecision?.(result); } catch { /* noop */ }
     render();

--- a/3dp_lib/dashboard_inferred_candidate_view.js
+++ b/3dp_lib/dashboard_inferred_candidate_view.js
@@ -9,7 +9,7 @@
  *
  * 【機能内容サマリ】
  * - inferredCandidateStore の保存レコードから O5 UI 用 ViewModel を生成する。
- * - status filter、sort、pending count、残量差分、履歴照合警告を read-only で計算する。
+ * - status filter、sort、pending count、残量差分、履歴照合警告、decision 送信可否を計算する。
  * - UI が candidate record や確定台帳を直接変更しないための表示専用境界を提供する。
  *
  * 【公開関数一覧】
@@ -17,9 +17,9 @@
  * - {@link listInferredCandidateViewModels}：candidate 一覧表示モデルを生成する
  * - {@link countPendingInferredCandidates}：pending candidate 件数を返す
  *
- * @version 1.390.1262 (PR #415)
+ * @version 1.390.1263 (PR #416)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-07-25 14:25:00
+ * @lastModified 2026-07-25 20:55:00
  * -----------------------------------------------------------
  * @todo
  * - O5C で recovery flag の起動時 reconciliation 結果を警告表示へ接続する。
@@ -29,7 +29,7 @@
 
 import { monitorData } from "./dashboard_data.js";
 import { jobObservationIdentity } from "./dashboard_history_identity.js";
-import { canExecuteLedgerDecision } from "./dashboard_inferred_candidate_decision.js";
+import { canSubmitLedgerDecision } from "./dashboard_inferred_candidate_decision.js";
 import { INFERRED_CANDIDATE_STATUS } from "./dashboard_offline_candidate_store.js";
 import { formatFilamentAmount, formatSpoolDisplayId } from "./dashboard_spool.js";
 
@@ -300,12 +300,12 @@ function _jobViewModels(record, spool) {
  *
  * 【詳細説明】
  * - inferredCandidateStore の生 record と monitorData の spool/history を read-only に参照する。
- * - 操作可否は candidate status と `canExecuteLedgerDecision()` で決める。
+ * - 操作可否は candidate status と `canSubmitLedgerDecision()` で決める。
  * - warningCodes は O4 保存後に履歴や spool が変化した場合の UI 警告として使う。
  *
  * @function buildInferredCandidateViewModel
  * @param {Object} record - inferredCandidateStore の candidate record。
- * @param {{canExecute?:boolean}} [options] - テスト用の操作可否注入。
+ * @param {{canSubmit?:boolean}} [options] - テスト用の操作可否注入。
  * @returns {Object} O5 UI 用 ViewModel。
  * @example
  * const vm = buildInferredCandidateViewModel(record);
@@ -331,8 +331,8 @@ export function buildInferredCandidateViewModel(record, options = {}) {
   }
   if (confidenceLevel === "low") warnings.add("low-confidence");
   if (monitorData.inferredDecisionRecoveryRequired) warnings.add("decision-recovery-required");
-  const canExecute = options.canExecute ?? canExecuteLedgerDecision();
-  if (!canExecute) warnings.add("relay-readonly");
+  const canSubmit = options.canSubmit ?? canSubmitLedgerDecision();
+  if (!canSubmit) warnings.add("relay-readonly");
   const isPending = status === INFERRED_CANDIDATE_STATUS.PENDING;
 
   return {
@@ -366,10 +366,10 @@ export function buildInferredCandidateViewModel(record, options = {}) {
     confidence: record?.confidence || null,
     evidence: record?.evidence || null,
     events: Array.isArray(record?.events) ? record.events.map(event => ({ ...event })) : [],
-    canConfirm: canExecute && isPending,
-    canReject: canExecute && isPending,
-    canReassign: canExecute && isPending,
-    readOnlyReason: canExecute ? null : "relay-readonly",
+    canConfirm: canSubmit && isPending,
+    canReject: canSubmit && isPending,
+    canReassign: canSubmit && isPending,
+    readOnlyReason: canSubmit ? null : "relay-readonly",
     warningCodes: [...warnings].sort()
   };
 }
@@ -383,7 +383,7 @@ export function buildInferredCandidateViewModel(record, options = {}) {
  * - sort は UI の選択値に従い、安定した tie-break として candidateHash を最後に使う。
  *
  * @function listInferredCandidateViewModels
- * @param {{status?:string,sort?:string,host?:?string,canExecute?:boolean}} [options] - filter/sort 条件。
+ * @param {{status?:string,sort?:string,host?:?string,canSubmit?:boolean}} [options] - filter/sort 条件。
  * @returns {Array<Object>} ViewModel 配列。
  * @example
  * const pending = listInferredCandidateViewModels({ status: "pending" });
@@ -396,7 +396,7 @@ export function listInferredCandidateViewModels(options = {}) {
     .filter(record => record && typeof record === "object")
     .filter(record => !host || record.host === host)
     .filter(record => statusFilter === INFERRED_CANDIDATE_FILTER.ALL || record.status === statusFilter)
-    .map(record => buildInferredCandidateViewModel(record, { canExecute: options.canExecute }));
+    .map(record => buildInferredCandidateViewModel(record, { canSubmit: options.canSubmit }));
 
   models.sort((a, b) => {
     if (sort === INFERRED_CANDIDATE_SORT.OLDEST) return (a.createdAt - b.createdAt) || a.candidateHash.localeCompare(b.candidateHash);
@@ -421,6 +421,6 @@ export function countPendingInferredCandidates(host = null) {
   return listInferredCandidateViewModels({
     status: INFERRED_CANDIDATE_FILTER.PENDING,
     host,
-    canExecute: true
+    canSubmit: true
   }).length;
 }

--- a/3dp_lib/dashboard_relay_bridge.js
+++ b/3dp_lib/dashboard_relay_bridge.js
@@ -11,6 +11,7 @@
  * - aggregator 更新後に dirty keys を収集し、リレーサーバにブロードキャスト
  *   （filamentSpools / hostSpoolMap / mountHistory の共有状態を含む）
  * - 子（satellite）からのコマンド/フィラメント操作 RPC を受信し親側で実行
+ * - 子（satellite）からの O5 inferred candidate decision request を親側で実行
  * - 新規子クライアント接続時にフルスナップショットを送信
  *
  * 【公開関数一覧】
@@ -20,9 +21,9 @@
  * - {@link buildCameraEndpoints}：カメラパススルー用エンドポイントを構築する
  * - {@link relayBroadcastIfNeeded}：変更があれば子へデルタ配信する
  *
- * @version 1.390.1245 (PR #412)
+ * @version 1.390.1263 (PR #416)
  * @since   1.390.820 (PR #367)
- * @lastModified 2026-07-19 18:45:00
+ * @lastModified 2026-07-25 20:55:00
  * -----------------------------------------------------------
  */
 
@@ -31,6 +32,7 @@
 import { monitorData, PLACEHOLDER_HOSTNAME } from "./dashboard_data.js";
 import { sendCommand, getHttpPort } from "./dashboard_connection.js";
 import { extractHost } from "./dashboard_target_identity.js";
+import { wallNowMs } from "./dashboard_time.js";
 
 /** ブリッジ初期化済みフラグ */
 let _initialized = false;
@@ -68,6 +70,7 @@ let _prevAuxHash = "";
  */
 const _NON_IDEMPOTENT_RELAY = new Set([
   "addSpool", "addSpoolFromPreset", "mountNewSpoolFromPreset", "confirmInferredSpool",
+  "confirmInferredCandidate", "rejectInferredCandidate", "reassignInferredCandidate",
   "importUserPresets"
 ]);
 
@@ -163,12 +166,14 @@ export function initRelayBridge() {
  * - switch が操作のホワイトリストを兼ねる（未知 action は無視してログのみ）。
  * - serialNo 採番・プリセット在庫消費などの不可逆リソースは必ず親側で消費される
  *   （サテライトでローカル実行するとカウンタが分岐し台帳が壊れるため）。
+ * - O5 inferred candidate decision は親の Decision Core だけが実行し、子は request のみを送る。
  *
  * @function handleRelayFilamentAction
  * @param {string} action - 操作種別
  *   ("mount" | "unmount" | "addSpool" | "addSpoolFromPreset" | "mountNewSpoolFromPreset" |
  *    "updateSpool" | "deleteSpool" | "restoreSpool" |
  *    "confirmInferredSpool" | "revertInferredSpool" | "resolveFilamentEvent" |
+ *    "confirmInferredCandidate" | "rejectInferredCandidate" | "reassignInferredCandidate" |
  *    "setInventoryQuantity" | "adjustInventory" | "setMinStockAlert" |
  *    "togglePresetVisibility" | "toggleBrandVisibility" | "togglePresetFavorite" |
  *    "addUserPreset" | "updateUserPreset" | "deleteUserPreset")
@@ -212,6 +217,24 @@ async function _resolveRelayPreset(payload) {
   return null;
 }
 
+/**
+ * O5 decision request の共通 options を親側の安全な形へ正規化する。
+ *
+ * 【詳細説明】
+ * - Satellite からの clock 注入は受け付けず、親の Decision Core が `wallNowMs()` で監査時刻を採番する。
+ * - actor は監査ログ用の表示情報に留め、未指定時は relay-satellite として記録する。
+ *
+ * @private
+ * @function _relayDecisionOptions
+ * @param {Object} payload - relay-filament payload。
+ * @returns {{actor:string}} Decision Core へ渡す options。
+ */
+function _relayDecisionOptions(payload) {
+  return {
+    actor: payload?.actor || "relay-satellite"
+  };
+}
+
 export async function handleRelayFilamentAction(action, payload) {
   // ★ レビュー指摘#1/#2/#3: 非冪等操作（採番・在庫消費・一括import）の opId 重複排除。
   //   子側 1.5 秒抑止だけでは、リトライやリレー再配信で同一操作が親へ2回届くと2回採番・
@@ -219,7 +242,7 @@ export async function handleRelayFilamentAction(action, payload) {
   //   2件を両方通さない）、既知 opId は実行しない。さらに同一 opId で action/payload 署名が
   //   異なる場合はクライアントの opId 再利用バグを隠さないよう警告する。
   if (_NON_IDEMPOTENT_RELAY.has(action) && payload && payload._opId) {
-    const now = Date.now();
+    const now = wallNowMs();
     const sig = `${action}:${JSON.stringify(payload)}`;
     const prev = _recentRelayOpIds.get(payload._opId);
     if (prev) {
@@ -314,6 +337,38 @@ export async function handleRelayFilamentAction(action, payload) {
           spoolMod.revertInferredSpool(payload.id);
         }
         break;
+      case "confirmInferredCandidate": {
+        // O5C: Satellite からの Confirm request。親の Decision Core が候補検証・台帳反映・耐久保存を行う。
+        if (payload.candidateHash) {
+          const decisionMod = await import("./dashboard_inferred_candidate_decision.js");
+          await decisionMod.confirmInferredCandidate(payload.candidateHash, _relayDecisionOptions(payload));
+        }
+        break;
+      }
+      case "rejectInferredCandidate": {
+        // O5C: Reject は確定台帳には触れないが、candidate status は親権威 store でのみ遷移する。
+        if (payload.candidateHash) {
+          const decisionMod = await import("./dashboard_inferred_candidate_decision.js");
+          await decisionMod.rejectInferredCandidate(payload.candidateHash, {
+            ..._relayDecisionOptions(payload),
+            reason: payload.reason,
+            note: payload.note || ""
+          });
+        }
+        break;
+      }
+      case "reassignInferredCandidate": {
+        // O5C: Reassign は target spool への確定台帳反映を伴うため、親の Decision Core だけが実行する。
+        if (payload.candidateHash && payload.targetSpoolId) {
+          const decisionMod = await import("./dashboard_inferred_candidate_decision.js");
+          await decisionMod.reassignInferredCandidate(
+            payload.candidateHash,
+            payload.targetSpoolId,
+            _relayDecisionOptions(payload)
+          );
+        }
+        break;
+      }
       case "resolveFilamentEvent":
         // ★ 監査 P0(第2報): フィラメント切れ文脈の解決（reseat 等）を親で確定。
         //   結果は relay-delta の filamentEventContext で全子へ還流する。
@@ -489,7 +544,7 @@ function _syncCameraEndpoints() {
 export function relayBroadcastIfNeeded() {
   if (!_initialized) return;
 
-  const now = Date.now();
+  const now = wallNowMs();
   if (now - _lastBroadcastMs < BROADCAST_INTERVAL_MS) return;
   _lastBroadcastMs = now;
 

--- a/tests/unit/dashboard_inferred_candidate_decision.test.js
+++ b/tests/unit/dashboard_inferred_candidate_decision.test.js
@@ -11,6 +11,8 @@ const mocks = vi.hoisted(() => ({
     inferredCandidateStore: {}
   },
   saveUnifiedStorageDurably: vi.fn(async () => ({ ok: true, backend: "test", reason: "saved" })),
+  sendRelayFilament: vi.fn(() => true),
+  getRelayMode: vi.fn(() => "standalone"),
   eventSeq: 0
 }));
 
@@ -29,8 +31,8 @@ vi.mock("../../3dp_lib/dashboard_printmanager.js", () => ({
 }));
 vi.mock("../../3dp_lib/dashboard_connection.js", () => ({ getDisplayBaseUrl: vi.fn(() => "") }));
 vi.mock("../../3dp_lib/dashboard_client_sync.js", () => ({
-  sendRelayFilament: vi.fn(),
-  getRelayMode: vi.fn(() => "standalone")
+  sendRelayFilament: mocks.sendRelayFilament,
+  getRelayMode: mocks.getRelayMode
 }));
 vi.mock("../../3dp_lib/dashboard_filament_ledger.js", () => ({
   appendMountEvent: vi.fn(),
@@ -52,10 +54,12 @@ const {
 } = await import("../../3dp_lib/dashboard_offline_candidate_store.js");
 const {
   canExecuteLedgerDecision,
+  canSubmitLedgerDecision,
   confirmInferredCandidate,
   rejectInferredCandidate,
   reassignInferredCandidate
 } = await import("../../3dp_lib/dashboard_inferred_candidate_decision.js");
+const { sendRelayFilament } = await import("../../3dp_lib/dashboard_client_sync.js");
 
 /**
  * observation key を持つ履歴 fixture を作る。
@@ -129,6 +133,10 @@ function candidate(over = {}) {
 beforeEach(() => {
   mocks.saveUnifiedStorageDurably.mockReset();
   mocks.saveUnifiedStorageDurably.mockResolvedValue({ ok: true, backend: "test", reason: "saved" });
+  mocks.sendRelayFilament.mockReset();
+  mocks.sendRelayFilament.mockReturnValue(true);
+  mocks.getRelayMode.mockReset();
+  mocks.getRelayMode.mockReturnValue("standalone");
   mocks.eventSeq = 0;
   delete globalThis.window;
   mocks.monitorData.machines = {
@@ -154,9 +162,53 @@ describe("canExecuteLedgerDecision", () => {
     const result = await confirmInferredCandidate("ic-a", { nowMs: 11000 });
 
     expect(canExecuteLedgerDecision()).toBe(false);
+    expect(canSubmitLedgerDecision()).toBe(false);
     expect(result.ok).toBe(false);
     expect(result.reason).toBe("decision_not_authorized");
     expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(10000);
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+
+  it("satellite 操作モードではローカル台帳を書かず Parent へ decision request を送る", async () => {
+    globalThis.window = { _3dpmonRelayChild: true };
+    mocks.getRelayMode.mockReturnValue("satellite");
+
+    const result = await confirmInferredCandidate("ic-a", { actor: "operator", nowMs: 11000 });
+
+    expect(canExecuteLedgerDecision()).toBe(false);
+    expect(canSubmitLedgerDecision()).toBe(true);
+    expect(result).toMatchObject({
+      ok: true,
+      reason: "decision_requested",
+      relayed: true,
+      action: "confirmInferredCandidate",
+      candidateHash: "ic-a"
+    });
+    expect(sendRelayFilament).toHaveBeenCalledWith("confirmInferredCandidate", {
+      candidateHash: "ic-a",
+      actor: "operator"
+    });
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(10000);
+    expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.PENDING);
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+
+  it("satellite request 送信に失敗した場合は未処理として返す", async () => {
+    globalThis.window = { _3dpmonRelayChild: true };
+    mocks.getRelayMode.mockReturnValue("satellite");
+    mocks.sendRelayFilament.mockReturnValue(false);
+
+    const result = await rejectInferredCandidate("ic-a", { actor: "operator", reason: "other", note: "skip" });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("decision_request_not_sent");
+    expect(sendRelayFilament).toHaveBeenCalledWith("rejectInferredCandidate", {
+      candidateHash: "ic-a",
+      actor: "operator",
+      reason: "other",
+      note: "skip"
+    });
+    expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.PENDING);
     expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/dashboard_inferred_candidate_ui.test.js
+++ b/tests/unit/dashboard_inferred_candidate_ui.test.js
@@ -167,4 +167,23 @@ describe("createInferredCandidateCenterContent", () => {
     expect(document.querySelector(".ic-readonly-note").textContent).toContain("親端末");
     expect(mocks.confirmInferredCandidate).not.toHaveBeenCalled();
   });
+
+  it("Satellite decision request 成功は親端末への送信として通知する", async () => {
+    mocks.confirmInferredCandidate.mockResolvedValueOnce({
+      ok: true,
+      reason: "decision_requested",
+      relayed: true,
+      action: "confirmInferredCandidate",
+      candidateHash: "ic-a"
+    });
+    const center = createInferredCandidateCenterContent();
+    document.body.appendChild(center.el);
+
+    center.el.querySelector("tbody .ic-open-button").click();
+    document.querySelector(".ic-action-primary").click();
+
+    await waitForAssertion(() => {
+      expect(mocks.showAlert).toHaveBeenCalledWith("親端末へ送信しました", "success");
+    });
+  });
 });

--- a/tests/unit/dashboard_inferred_candidate_view.test.js
+++ b/tests/unit/dashboard_inferred_candidate_view.test.js
@@ -10,12 +10,12 @@ const mocks = vi.hoisted(() => ({
     filamentSpools: [],
     inferredCandidateStore: {}
   },
-  canExecute: true
+  canSubmit: true
 }));
 
 vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mocks.monitorData }));
 vi.mock("../../3dp_lib/dashboard_inferred_candidate_decision.js", () => ({
-  canExecuteLedgerDecision: () => mocks.canExecute
+  canSubmitLedgerDecision: () => mocks.canSubmit
 }));
 vi.mock("../../3dp_lib/dashboard_spool.js", () => ({
   formatFilamentAmount: (mm) => ({ display: `${Math.round(Number(mm)).toLocaleString()} mm` }),
@@ -60,7 +60,7 @@ function record(hash, over = {}) {
 }
 
 beforeEach(() => {
-  mocks.canExecute = true;
+  mocks.canSubmit = true;
   mocks.monitorData.machines = {
     k1: {
       storedData: { hostname: { rawValue: "K1 Max" } },
@@ -100,7 +100,7 @@ describe("buildInferredCandidateViewModel", () => {
   });
 
   it("Satellite相当では閲覧専用 warning と操作不可を返す", () => {
-    mocks.canExecute = false;
+    mocks.canSubmit = false;
 
     const vm = buildInferredCandidateViewModel(mocks.monitorData.inferredCandidateStore["ic-new"]);
 
@@ -109,6 +109,17 @@ describe("buildInferredCandidateViewModel", () => {
     expect(vm.canReassign).toBe(false);
     expect(vm.readOnlyReason).toBe("relay-readonly");
     expect(vm.warningCodes).toContain("relay-readonly");
+  });
+
+  it("Satellite request が可能な場合は操作ボタンを有効化する", () => {
+    mocks.canSubmit = true;
+
+    const vm = buildInferredCandidateViewModel(mocks.monitorData.inferredCandidateStore["ic-new"]);
+
+    expect(vm.canConfirm).toBe(true);
+    expect(vm.canReject).toBe(true);
+    expect(vm.canReassign).toBe(true);
+    expect(vm.readOnlyReason).toBeNull();
   });
 
   it("O4保存後に履歴が帰属済みになった場合は警告へ出す", () => {

--- a/tests/unit/dashboard_relay_bridge_filament_ops.test.js
+++ b/tests/unit/dashboard_relay_bridge_filament_ops.test.js
@@ -38,6 +38,11 @@ vi.mock("../../3dp_lib/dashboard_spool.js", () => ({
 vi.mock("../../3dp_lib/dashboard_filament_ledger.js", () => ({
   resolveFilamentEvent: vi.fn(),
 }));
+vi.mock("../../3dp_lib/dashboard_inferred_candidate_decision.js", () => ({
+  confirmInferredCandidate: vi.fn(async () => ({ ok: true, reason: "confirmed" })),
+  rejectInferredCandidate: vi.fn(async () => ({ ok: true, reason: "rejected" })),
+  reassignInferredCandidate: vi.fn(async () => ({ ok: true, reason: "reassigned" })),
+}));
 vi.mock("../../3dp_lib/dashboard_filament_inventory.js", () => ({
   setInventoryQuantity: vi.fn(),
   adjustInventory: vi.fn(),
@@ -60,6 +65,7 @@ vi.mock("../../3dp_lib/dashboard_storage.js", () => ({
 const { handleRelayFilamentAction } = await import("../../3dp_lib/dashboard_relay_bridge.js");
 const spool = await import("../../3dp_lib/dashboard_spool.js");
 const ledger = await import("../../3dp_lib/dashboard_filament_ledger.js");
+const decision = await import("../../3dp_lib/dashboard_inferred_candidate_decision.js");
 const inventory = await import("../../3dp_lib/dashboard_filament_inventory.js");
 const presets = await import("../../3dp_lib/dashboard_filament_presets.js");
 const { saveUnifiedStorage } = await import("../../3dp_lib/dashboard_storage.js");
@@ -139,6 +145,43 @@ describe("handleRelayFilamentAction — 親側 RPC ディスパッチ", () => {
     await handleRelayFilamentAction("resolveFilamentEvent", { host: "h1", resolution: "reseat", evId: "fctx_h1_100" });
     expect(ledger.resolveFilamentEvent).toHaveBeenCalledWith("h1", "reseat", { expectedEvId: "fctx_h1_100" });
     expect(saveUnifiedStorage).toHaveBeenCalled();
+  });
+
+  it("O5 decision request → 親の Decision Core へ委譲する", async () => {
+    await handleRelayFilamentAction("confirmInferredCandidate", {
+      candidateHash: "ic-a",
+      actor: "satellite-user",
+      _opId: "o5-confirm-1"
+    });
+    expect(decision.confirmInferredCandidate).toHaveBeenCalledWith("ic-a", { actor: "satellite-user" });
+
+    await handleRelayFilamentAction("rejectInferredCandidate", {
+      candidateHash: "ic-b",
+      actor: "satellite-user",
+      reason: "other",
+      note: "wrong spool",
+      _opId: "o5-reject-1"
+    });
+    expect(decision.rejectInferredCandidate).toHaveBeenCalledWith("ic-b", {
+      actor: "satellite-user",
+      reason: "other",
+      note: "wrong spool"
+    });
+
+    await handleRelayFilamentAction("reassignInferredCandidate", {
+      candidateHash: "ic-c",
+      targetSpoolId: "S2",
+      actor: "satellite-user",
+      _opId: "o5-reassign-1"
+    });
+    expect(decision.reassignInferredCandidate).toHaveBeenCalledWith("ic-c", "S2", { actor: "satellite-user" });
+  });
+
+  it("O5 decision request は opId 重複排除の対象になる", async () => {
+    await handleRelayFilamentAction("confirmInferredCandidate", { candidateHash: "ic-a", _opId: "o5-dup-1" });
+    await handleRelayFilamentAction("confirmInferredCandidate", { candidateHash: "ic-a", _opId: "o5-dup-1" });
+
+    expect(decision.confirmInferredCandidate).toHaveBeenCalledTimes(1);
   });
 
   it("opId 重複排除: 同一 opId の非冪等操作は2回目を実行しない (#1)", async () => {


### PR DESCRIPTION
## Summary
- Add O5C satellite decision requests for inferred filament candidates.
- Route Satellite Confirm/Reject/Reassign calls through `sendRelayFilament` instead of mutating local ledger state.
- Dispatch the new O5 relay actions on the Parent through the existing Decision Core.
- Enable Candidate Center actions when a Satellite can submit a parent request, while readonly children remain disabled.
- Extend tests for satellite request routing, parent relay dispatch, duplicate opId suppression, and UI request feedback.

## Safety Notes
- Satellite clients still never write confirmed ledger or candidate state locally.
- Parent remains the only authority that applies O5 decisions and runs durable save/rollback logic.
- O5 relay actions are non-idempotent and receive the existing `_opId` duplicate protection.
- Relay timing now uses `wallNowMs()` on the touched send/dispatch paths.

## Verification
- `npx vitest run tests/unit/dashboard_inferred_candidate_decision.test.js tests/unit/dashboard_inferred_candidate_view.test.js tests/unit/dashboard_inferred_candidate_ui.test.js tests/unit/dashboard_relay_bridge_filament_ops.test.js tests/unit/dashboard_client_sync_filament_sync.test.js`
- `npx eslint 3dp_lib/dashboard_inferred_candidate_decision.js 3dp_lib/dashboard_inferred_candidate_view.js 3dp_lib/dashboard_inferred_candidate_ui.js 3dp_lib/dashboard_client_sync.js 3dp_lib/dashboard_relay_bridge.js tests/unit/dashboard_inferred_candidate_decision.test.js tests/unit/dashboard_inferred_candidate_view.test.js tests/unit/dashboard_inferred_candidate_ui.test.js tests/unit/dashboard_relay_bridge_filament_ops.test.js` (0 errors; existing warnings remain)
- `npx vitest run`