### PR TITLE
Add filament recovery surface diagnostics

### DIFF
--- a/3dp_lib/dashboard_client_sync.js
+++ b/3dp_lib/dashboard_client_sync.js
@@ -10,7 +10,7 @@
  * 【機能内容サマリ】
  * - 親リレーサーバへの WebSocket 接続
  * - relay-snapshot / relay-delta の受信と monitorData への反映
- *   （フィラメント共有状態は親権威の全置換 + mountHistory 同期）
+ *   （フィラメント共有状態は親権威の全置換 + mountHistory / recovery 診断同期）
  * - satellite モードでのコマンド/フィラメント操作の送信（操作は親へ RPC 委譲）
  * - O5 inferred candidate decision request を Parent へ送信
  * - 初回接続は常に readonly。?relay=satellite 要求時は自動昇格リクエスト（PIN 保護）
@@ -21,9 +21,9 @@
  * - {@link sendRelayCommand}：親経由でプリンタにコマンド送信
  * - {@link sendRelayFilament}：親経由でフィラメント操作
  *
- * @version 1.390.1264 (PR #417)
+ * @version 1.390.1268 (PR #418)
  * @since   1.390.820 (PR #367)
- * @lastModified 2026-07-25 22:09:00
+ * @lastModified 2026-08-01 23:20:09
  * -----------------------------------------------------------
  */
 
@@ -297,7 +297,7 @@ function _applyRelayPrintStore(hostname, ps) {
 }
 
 /**
- * 親から受信した共有フィラメント状態（filamentSpools / hostSpoolMap / mountHistory）を
+ * 親から受信した共有フィラメント状態（filamentSpools / hostSpoolMap / mountHistory / recovery 診断）を
  * monitorData へ「全置換」で適用する。
  *
  * 【詳細説明】
@@ -313,7 +313,7 @@ function _applyRelayPrintStore(hostname, ps) {
  * ※ モジュール内部用だが、マージ規則の回帰テストのために export している。
  *
  * @function _applySharedFilamentState
- * @param {{filamentSpools?:Array<Object>, hostSpoolMap?:Object, mountHistory?:Array<Object>, pendingUnattributedUsage?:Array<Object>, inferredCandidateStore?:Object}} shared
+ * @param {{filamentSpools?:Array<Object>, hostSpoolMap?:Object, mountHistory?:Array<Object>, pendingUnattributedUsage?:Array<Object>, inferredCandidateStore?:Object, inferredDecisionRecoveryRequired?:Object|null, ledgerRepairRequired?:Object, mountHistoryRejectedEvents?:Array<Object>}} shared
  *   - 受信した共有データ
  * @returns {void}
  */
@@ -366,6 +366,28 @@ export function _applySharedFilamentState(shared) {
     for (const k of Object.keys(store)) delete store[k];
     Object.assign(store, shared.inferredCandidateStore);
   }
+  // ★ #418: Recovery / repair 診断も親が権威。Satellite ではローカル復旧状態を推測せず、
+  //   親が送った状態をそのまま read-only 表示へ使う。欠落時は部分deltaとして不変、
+  //   null/{} / [] は「親で解消済み」の明示状態として反映する。
+  if (Object.prototype.hasOwnProperty.call(shared, "inferredDecisionRecoveryRequired")) {
+    monitorData.inferredDecisionRecoveryRequired =
+      shared.inferredDecisionRecoveryRequired && typeof shared.inferredDecisionRecoveryRequired === "object"
+        ? { ...shared.inferredDecisionRecoveryRequired }
+        : null;
+  }
+  if (Object.prototype.hasOwnProperty.call(shared, "ledgerRepairRequired")
+      && shared.ledgerRepairRequired
+      && typeof shared.ledgerRepairRequired === "object") {
+    if (!monitorData.ledgerRepairRequired || typeof monitorData.ledgerRepairRequired !== "object") {
+      monitorData.ledgerRepairRequired = {};
+    }
+    for (const k of Object.keys(monitorData.ledgerRepairRequired)) delete monitorData.ledgerRepairRequired[k];
+    Object.assign(monitorData.ledgerRepairRequired, shared.ledgerRepairRequired);
+  }
+  if (Object.prototype.hasOwnProperty.call(shared, "mountHistoryRejectedEvents")) {
+    if (!Array.isArray(monitorData.mountHistoryRejectedEvents)) monitorData.mountHistoryRejectedEvents = [];
+    _replaceArrayInPlace(monitorData.mountHistoryRejectedEvents, shared.mountHistoryRejectedEvents);
+  }
   if (shared.filamentEventContext && typeof shared.filamentEventContext === "object") {
     if (!monitorData.filamentEventContext || typeof monitorData.filamentEventContext !== "object") {
       monitorData.filamentEventContext = {};
@@ -394,7 +416,7 @@ let _prevDomainSig = "";
  * remainingLengthMm が毎 tick 変化する。これを毎回管理画面の全再描画に繋げると
  * テーブルを 2回/秒で再構築し CPU を圧迫する（近年の描画律速修正に逆行する）。
  * よって残量そのものはシグネチャに含めず、スプール集合・在庫数量・プリセット集合・
- * serialCounter・使用履歴件数など「表示の構造」が変わったときだけ再描画する。
+ * serialCounter・使用履歴件数・recovery診断など「表示の構造」が変わったときだけ再描画する。
  * 残量のライブ表示はフィラメントプレビュー（dirty-key 経路）が別途担う。
  *
  * @private
@@ -410,6 +432,9 @@ function _maybeNotifyFilamentDomainChanged() {
     (monitorData.favoritePresets || []).join(","),
     monitorData.spoolSerialCounter ?? 0,
     (monitorData.usageHistory || []).length,
+    JSON.stringify(monitorData.inferredDecisionRecoveryRequired || null),
+    JSON.stringify(monitorData.ledgerRepairRequired || {}),
+    JSON.stringify(monitorData.mountHistoryRejectedEvents || []),
   ].join("|");
   if (sig === _prevDomainSig) return;
   _prevDomainSig = sig;

--- a/3dp_lib/dashboard_inferred_candidate_ui.js
+++ b/3dp_lib/dashboard_inferred_candidate_ui.js
@@ -11,13 +11,14 @@
  * - O5B Candidate Center として pending/処理済み candidate の一覧、詳細、監査 timeline を描画する。
  * - Confirm / Reject / Reassign / Undo の操作ダイアログを提供し、実更新は Decision Core へ委譲する。
  * - SATELLITE 子では Parent へ decision request を送り、readonly 子では操作ボタンを disabled にする。
+ * - recovery / repair flag は read-only 診断カードとして表示し、復旧操作は後続PRへ分離する。
  *
  * 【公開関数一覧】
  * - {@link createInferredCandidateCenterContent}：フィラメント管理モーダル用 Candidate Center を生成する
  *
- * @version 1.390.1266 (PR #417)
+ * @version 1.390.1267 (PR #418)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-07-26 11:03:46
+ * @lastModified 2026-07-26 15:48:10
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -35,6 +36,7 @@ import {
 import {
   INFERRED_CANDIDATE_FILTER,
   INFERRED_CANDIDATE_SORT,
+  buildInferredRecoverySurfaceViewModel,
   buildInferredCandidateViewModel,
   countPendingInferredCandidates,
   listInferredCandidateViewModels
@@ -252,6 +254,61 @@ function _warningChips(codes) {
     wrap.appendChild(_el("span", "ic-warning-chip", WARNING_LABELS[code] || code));
   }
   return wrap;
+}
+
+/**
+ * recovery / repair 診断カードを生成する。
+ *
+ * 【詳細説明】
+ * - #418 では復旧操作を持たせず、異常状態を read-only で見えるようにする。
+ * - card.details は ViewModel 層で表示可能な文字列へ整形済みなので、ここでは DOM を組み立てるだけにする。
+ *
+ * @private
+ * @function _recoveryCard
+ * @param {Object} card - recovery surface card ViewModel。
+ * @returns {HTMLElement} card 要素。
+ */
+function _recoveryCard(card) {
+  const el = _el("article", `ic-recovery-card ic-recovery-${card.severity || "warning"}`);
+  const header = _el("div", "ic-recovery-card-header");
+  header.append(
+    _el("span", "ic-recovery-severity", card.severity === "blocker" ? "BLOCKER" : "WARNING"),
+    _el("strong", "ic-recovery-title", card.title || "Recovery item")
+  );
+  el.append(header, _el("p", "ic-recovery-summary", card.summary || ""));
+  const detailWrap = _el("div", "ic-recovery-details");
+  for (const detail of card.details || []) {
+    detailWrap.appendChild(_kv(detail.label, detail.value));
+  }
+  if (detailWrap.childNodes.length > 0) el.appendChild(detailWrap);
+  return el;
+}
+
+/**
+ * recovery / repair 診断サーフェスを描画する。
+ *
+ * 【詳細説明】
+ * - recovery item が無い場合は空要素のままにし、Candidate Center の通常操作を邪魔しない。
+ * - blocker は decision guard と連動する状態なので、件数サマリを先頭へ出す。
+ *
+ * @private
+ * @function _renderRecoverySurface
+ * @param {HTMLElement} wrap - 描画先。
+ * @returns {void}
+ */
+function _renderRecoverySurface(wrap) {
+  const model = buildInferredRecoverySurfaceViewModel();
+  wrap.innerHTML = "";
+  if (!model.hasIssues) return;
+  const panel = _el("section", "ic-recovery-surface");
+  panel.appendChild(_el("h4", "", "Recovery / repair status"));
+  panel.appendChild(_el(
+    "div",
+    "ic-recovery-overview",
+    `Blocker ${model.blockerCount} / Warning ${model.warningCount}`
+  ));
+  for (const card of model.cards) panel.appendChild(_recoveryCard(card));
+  wrap.appendChild(panel);
 }
 
 /**
@@ -610,6 +667,7 @@ function _row(vm, render, onAfterDecision) {
  */
 export function createInferredCandidateCenterContent(options = {}) {
   const root = _el("div", "filament-manager-content ic-center");
+  const recoveryWrap = _el("div", "ic-recovery-wrap");
   const toolbar = _el("div", "ic-toolbar");
   const count = _el("span", "ic-count");
   const statusSelect = document.createElement("select");
@@ -643,7 +701,7 @@ export function createInferredCandidateCenterContent(options = {}) {
   const refreshBtn = _el("button", "ic-open-button", "Refresh");
   toolbar.append(count, statusSelect, sortSelect, refreshBtn);
   const body = _el("div", "ic-list-wrap");
-  root.append(toolbar, body);
+  root.append(recoveryWrap, toolbar, body);
 
   /**
    * Candidate Center の一覧表示を最新 store から再構築する。
@@ -656,6 +714,7 @@ export function createInferredCandidateCenterContent(options = {}) {
    * @returns {void} 戻り値はない。
    */
   function render() {
+    _renderRecoverySurface(recoveryWrap);
     const models = listInferredCandidateViewModels({
       status: statusSelect.value,
       sort: sortSelect.value,

--- a/3dp_lib/dashboard_inferred_candidate_view.js
+++ b/3dp_lib/dashboard_inferred_candidate_view.js
@@ -10,16 +10,18 @@
  * 【機能内容サマリ】
  * - inferredCandidateStore の保存レコードから O5 UI 用 ViewModel を生成する。
  * - status filter、sort、pending count、残量差分、履歴照合警告、decision/undo 送信可否を計算する。
+ * - recovery / repair flag を read-only 診断カードへ変換し、異常系を操作前に見える状態にする。
  * - UI が candidate record や確定台帳を直接変更しないための表示専用境界を提供する。
  *
  * 【公開関数一覧】
  * - {@link buildInferredCandidateViewModel}：candidate record 1件を表示モデルへ変換する
  * - {@link listInferredCandidateViewModels}：candidate 一覧表示モデルを生成する
  * - {@link countPendingInferredCandidates}：pending candidate 件数を返す
+ * - {@link buildInferredRecoverySurfaceViewModel}：recovery / repair 状態を診断表示モデルへ変換する
  *
- * @version 1.390.1264 (PR #417)
+ * @version 1.390.1267 (PR #418)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-07-25 22:09:00
+ * @lastModified 2026-07-26 15:48:10
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -180,6 +182,48 @@ function _formatTime(epochMs) {
   } catch {
     return "--";
   }
+}
+
+/**
+ * 任意値を表示用の短い文字列へ変換する。
+ *
+ * 【詳細説明】
+ * - recovery flag には save/rollback などの object が入る場合があるため、UI では重要な
+ *   先頭情報だけを読めるよう JSON 化する。
+ * - 表示不能な値は `"--"` に寄せ、診断カード生成で例外を出さない。
+ *
+ * @private
+ * @function _formatValue
+ * @param {*} value - 表示対象値。
+ * @returns {string} 表示文字列。
+ */
+function _formatValue(value) {
+  if (value == null || value === "") return "--";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * recovery surface 用の key/value 配列を生成する。
+ *
+ * 【詳細説明】
+ * - undefined/null/空文字の値は表示対象から外し、カード内の情報量を絞る。
+ * - reason や candidateHash など、修復対象を特定するための値だけを上位で指定して渡す。
+ *
+ * @private
+ * @function _details
+ * @param {Array<{label:string,value:*}>} entries - detail 候補。
+ * @returns {Array<{label:string,value:string}>} 表示可能な detail。
+ */
+function _details(entries) {
+  return entries
+    .filter(item => item && item.value != null && item.value !== "")
+    .map(item => ({ label: item.label, value: _formatValue(item.value) }));
 }
 
 /**
@@ -428,4 +472,105 @@ export function countPendingInferredCandidates(host = null) {
     host,
     canSubmit: true
   }).length;
+}
+
+/**
+ * O5/ledger の recovery / repair 状態を read-only 診断表示モデルへ変換する。
+ *
+ * 【詳細説明】
+ * - この関数は monitorData を参照するだけで、recovery flag の解除や candidate 遷移は行わない。
+ * - `inferredDecisionRecoveryRequired` は新規 decision を止める blocker として表示する。
+ * - `ledgerRepairRequired` は host 単位の mount ledger 修復要求として表示する。
+ * - `mountHistoryRejectedEvents` は隔離済みイベントの件数と最新数件を表示し、元データが失われていない
+ *   ことをオペレーターが確認できるようにする。
+ *
+ * @function buildInferredRecoverySurfaceViewModel
+ * @param {{maxRejectedEvents?:number}} [options] - 表示する隔離イベントの最大件数。
+ * @returns {{hasIssues:boolean,totalCount:number,blockerCount:number,warningCount:number,cards:Array<Object>}}
+ *   recovery surface 表示モデル。
+ * @example
+ * const recovery = buildInferredRecoverySurfaceViewModel();
+ */
+export function buildInferredRecoverySurfaceViewModel(options = {}) {
+  const cards = [];
+  const recovery = monitorData.inferredDecisionRecoveryRequired;
+  if (recovery && typeof recovery === "object") {
+    cards.push({
+      type: "decision-recovery",
+      severity: "blocker",
+      title: "O5 decision recovery required",
+      summary: "保存失敗後のrollback状態を確認するまで、新しいcandidate decisionは停止されます",
+      host: recovery.host || null,
+      candidateHash: recovery.candidateHash || null,
+      createdAt: Number(recovery.createdAt) || 0,
+      createdAtDisplay: _formatTime(recovery.createdAt),
+      details: _details([
+        { label: "Action", value: recovery.action },
+        { label: "Reason", value: recovery.reason },
+        { label: "Candidate", value: recovery.candidateHash },
+        { label: "Save", value: recovery.save?.reason },
+        { label: "Rollback save", value: recovery.rollbackSave?.reason }
+      ])
+    });
+  }
+
+  const repair = monitorData.ledgerRepairRequired && typeof monitorData.ledgerRepairRequired === "object"
+    ? monitorData.ledgerRepairRequired
+    : {};
+  for (const [host, item] of Object.entries(repair)) {
+    if (!item || typeof item !== "object") continue;
+    cards.push({
+      type: "ledger-repair",
+      severity: "blocker",
+      title: "Mount ledger repair required",
+      summary: `${_hostLabel(host)} の装着区間が曖昧なため、暗黙クローズを停止しています`,
+      host,
+      candidateHash: null,
+      createdAt: Number(item.detectedAtEpochMs) || 0,
+      createdAtDisplay: _formatTime(item.detectedAtEpochMs),
+      details: _details([
+        { label: "Host", value: _hostLabel(host) },
+        { label: "Spool", value: item.spoolId },
+        { label: "Status", value: item.status },
+        { label: "Detected", value: _formatTime(item.detectedAtEpochMs) }
+      ])
+    });
+  }
+
+  const rejected = Array.isArray(monitorData.mountHistoryRejectedEvents)
+    ? monitorData.mountHistoryRejectedEvents
+    : [];
+  const maxRejected = Math.max(1, Math.min(10, Number(options.maxRejectedEvents) || 3));
+  if (rejected.length > 0) {
+    const recent = rejected.slice(-maxRejected).reverse();
+    cards.push({
+      type: "mount-history-rejected",
+      severity: "warning",
+      title: "Rejected mount history events",
+      summary: `${rejected.length}件の mountHistory event が隔離されています`,
+      host: null,
+      candidateHash: null,
+      createdAt: 0,
+      createdAtDisplay: "--",
+      details: recent.map((item, index) => ({
+        label: `Rejected ${index + 1}`,
+        value: _formatValue({
+          reason: item?.reason || "unknown",
+          host: item?.event?.host || null,
+          spoolId: item?.event?.spoolId || null,
+          evId: item?.event?.evId || null
+        })
+      }))
+    });
+  }
+
+  const blockerCount = cards.filter(card => card.severity === "blocker").length;
+  const warningCount = cards.filter(card => card.severity !== "blocker").length;
+  return {
+    hasIssues: cards.length > 0,
+    totalCount: cards.length,
+    blockerCount,
+    warningCount,
+    cards
+  };
 }

--- a/3dp_lib/dashboard_relay_bridge.js
+++ b/3dp_lib/dashboard_relay_bridge.js
@@ -9,7 +9,7 @@
  *
  * 【機能内容サマリ】
  * - aggregator 更新後に dirty keys を収集し、リレーサーバにブロードキャスト
- *   （filamentSpools / hostSpoolMap / mountHistory の共有状態を含む）
+ *   （filamentSpools / hostSpoolMap / mountHistory / recovery 診断の共有状態を含む）
  * - 子（satellite）からのコマンド/フィラメント操作 RPC を受信し親側で実行
  * - 子（satellite）からの O5 inferred candidate decision request を親側で実行
  * - 新規子クライアント接続時にフルスナップショットを送信
@@ -21,9 +21,9 @@
  * - {@link buildCameraEndpoints}：カメラパススルー用エンドポイントを構築する
  * - {@link relayBroadcastIfNeeded}：変更があれば子へデルタ配信する
  *
- * @version 1.390.1264 (PR #417)
+ * @version 1.390.1268 (PR #418)
  * @since   1.390.820 (PR #367)
- * @lastModified 2026-07-25 22:09:00
+ * @lastModified 2026-08-01 23:20:09
  * -----------------------------------------------------------
  */
 
@@ -51,6 +51,9 @@ let _prevPendingHash = "";
 
 /** 前回ブロードキャストした inferredCandidateStore（オフライン推定候補）のハッシュ（変更検出） */
 let _prevInferredCandidateHash = "";
+
+/** 前回ブロードキャストした recovery / repair 診断状態のハッシュ（変更検出） */
+let _prevRecoveryHash = "";
 
 /** 前回ブロードキャストした ItemKeeper 設定のハッシュ（変更検出） */
 let _prevIkHash = "";
@@ -690,6 +693,23 @@ function _buildDelta() {
     hasChanges = true;
   }
 
+  // ★ #418: recovery / repair 診断は Parent が権威を持つ。
+  //   Candidate Center の read-only 診断を Satellite でも親と一致させるため、
+  //   candidate store とは別ハッシュで低頻度同期する。
+  const recoveryHash = _quickHash(
+    monitorData.inferredDecisionRecoveryRequired || null,
+    monitorData.ledgerRepairRequired || {},
+    monitorData.mountHistoryRejectedEvents || []
+  );
+  if (recoveryHash !== _prevRecoveryHash) {
+    _prevRecoveryHash = recoveryHash;
+    sharedDelta = sharedDelta || {};
+    sharedDelta.inferredDecisionRecoveryRequired = monitorData.inferredDecisionRecoveryRequired || null;
+    sharedDelta.ledgerRepairRequired = monitorData.ledgerRepairRequired || {};
+    sharedDelta.mountHistoryRejectedEvents = monitorData.mountHistoryRejectedEvents || [];
+    hasChanges = true;
+  }
+
   // ★ 監査 P0(第2報): フィラメント補助ドメイン（在庫・カスタムプリセット・表示/
   //   お気に入り・切れ文脈・serialCounter・使用履歴）の変更検出。従来は
   //   filamentSpools/hostSpoolMap/mountHistory のみ共有していたため、これらが親子で
@@ -799,6 +819,10 @@ function _buildFullSnapshot() {
     pendingUnattributedUsageArchive: monitorData.pendingUnattributedUsageArchive || {},
     // ★ #412-O4: 子は分類済み candidate と推定量だけを受け取り、生観測は受け取らない。
     inferredCandidateStore: monitorData.inferredCandidateStore || {},
+    // ★ #418: Candidate Center の Recovery / repair 診断も親権威で子へ同梱する。
+    inferredDecisionRecoveryRequired: monitorData.inferredDecisionRecoveryRequired || null,
+    ledgerRepairRequired: monitorData.ledgerRepairRequired || {},
+    mountHistoryRejectedEvents: monitorData.mountHistoryRejectedEvents || [],
     // ★ 監査 P0(第2報): フィラメント補助ドメインをスナップショットにも同梱（親=権威）。
     filamentInventory: monitorData.filamentInventory || [],
     userPresets: monitorData.userPresets || [],

--- a/3dp_panel.css
+++ b/3dp_panel.css
@@ -3929,6 +3929,67 @@ body.relay-readonly textarea {
   font-size: var(--font-sm);
   font-weight: bold;
 }
+.ic-recovery-wrap {
+  display: block;
+}
+
+.ic-recovery-surface {
+  border: 1px solid var(--color-warning);
+  border-radius: var(--radius-sm);
+  background: var(--color-warning-bg);
+  color: var(--color-warning-text);
+  padding: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.ic-recovery-surface h4 {
+  margin: 0 0 var(--space-1);
+  font-size: var(--font-base);
+}
+
+.ic-recovery-overview {
+  font-size: var(--font-sm);
+  font-weight: bold;
+  margin-bottom: var(--space-2);
+}
+
+.ic-recovery-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  padding: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.ic-recovery-blocker {
+  border-color: var(--color-danger);
+}
+
+.ic-recovery-card-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.ic-recovery-severity {
+  border-radius: var(--radius-full);
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  font-size: var(--font-xs);
+  font-weight: bold;
+  padding: 1px var(--space-2);
+}
+
+.ic-recovery-summary {
+  margin: var(--space-1) 0;
+  font-size: var(--font-sm);
+}
+
+.ic-recovery-details {
+  margin-top: var(--space-1);
+}
 .ic-list-wrap {
   flex: 1;
   min-height: 0;

--- a/docs/en/filament_manual.md
+++ b/docs/en/filament_manual.md
@@ -123,6 +123,15 @@ Reject, Reassign and Undo. Satellite devices can view candidates. When a
 Satellite is promoted to operation mode, decision requests are sent to
 the Parent; readonly Satellites keep the action buttons disabled.
 
+When required, the top of the Inferred Candidate tab shows a Recovery /
+repair status surface. This is a read-only diagnostic view for states
+such as `inferredDecisionRecoveryRequired`, `ledgerRepairRequired` and
+`mountHistoryRejectedEvents`, where the app must not continue
+automatically. It shows the related candidate, host, spool, save-failure
+reason and quarantined mountHistory events. In #418 this surface does not
+run repair or clear flags; those actions are intentionally left for the
+later Recovery Actions slice.
+
 ### Registered Filament Tab
 
 The Registered Filament tab lists all spools that have been added so far and lets you edit them.

--- a/docs/en/filament_manual.md
+++ b/docs/en/filament_manual.md
@@ -128,9 +128,10 @@ repair status surface. This is a read-only diagnostic view for states
 such as `inferredDecisionRecoveryRequired`, `ledgerRepairRequired` and
 `mountHistoryRejectedEvents`, where the app must not continue
 automatically. It shows the related candidate, host, spool, save-failure
-reason and quarantined mountHistory events. In #418 this surface does not
-run repair or clear flags; those actions are intentionally left for the
-later Recovery Actions slice.
+reason and quarantined mountHistory events. In Relay setups, Satellites
+mirror this diagnostic state from the Parent authority. In #418 this
+surface does not run repair or clear flags; those actions are intentionally
+left for the later Recovery Actions slice.
 
 ### Registered Filament Tab
 

--- a/docs/ja/filament_manual.md
+++ b/docs/ja/filament_manual.md
@@ -92,6 +92,8 @@ monitorData.hostSpoolMap = {
 
 Relay 構成では、Standalone と Parent は Confirm / Reject / Reassign / Undo を実行できます。Satellite は候補を閲覧でき、操作モードに昇格している場合は Parent へ decision request を送ります。Readonly の Satellite では操作ボタンは無効化されます。
 
+推定候補タブの上部には、必要に応じて Recovery / repair status が表示されます。これは `inferredDecisionRecoveryRequired`、`ledgerRepairRequired`、`mountHistoryRejectedEvents` など、自動継続してはいけない状態を確認するための読み取り専用診断です。表示された場合は、原因となった candidate、host、spool、保存失敗理由、隔離された mountHistory event を確認できます。#418 時点ではこの画面から修復や解除は実行せず、整合確認と復旧操作は後続の Recovery Actions で扱います。
+
 ### 登録済みフィラメントタブ
 
 登録済みフィラメントタブでは、過去に登録したスプールを一覧で確認し編集できます。

--- a/docs/ja/filament_manual.md
+++ b/docs/ja/filament_manual.md
@@ -92,7 +92,7 @@ monitorData.hostSpoolMap = {
 
 Relay 構成では、Standalone と Parent は Confirm / Reject / Reassign / Undo を実行できます。Satellite は候補を閲覧でき、操作モードに昇格している場合は Parent へ decision request を送ります。Readonly の Satellite では操作ボタンは無効化されます。
 
-推定候補タブの上部には、必要に応じて Recovery / repair status が表示されます。これは `inferredDecisionRecoveryRequired`、`ledgerRepairRequired`、`mountHistoryRejectedEvents` など、自動継続してはいけない状態を確認するための読み取り専用診断です。表示された場合は、原因となった candidate、host、spool、保存失敗理由、隔離された mountHistory event を確認できます。#418 時点ではこの画面から修復や解除は実行せず、整合確認と復旧操作は後続の Recovery Actions で扱います。
+推定候補タブの上部には、必要に応じて Recovery / repair status が表示されます。これは `inferredDecisionRecoveryRequired`、`ledgerRepairRequired`、`mountHistoryRejectedEvents` など、自動継続してはいけない状態を確認するための読み取り専用診断です。表示された場合は、原因となった candidate、host、spool、保存失敗理由、隔離された mountHistory event を確認できます。Relay 構成では Satellite も Parent 権威の診断状態をミラー表示します。#418 時点ではこの画面から修復や解除は実行せず、整合確認と復旧操作は後続の Recovery Actions で扱います。
 
 ### 登録済みフィラメントタブ
 

--- a/tests/unit/dashboard_client_sync_filament_sync.test.js
+++ b/tests/unit/dashboard_client_sync_filament_sync.test.js
@@ -157,6 +157,13 @@ describe("_applySharedFilamentState — フィラメント補助ドメイン（�
       monitorData.inferredCandidateStore = {};
     }
     for (const k of Object.keys(monitorData.inferredCandidateStore)) delete monitorData.inferredCandidateStore[k];
+    monitorData.inferredDecisionRecoveryRequired = null;
+    if (!monitorData.ledgerRepairRequired || typeof monitorData.ledgerRepairRequired !== "object") {
+      monitorData.ledgerRepairRequired = {};
+    }
+    for (const k of Object.keys(monitorData.ledgerRepairRequired)) delete monitorData.ledgerRepairRequired[k];
+    if (!Array.isArray(monitorData.mountHistoryRejectedEvents)) monitorData.mountHistoryRejectedEvents = [];
+    monitorData.mountHistoryRejectedEvents.splice(0, monitorData.mountHistoryRejectedEvents.length);
   });
 
   it("Phase4: pendingUnattributedUsage を親からミラー（in-place 全置換・参照維持）", () => {
@@ -198,6 +205,60 @@ describe("_applySharedFilamentState — フィラメント補助ドメイン（�
     expect(monitorData.inferredCandidateStore["ic-a"]).toEqual({
       candidateHash: "ic-a", host: "k1", status: "pending", usedMm: 1200
     });
+  });
+
+  it("#418: recovery / repair 診断を親から全置換ミラーする", () => {
+    monitorData.inferredDecisionRecoveryRequired = { candidateHash: "stale", reason: "old" };
+    monitorData.ledgerRepairRequired.stale = { status: "old" };
+    monitorData.mountHistoryRejectedEvents.push({ reason: "old", event: { evId: "old" } });
+
+    _applySharedFilamentState({
+      inferredDecisionRecoveryRequired: { candidateHash: "ic-a", action: "confirm", reason: "rollback_durable_save_failed" },
+      ledgerRepairRequired: { k1: { spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 123 } },
+      mountHistoryRejectedEvents: [{ reason: "reanchor-invalid-reference", event: { evId: "ev-a", host: "k1" } }],
+    });
+
+    expect(monitorData.inferredDecisionRecoveryRequired).toEqual({
+      candidateHash: "ic-a",
+      action: "confirm",
+      reason: "rollback_durable_save_failed",
+    });
+    expect(monitorData.ledgerRepairRequired.stale).toBeUndefined();
+    expect(monitorData.ledgerRepairRequired.k1).toEqual({ spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 123 });
+    expect(monitorData.mountHistoryRejectedEvents).toEqual([
+      { reason: "reanchor-invalid-reference", event: { evId: "ev-a", host: "k1" } },
+    ]);
+  });
+
+  it("#418: 親で解消済みの recovery / repair 診断を Satellite 側から消す", () => {
+    monitorData.inferredDecisionRecoveryRequired = { candidateHash: "ic-a", reason: "old" };
+    monitorData.ledgerRepairRequired.k1 = { status: "ambiguous" };
+    monitorData.mountHistoryRejectedEvents.push({ reason: "old" });
+
+    _applySharedFilamentState({
+      inferredDecisionRecoveryRequired: null,
+      ledgerRepairRequired: {},
+      mountHistoryRejectedEvents: [],
+    });
+
+    expect(monitorData.inferredDecisionRecoveryRequired).toBeNull();
+    expect(monitorData.ledgerRepairRequired).toEqual({});
+    expect(monitorData.mountHistoryRejectedEvents).toEqual([]);
+  });
+
+  it("#418: recovery 診断だけが変化した場合も開いている管理画面を再描画する", () => {
+    globalThis.window._refreshFilamentManagerIfOpen = vi.fn();
+    _applySharedFilamentState({
+      inferredDecisionRecoveryRequired: { candidateHash: "ic-a", reason: "rollback_failed" },
+    });
+    const firstCount = globalThis.window._refreshFilamentManagerIfOpen.mock.calls.length;
+
+    _applySharedFilamentState({
+      inferredDecisionRecoveryRequired: { candidateHash: "ic-b", reason: "rollback_failed" },
+    });
+
+    expect(globalThis.window._refreshFilamentManagerIfOpen.mock.calls.length).toBeGreaterThan(firstCount);
+    delete globalThis.window._refreshFilamentManagerIfOpen;
   });
 
   it("在庫・プリセット・使用履歴を親からミラー（in-place 全置換・参照維持）", () => {

--- a/tests/unit/dashboard_inferred_candidate_ui.test.js
+++ b/tests/unit/dashboard_inferred_candidate_ui.test.js
@@ -16,7 +16,8 @@ const mocks = vi.hoisted(() => ({
   reassignInferredCandidate: vi.fn(async () => ({ ok: true, reason: "reassigned" })),
   undoInferredCandidateDecision: vi.fn(async () => ({ ok: true, reason: "undone" })),
   showConfirmDialog: vi.fn(async () => true),
-  showAlert: vi.fn()
+  showAlert: vi.fn(),
+  recoveryVm: { hasIssues: false, totalCount: 0, blockerCount: 0, warningCount: 0, cards: [] }
 }));
 
 vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mocks.monitorData }));
@@ -44,6 +45,7 @@ vi.mock("../../3dp_lib/dashboard_inferred_candidate_view.js", () => ({
     SPOOL: "spool"
   },
   buildInferredCandidateViewModel: vi.fn(() => mocks.vm),
+  buildInferredRecoverySurfaceViewModel: vi.fn(() => mocks.recoveryVm),
   countPendingInferredCandidates: vi.fn(() => mocks.vm?.status === "pending" ? 1 : 0),
   listInferredCandidateViewModels: vi.fn(() => mocks.vm ? [mocks.vm] : [])
 }));
@@ -124,6 +126,7 @@ async function waitForAssertion(assertion) {
 beforeEach(() => {
   document.body.innerHTML = "";
   mocks.vm = vm();
+  mocks.recoveryVm = { hasIssues: false, totalCount: 0, blockerCount: 0, warningCount: 0, cards: [] };
   mocks.monitorData.filamentSpools = [
     { id: "S2", name: "PLA Blue", material: "PLA", remainingLengthMm: 8000 }
   ];
@@ -138,6 +141,43 @@ beforeEach(() => {
 });
 
 describe("createInferredCandidateCenterContent", () => {
+  it("recovery surface を read-only 診断として表示する", () => {
+    mocks.recoveryVm = {
+      hasIssues: true,
+      totalCount: 2,
+      blockerCount: 1,
+      warningCount: 1,
+      cards: [
+        {
+          severity: "blocker",
+          title: "O5 decision recovery required",
+          summary: "rollback状態の確認が必要です",
+          details: [
+            { label: "Candidate", value: "ic-a" },
+            { label: "Reason", value: "rollback_durable_save_failed" }
+          ]
+        },
+        {
+          severity: "warning",
+          title: "Rejected mount history events",
+          summary: "2件の mountHistory event が隔離されています",
+          details: [{ label: "Rejected 1", value: "ev-b" }]
+        }
+      ]
+    };
+
+    const center = createInferredCandidateCenterContent();
+    document.body.appendChild(center.el);
+
+    expect(document.querySelector(".ic-recovery-surface").textContent).toContain("Blocker 1 / Warning 1");
+    expect(document.querySelector(".ic-recovery-surface").textContent).toContain("O5 decision recovery required");
+    expect(document.querySelector(".ic-recovery-surface").textContent).toContain("Rejected mount history events");
+    expect(mocks.confirmInferredCandidate).not.toHaveBeenCalled();
+    expect(mocks.rejectInferredCandidate).not.toHaveBeenCalled();
+    expect(mocks.reassignInferredCandidate).not.toHaveBeenCalled();
+    expect(mocks.undoInferredCandidateDecision).not.toHaveBeenCalled();
+  });
+
   it("candidate 一覧から詳細を開き、Confirm は Decision Core を呼ぶ", async () => {
     const center = createInferredCandidateCenterContent();
     document.body.appendChild(center.el);

--- a/tests/unit/dashboard_inferred_candidate_view.test.js
+++ b/tests/unit/dashboard_inferred_candidate_view.test.js
@@ -25,6 +25,7 @@ vi.mock("../../3dp_lib/dashboard_spool.js", () => ({
 const {
   INFERRED_CANDIDATE_FILTER,
   INFERRED_CANDIDATE_SORT,
+  buildInferredRecoverySurfaceViewModel,
   buildInferredCandidateViewModel,
   countPendingInferredCandidates,
   listInferredCandidateViewModels
@@ -81,6 +82,8 @@ beforeEach(() => {
     "ic-old": record("ic-old", { createdAt: 1000, status: "confirmed" })
   };
   delete mocks.monitorData.inferredDecisionRecoveryRequired;
+  mocks.monitorData.ledgerRepairRequired = {};
+  mocks.monitorData.mountHistoryRejectedEvents = [];
 });
 
 describe("buildInferredCandidateViewModel", () => {
@@ -158,5 +161,53 @@ describe("listInferredCandidateViewModels", () => {
     expect(allOldest.map(vm => vm.candidateHash)).toEqual(["ic-old", "ic-new"]);
     expect(countPendingInferredCandidates()).toBe(1);
     expect(INFERRED_CANDIDATE_FILTER.UNDONE).toBe("undone");
+  });
+});
+
+describe("buildInferredRecoverySurfaceViewModel", () => {
+  it("recovery / ledger repair / rejected mount events を read-only card に変換する", () => {
+    mocks.monitorData.inferredDecisionRecoveryRequired = {
+      candidateHash: "ic-new",
+      action: "confirmInferredCandidate",
+      reason: "rollback_durable_save_failed",
+      createdAt: 4000,
+      save: { reason: "quota" },
+      rollbackSave: { reason: "quota-again" }
+    };
+    mocks.monitorData.ledgerRepairRequired = {
+      k1: { spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 5000 }
+    };
+    mocks.monitorData.mountHistoryRejectedEvents = [
+      { reason: "reanchor-invalid-reference", event: { evId: "ev-a", host: "k1", spoolId: "S1" } },
+      { reason: "supersede-invalid-survivor", event: { evId: "ev-b", host: "k2", spoolId: "S2" } }
+    ];
+
+    const vm = buildInferredRecoverySurfaceViewModel({ maxRejectedEvents: 1 });
+
+    expect(vm.hasIssues).toBe(true);
+    expect(vm.totalCount).toBe(3);
+    expect(vm.blockerCount).toBe(2);
+    expect(vm.warningCount).toBe(1);
+    expect(vm.cards.map(card => card.type)).toEqual([
+      "decision-recovery",
+      "ledger-repair",
+      "mount-history-rejected"
+    ]);
+    expect(vm.cards[0].details).toContainEqual({ label: "Candidate", value: "ic-new" });
+    expect(vm.cards[1].summary).toContain("K1 Max");
+    expect(vm.cards[2].details).toHaveLength(1);
+    expect(vm.cards[2].details[0].value).toContain("ev-b");
+  });
+
+  it("recovery item がない場合は空の診断モデルを返す", () => {
+    const vm = buildInferredRecoverySurfaceViewModel();
+
+    expect(vm).toMatchObject({
+      hasIssues: false,
+      totalCount: 0,
+      blockerCount: 0,
+      warningCount: 0,
+      cards: []
+    });
   });
 });

--- a/tests/unit/dashboard_relay_bridge_filament_ops.test.js
+++ b/tests/unit/dashboard_relay_bridge_filament_ops.test.js
@@ -16,6 +16,19 @@ vi.mock("../../3dp_lib/dashboard_data.js", () => ({
     filamentSpools: [],
     hostSpoolMap: {},
     mountHistory: [],
+    inferredDecisionRecoveryRequired: null,
+    ledgerRepairRequired: {},
+    mountHistoryRejectedEvents: [],
+    inferredCandidateStore: {},
+    pendingUnattributedUsage: [],
+    pendingUnattributedUsageArchive: {},
+    filamentInventory: [],
+    userPresets: [],
+    hiddenPresets: [],
+    favoritePresets: [],
+    filamentEventContext: {},
+    spoolSerialCounter: 0,
+    usageHistory: [],
     appSettings: { connectionTargets: [] },
   },
   PLACEHOLDER_HOSTNAME: "_$_NO_MACHINE_$_",
@@ -63,17 +76,71 @@ vi.mock("../../3dp_lib/dashboard_storage.js", () => ({
   saveUnifiedStorage: vi.fn(),
 }));
 
-const { handleRelayFilamentAction } = await import("../../3dp_lib/dashboard_relay_bridge.js");
+const { handleRelayFilamentAction, initRelayBridge, relayBroadcastIfNeeded } = await import("../../3dp_lib/dashboard_relay_bridge.js");
 const spool = await import("../../3dp_lib/dashboard_spool.js");
 const ledger = await import("../../3dp_lib/dashboard_filament_ledger.js");
 const decision = await import("../../3dp_lib/dashboard_inferred_candidate_decision.js");
 const inventory = await import("../../3dp_lib/dashboard_filament_inventory.js");
 const presets = await import("../../3dp_lib/dashboard_filament_presets.js");
 const { saveUnifiedStorage } = await import("../../3dp_lib/dashboard_storage.js");
+const { monitorData } = await import("../../3dp_lib/dashboard_data.js");
 
 const RESOLVED_PRESET = { presetId: "p1", name: "PLA" };
 
 const PRESET = { presetId: "p1", name: "PLA" };
+
+/**
+ * relay bridge の Electron API mock を設定する。
+ *
+ * @function setupRelayApi
+ * @returns {{snapshotHandler:Function|null}} snapshot request handler 参照。
+ */
+function setupRelayApi() {
+  const state = { snapshotHandler: null };
+  globalThis.window.electronAPI = {
+    relayBroadcast: vi.fn(),
+    relaySendSnapshot: vi.fn(),
+    onRelayCommand: vi.fn(),
+    onRelayFilament: vi.fn(),
+    onRelaySettings: vi.fn(),
+    onRelayRequestSnapshot: vi.fn((handler) => { state.snapshotHandler = handler; }),
+    onRelayPromoteRequest: vi.fn(),
+    setCameraEndpoints: vi.fn(),
+  };
+  return state;
+}
+
+describe("relayBroadcastIfNeeded — #418 recovery 診断同期", () => {
+  it("full snapshot と delta に Parent 権威の recovery / repair 診断を同梱する", () => {
+    const relay = setupRelayApi();
+    monitorData.inferredDecisionRecoveryRequired = {
+      candidateHash: "ic-a",
+      action: "confirm",
+      reason: "rollback_durable_save_failed",
+    };
+    monitorData.ledgerRepairRequired = {
+      k1: { spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 123 },
+    };
+    monitorData.mountHistoryRejectedEvents = [
+      { reason: "reanchor-invalid-reference", event: { evId: "ev-a", host: "k1", spoolId: "S1" } },
+    ];
+
+    expect(initRelayBridge()).toBe(true);
+    relay.snapshotHandler({ clientId: "child-1" });
+
+    const snapshot = globalThis.window.electronAPI.relaySendSnapshot.mock.calls[0][1];
+    expect(snapshot.inferredDecisionRecoveryRequired).toEqual(monitorData.inferredDecisionRecoveryRequired);
+    expect(snapshot.ledgerRepairRequired).toEqual(monitorData.ledgerRepairRequired);
+    expect(snapshot.mountHistoryRejectedEvents).toEqual(monitorData.mountHistoryRejectedEvents);
+
+    relayBroadcastIfNeeded();
+
+    const delta = globalThis.window.electronAPI.relayBroadcast.mock.calls[0][0];
+    expect(delta.shared.inferredDecisionRecoveryRequired).toEqual(monitorData.inferredDecisionRecoveryRequired);
+    expect(delta.shared.ledgerRepairRequired).toEqual(monitorData.ledgerRepairRequired);
+    expect(delta.shared.mountHistoryRejectedEvents).toEqual(monitorData.mountHistoryRejectedEvents);
+  });
+});
 
 describe("handleRelayFilamentAction — 親側 RPC ディスパッチ", () => {
   beforeEach(() => vi.clearAllMocks());


### PR DESCRIPTION
## Summary
- add a read-only Recovery / repair status surface to the inferred candidate center
- expose decision recovery, ledger repair, and quarantined mountHistory events through view models
- document the read-only recovery status behavior in the Japanese and English filament manuals

## Validation
- npx vitest run tests/unit/dashboard_inferred_candidate_decision.test.js tests/unit/dashboard_inferred_candidate_view.test.js tests/unit/dashboard_inferred_candidate_ui.test.js tests/unit/dashboard_relay_bridge_filament_ops.test.js tests/unit/dashboard_offline_candidate_store.test.js
- npx vitest run
- npx eslint 3dp_lib/dashboard_inferred_candidate_view.js 3dp_lib/dashboard_inferred_candidate_ui.js tests/unit/dashboard_inferred_candidate_view.test.js tests/unit/dashboard_inferred_candidate_ui.test.js
- git diff --check

## Notes
- `npm run lint` still fails on existing repository-wide lint issues outside this slice, including `3dp_lib/dashboard_ui_mapping.js` duplicate key `estimatedRemainingTime`.
- `npx stylelint 3dp_panel.css` still reports existing CSS lint debt across the file; this slice uses existing design tokens and does not introduce hardcoded colors.
