### PR TITLE
Harden O5 inferred candidate decisions

### DIFF
--- a/3dp_lib/dashboard_inferred_candidate_decision.js
+++ b/3dp_lib/dashboard_inferred_candidate_decision.js
@@ -14,6 +14,8 @@
  * - SATELLITE はローカル candidate/ledger を書かず、Parent へ decision request を送る。
  * - Confirm/Reassign は台帳反映、candidate 状態遷移、耐久保存を一連の transaction として扱い、
  *   保存失敗時はメモリ rollback と rollback 状態の耐久保存を試みる。
+ * - Parent/Standalone のローカル decision は全体直列化し、保存待ち中の別 decision が rollback
+ *   snapshot をまたいで混線しないようにする。
  * - Undo も同じ transaction 境界で、O5 が追加した台帳 event と履歴 attribution だけを逆反映する。
  *
  * 【公開関数一覧】
@@ -24,9 +26,9 @@
  * - {@link reassignInferredCandidate}：別 spool へ再割当てして推定使用量を確定する
  * - {@link undoInferredCandidateDecision}：確定済み candidate の台帳反映を取り消す
  *
- * @version 1.390.1265 (PR #417)
+ * @version 1.390.1268 (PR #419)
  * @since   1.390.1261 (PR #414)
- * @lastModified 2026-07-26 00:03:27
+ * @lastModified 2026-07-29 17:25:57
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -67,6 +69,38 @@ const ALLOWED_REJECT_REASONS = new Set([
   "operator-decision",
   "other"
 ]);
+
+/**
+ * Parent/Standalone で実行する O5 decision の直列化キュー。
+ *
+ * 【詳細説明】
+ * - JavaScript は単一スレッドだが、`await saveUnifiedStorageDurably()` 中には別の UI/RPC 操作が
+ *   開始できるため、同一 spool の rollback snapshot が後続 decision を巻き戻す危険がある。
+ * - 初期実装では host/spool 単位ではなく全 O5 decision を直列化し、Confirm/Reassign/Reject/Undo の
+ *   競合範囲を安全側で閉じる。
+ *
+ * @type {Promise<void>}
+ */
+let _decisionQueue = Promise.resolve();
+
+/**
+ * ローカル O5 decision を全体キューへ投入する。
+ *
+ * 【詳細説明】
+ * - 直前 decision が成功しても失敗しても、次の decision は必ずその後に開始する。
+ * - 呼び出し元には task の戻り値をそのまま返し、キュー内部では rejection を吸収して後続が詰まらない
+ *   ようにする。
+ *
+ * @private
+ * @function _enqueueDecision
+ * @param {Function} task - 実行する decision 本体。
+ * @returns {Promise<*>} decision 本体の戻り値。
+ */
+function _enqueueDecision(task) {
+  const run = _decisionQueue.then(task, task);
+  _decisionQueue = run.catch(() => {});
+  return run;
+}
 
 /**
  * JSON 互換オブジェクトを deep clone する。
@@ -420,9 +454,20 @@ export function canSubmitLedgerDecision() {
  * const result = await confirmInferredCandidate("ic-abcd", { actor: "operator" });
  */
 export async function confirmInferredCandidate(candidateHash, options = {}) {
-  if (_isRelayChild()) {
-    return _requestLedgerDecision("confirmInferredCandidate", candidateHash, {}, options);
-  }
+  if (_isRelayChild()) return _requestLedgerDecision("confirmInferredCandidate", candidateHash, {}, options);
+  return _enqueueDecision(() => _confirmInferredCandidateLocal(candidateHash, options));
+}
+
+/**
+ * candidate spool のまま推定使用量をローカル確定する。
+ *
+ * @private
+ * @function _confirmInferredCandidateLocal
+ * @param {string} candidateHash - 確定する candidateHash。
+ * @param {{actor?:string,nowMs?:number,save?:boolean}} [options] - 操作者・clock・保存オプション。
+ * @returns {Promise<Object>} decision 結果。
+ */
+async function _confirmInferredCandidateLocal(candidateHash, options = {}) {
   const guard = _decisionGuard(candidateHash);
   if (guard) return guard;
   const pending = _validatePendingCandidate(candidateHash);
@@ -482,6 +527,20 @@ export async function rejectInferredCandidate(candidateHash, options = {}) {
       note: options.note || ""
     }, options);
   }
+  return _enqueueDecision(() => _rejectInferredCandidateLocal(candidateHash, options));
+}
+
+/**
+ * pending candidate をローカル否認する。
+ *
+ * @private
+ * @function _rejectInferredCandidateLocal
+ * @param {string} candidateHash - 否認する candidateHash。
+ * @param {{actor?:string,reason?:string,note?:string,nowMs?:number,save?:boolean}} [options]
+ *   - 操作者・否認理由・clock・保存オプション。
+ * @returns {Promise<Object>} decision 結果。
+ */
+async function _rejectInferredCandidateLocal(candidateHash, options = {}) {
   const guard = _decisionGuard(candidateHash);
   if (guard) return guard;
   const rejectReason = options.reason || "operator-decision";
@@ -543,6 +602,20 @@ export async function reassignInferredCandidate(candidateHash, targetSpoolId, op
       targetSpoolId: String(targetSpoolId)
     }, options);
   }
+  return _enqueueDecision(() => _reassignInferredCandidateLocal(candidateHash, targetSpoolId, options));
+}
+
+/**
+ * pending candidate を別 spool へローカル再割当てして確定する。
+ *
+ * @private
+ * @function _reassignInferredCandidateLocal
+ * @param {string} candidateHash - 再割当てする candidateHash。
+ * @param {string} targetSpoolId - 再割当て先 spool ID。
+ * @param {{actor?:string,nowMs?:number,save?:boolean}} [options] - 操作者・clock・保存オプション。
+ * @returns {Promise<Object>} decision 結果。
+ */
+async function _reassignInferredCandidateLocal(candidateHash, targetSpoolId, options = {}) {
   const guard = _decisionGuard(candidateHash);
   if (guard) return guard;
   if (!targetSpoolId) return { ok: false, reason: "target_spool_required", candidateHash };
@@ -598,9 +671,20 @@ export async function reassignInferredCandidate(candidateHash, targetSpoolId, op
  * const result = await undoInferredCandidateDecision("ic-abcd", { actor: "operator" });
  */
 export async function undoInferredCandidateDecision(candidateHash, options = {}) {
-  if (_isRelayChild()) {
-    return _requestLedgerDecision("undoInferredCandidateDecision", candidateHash, {}, options);
-  }
+  if (_isRelayChild()) return _requestLedgerDecision("undoInferredCandidateDecision", candidateHash, {}, options);
+  return _enqueueDecision(() => _undoInferredCandidateDecisionLocal(candidateHash, options));
+}
+
+/**
+ * confirmed / reassigned candidate の確定台帳反映をローカルで取り消す。
+ *
+ * @private
+ * @function _undoInferredCandidateDecisionLocal
+ * @param {string} candidateHash - Undo する candidateHash。
+ * @param {{actor?:string,nowMs?:number,save?:boolean}} [options] - 操作者・clock・保存オプション。
+ * @returns {Promise<Object>} decision 結果。
+ */
+async function _undoInferredCandidateDecisionLocal(candidateHash, options = {}) {
   const guard = _decisionGuard(candidateHash);
   if (guard) return guard;
   const undoable = _validateUndoableCandidate(candidateHash);

--- a/3dp_lib/dashboard_inferred_candidate_ledger.js
+++ b/3dp_lib/dashboard_inferred_candidate_ledger.js
@@ -11,6 +11,7 @@
  * - O5 Human Decision Layer で承認された inferredCandidate を、確定台帳へ反映する。
  * - 確定残量、印刷履歴 filamentInfo、spool.usedLengthLog を同じ決定単位で更新する。
  * - Undo 時は candidateHash で照合できる O5 確定 event と履歴 attribution だけを逆反映する。
+ * - Undo は確定 event を物理削除せず、逆仕訳 event を追記して監査証跡を残す。
  * - 保存失敗時にメモリ状態を元へ戻せるよう、反映前 snapshot と rollback API を提供する。
  *
  * 【公開関数一覧】
@@ -18,9 +19,9 @@
  * - {@link undoInferredCandidateLedger}：確定済み candidate の台帳反映を取り消す
  * - {@link rollbackInferredCandidateLedger}：確定反映前 snapshot へメモリ状態を戻す
  *
- * @version 1.390.1266 (PR #417)
+ * @version 1.390.1268 (PR #419)
  * @since   1.390.1261 (PR #414)
- * @lastModified 2026-07-26 11:03:46
+ * @lastModified 2026-07-29 17:25:57
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -46,6 +47,41 @@ const INFERRED_DEBIT_STATUS = "inferred-debit";
  * @constant {string}
  */
 export const INFERRED_DECISION_LEDGER_EVENT_TYPE = "inferred-continuity-confirmed";
+
+/**
+ * O5 Undo が spool.usedLengthLog へ追記する逆仕訳 event の種別。
+ *
+ * @constant {string}
+ */
+export const INFERRED_DECISION_UNDO_LEDGER_EVENT_TYPE = "inferred-continuity-undone";
+
+/**
+ * O5 attribution として履歴行へ追加され得るキー。
+ *
+ * 【詳細説明】
+ * - Undo 前に Confirm/Reassign 後の履歴行が期待状態から変化していないか検証するために使う。
+ * - Confirm 前から存在したキーは snapshot 側の値と比較し、O5 が追加したキーだけを許容する。
+ *
+ * @constant {Set<string>}
+ */
+const O5_ATTRIBUTION_KEYS = new Set([
+  "spoolId",
+  "serialNo",
+  "spoolName",
+  "colorName",
+  "filamentColor",
+  "material",
+  "spoolCount",
+  "expectedRemain",
+  "usedMm",
+  "isOfflineInferred",
+  "isInferredContinuityConfirmed",
+  "candidateHash",
+  "decisionType",
+  "originalCandidateSpoolId",
+  "confirmedAt",
+  "confirmedBy"
+]);
 
 /**
  * JSON 互換オブジェクトを deep clone する。
@@ -236,6 +272,30 @@ function _hasExistingDecisionEvent(spool, candidateHash) {
 }
 
 /**
+ * 指定した確定 event が既に Undo 済みか判定する。
+ *
+ * 【詳細説明】
+ * - Undo は candidate status 側でも多重実行を防ぐが、台帳側にも逆仕訳 event を残すため、
+ *   usedLengthLog だけを見ても二重Undoを検出できるようにする。
+ *
+ * @private
+ * @function _hasUndoEventForDecisionEvent
+ * @param {Object} spool - 対象 spool。
+ * @param {Object} decisionEvent - 元の O5 確定 event。
+ * @returns {boolean} 既に逆仕訳 event がある場合 true。
+ */
+function _hasUndoEventForDecisionEvent(spool, decisionEvent) {
+  const log = Array.isArray(spool?.usedLengthLog) ? spool.usedLengthLog : [];
+  const eventId = decisionEvent?.eventId;
+  if (!eventId) return false;
+  return log.some(item =>
+    item
+    && item.type === INFERRED_DECISION_UNDO_LEDGER_EVENT_TYPE
+    && item.reversesEventId === eventId
+  );
+}
+
+/**
  * spool.usedLengthLog から同じ candidate の O5 確定 event を列挙する。
  *
  * 【詳細説明】
@@ -344,6 +404,84 @@ function _restoreHistoryAttributionFromBefore(entry, before) {
 }
 
 /**
+ * 2つの JSON 互換値が同じ内容か判定する。
+ *
+ * @private
+ * @function _sameJson
+ * @param {*} a - 比較値。
+ * @param {*} b - 比較値。
+ * @returns {boolean} JSON 表現が一致する場合 true。
+ */
+function _sameJson(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Undo 対象履歴行が Confirm/Reassign 直後の期待状態から変化していないか検証する。
+ *
+ * 【詳細説明】
+ * - Undo は Confirm 前 snapshot へ戻すため、Confirm 後に別経路が合法 metadata を追加している場合、
+ *   無条件に復元するとその変更を消してしまう。
+ * - そこで、現在の履歴行が「snapshot + O5 attribution」だけで構成されているかを確認する。
+ * - 色だけの既存 filamentInfo を同じ行へ昇格したケースと、O5 attribution を末尾追加したケースの
+ *   両方を許容する。
+ *
+ * @private
+ * @function _validateHistoryPostStateBeforeUndo
+ * @param {Object} entry - 現在の履歴行。
+ * @param {Object} before - Confirm/Reassign 前 snapshot。
+ * @param {string} targetSpoolId - Undo 対象 spool ID。
+ * @param {string} candidateHash - Undo 対象 candidateHash。
+ * @returns {{ok:boolean,reason:string}} 検証結果。
+ */
+function _validateHistoryPostStateBeforeUndo(entry, before, targetSpoolId, candidateHash) {
+  const info = Array.isArray(entry?.filamentInfo) ? entry.filamentInfo : [];
+  const targetId = String(targetSpoolId);
+  const matches = [];
+  for (let index = 0; index < info.length; index++) {
+    const item = info[index];
+    if (item
+        && item.isInferredContinuityConfirmed === true
+        && item.candidateHash === candidateHash
+        && String(item.spoolId) === targetId) {
+      matches.push(index);
+    }
+  }
+  if (matches.length === 0) return { ok: false, reason: "candidate_history_link_missing" };
+  if (matches.length > 1) return { ok: false, reason: "candidate_history_link_ambiguous" };
+  if (entry.filamentId != null && String(entry.filamentId) !== targetId) {
+    return { ok: false, reason: "candidate_history_post_state_changed" };
+  }
+
+  const beforeInfo = before?.filamentInfoPresent === true && Array.isArray(before.filamentInfo)
+    ? before.filamentInfo
+    : [];
+  const targetIndex = matches[0];
+  const withoutTarget = info.filter((_, index) => index !== targetIndex);
+  if (_sameJson(withoutTarget, beforeInfo)) return { ok: true, reason: "history_post_state_ok" };
+  if (info.length !== beforeInfo.length) return { ok: false, reason: "candidate_history_post_state_changed" };
+
+  for (let index = 0; index < info.length; index++) {
+    const current = info[index] || {};
+    const expected = beforeInfo[index] || {};
+    if (index !== targetIndex) {
+      if (!_sameJson(current, expected)) return { ok: false, reason: "candidate_history_post_state_changed" };
+      continue;
+    }
+    for (const key of Object.keys(expected)) {
+      if (O5_ATTRIBUTION_KEYS.has(key)) continue;
+      if (!_sameJson(current[key], expected[key])) return { ok: false, reason: "candidate_history_post_state_changed" };
+    }
+    for (const key of Object.keys(current)) {
+      if (!(key in expected) && !O5_ATTRIBUTION_KEYS.has(key)) {
+        return { ok: false, reason: "candidate_history_post_state_changed" };
+      }
+    }
+  }
+  return { ok: true, reason: "history_post_state_ok" };
+}
+
+/**
  * candidate record から確定先 spool ID を取得する。
  *
  * 【詳細説明】
@@ -397,57 +535,6 @@ function _linkHistoryEntryToSpool(entry, spool, usedMm, metadata) {
     entry.filamentInfo = [...prev, info];
   }
   entry.filamentId = spool.id;
-}
-
-/**
- * 履歴行から指定 candidate の O5 確定 attribution を取り除く。
- *
- * 【詳細説明】
- * - 通常の確定帰属や別 candidate の filamentInfo を巻き込まないため、candidateHash と spoolId が
- *   一致する `isInferredContinuityConfirmed` 行だけを削除する。
- * - 削除後に他の spoolId 付き filamentInfo が残る場合は、その spoolId を filamentId に戻す。
- *   残らない場合は filamentId を削除し、履歴行を未帰属へ戻す。
- *
- * @private
- * @function _unlinkHistoryEntryFromCandidate
- * @param {Object} entry - 更新対象履歴行。
- * @param {string} targetSpoolId - Undo 対象の確定先 spool ID。
- * @param {string} candidateHash - Undo 対象 candidateHash。
- * @returns {{ok:boolean,reason:string}} 削除結果。
- */
-function _unlinkHistoryEntryFromCandidate(entry, targetSpoolId, candidateHash) {
-  const info = Array.isArray(entry?.filamentInfo) ? entry.filamentInfo : [];
-  const targetId = String(targetSpoolId);
-  const matches = [];
-  for (let index = 0; index < info.length; index++) {
-    const item = info[index];
-    if (item
-        && item.isInferredContinuityConfirmed === true
-        && item.candidateHash === candidateHash
-        && String(item.spoolId) === targetId) {
-      matches.push(index);
-    }
-  }
-  if (matches.length === 0) return { ok: false, reason: "candidate_history_link_missing" };
-  if (matches.length > 1) return { ok: false, reason: "candidate_history_link_ambiguous" };
-
-  const remove = new Set(matches);
-  const remaining = info.filter((_, index) => !remove.has(index));
-  if (remaining.length > 0) {
-    entry.filamentInfo = remaining;
-  } else {
-    delete entry.filamentInfo;
-  }
-
-  if (entry.filamentId != null && String(entry.filamentId) === targetId) {
-    const remainingSpool = remaining.find(item => item && item.spoolId);
-    if (remainingSpool?.spoolId) {
-      entry.filamentId = remainingSpool.spoolId;
-    } else {
-      delete entry.filamentId;
-    }
-  }
-  return { ok: true, reason: "history_link_removed" };
 }
 
 /**
@@ -506,6 +593,9 @@ export function applyInferredCandidateLedger(candidateRecord, targetSpoolId, opt
   const debits = _candidateDebits(candidateRecord);
   const total = _validateDebitTotal(candidateRecord, debits);
   if (!total.ok) return { ok: false, reason: total.reason, snapshot: null, spool };
+  if (remaining < total.usedMm) {
+    return { ok: false, reason: "confirmed_remaining_insufficient", snapshot: null, spool };
+  }
 
   const byKey = _historyIndexByObservationKey(history);
   const updates = [];
@@ -621,6 +711,9 @@ export function undoInferredCandidateLedger(candidateRecord, options = {}) {
   if (String(events[0].event.host ?? "") !== String(host)) {
     return { ok: false, reason: "candidate_ledger_event_host_mismatch", snapshot: null, spool };
   }
+  if (_hasUndoEventForDecisionEvent(spool, events[0].event)) {
+    return { ok: false, reason: "candidate_ledger_event_already_undone", snapshot: null, spool };
+  }
   const eventUsedMm = _positiveMm(events[0].event.usedMm);
   if (eventUsedMm <= 0) return { ok: false, reason: "candidate_ledger_event_used_mm_missing", snapshot: null, spool };
 
@@ -653,7 +746,7 @@ export function undoInferredCandidateLedger(candidateRecord, options = {}) {
     const entry = history[index];
     const before = beforeMap.map.get(key);
     if (!before) return { ok: false, reason: "candidate_history_snapshot_missing", snapshot: null, spool, observationKey: key };
-    const probe = _unlinkHistoryEntryFromCandidate(_clone(entry), targetSpoolId, candidateRecord.candidateHash);
+    const probe = _validateHistoryPostStateBeforeUndo(entry, before, targetSpoolId, candidateRecord.candidateHash);
     if (!probe.ok) return { ok: false, reason: probe.reason, snapshot: null, spool, observationKey: key };
     updates.push({ index, entry, debit, before });
   }
@@ -669,7 +762,22 @@ export function undoInferredCandidateLedger(candidateRecord, options = {}) {
   for (const item of updates) {
     _restoreHistoryAttributionFromBefore(item.entry, item.before);
   }
-  spool.usedLengthLog.splice(events[0].index, 1);
+  const now = _nowMs(options);
+  const actor = options.actor || "user";
+  const undoEvent = {
+    eventId: options.eventId || randomEventId("icdu"),
+    type: INFERRED_DECISION_UNDO_LEDGER_EVENT_TYPE,
+    reversesEventId: events[0].event.eventId ?? null,
+    candidateHash: candidateRecord.candidateHash,
+    host,
+    spoolId: spool.id,
+    actor,
+    usedMm: eventUsedMm,
+    observationKeys: Array.isArray(events[0].event.observationKeys) ? events[0].event.observationKeys.slice() : [],
+    createdAt: now
+  };
+  if (!Array.isArray(spool.usedLengthLog)) spool.usedLengthLog = [];
+  spool.usedLengthLog.push(undoEvent);
   spool.remainingLengthMm = remaining + eventUsedMm;
 
   return {
@@ -678,7 +786,8 @@ export function undoInferredCandidateLedger(candidateRecord, options = {}) {
     snapshot,
     spool,
     historyEntries: updates.map(item => item.entry),
-    event: events[0].event
+    event: undoEvent,
+    reversedEvent: events[0].event
   };
 }
 

--- a/3dp_lib/dashboard_inferred_candidate_ledger.js
+++ b/3dp_lib/dashboard_inferred_candidate_ledger.js
@@ -19,9 +19,9 @@
  * - {@link undoInferredCandidateLedger}：確定済み candidate の台帳反映を取り消す
  * - {@link rollbackInferredCandidateLedger}：確定反映前 snapshot へメモリ状態を戻す
  *
- * @version 1.390.1268 (PR #419)
+ * @version 1.390.1269 (PR #419)
  * @since   1.390.1261 (PR #414)
- * @lastModified 2026-07-29 17:25:57
+ * @lastModified 2026-08-01 19:47:47
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -54,34 +54,6 @@ export const INFERRED_DECISION_LEDGER_EVENT_TYPE = "inferred-continuity-confirme
  * @constant {string}
  */
 export const INFERRED_DECISION_UNDO_LEDGER_EVENT_TYPE = "inferred-continuity-undone";
-
-/**
- * O5 attribution として履歴行へ追加され得るキー。
- *
- * 【詳細説明】
- * - Undo 前に Confirm/Reassign 後の履歴行が期待状態から変化していないか検証するために使う。
- * - Confirm 前から存在したキーは snapshot 側の値と比較し、O5 が追加したキーだけを許容する。
- *
- * @constant {Set<string>}
- */
-const O5_ATTRIBUTION_KEYS = new Set([
-  "spoolId",
-  "serialNo",
-  "spoolName",
-  "colorName",
-  "filamentColor",
-  "material",
-  "spoolCount",
-  "expectedRemain",
-  "usedMm",
-  "isOfflineInferred",
-  "isInferredContinuityConfirmed",
-  "candidateHash",
-  "decisionType",
-  "originalCandidateSpoolId",
-  "confirmedAt",
-  "confirmedBy"
-]);
 
 /**
  * JSON 互換オブジェクトを deep clone する。
@@ -351,11 +323,68 @@ function _captureHistoryBefore(entry, observationKey) {
 }
 
 /**
- * ledger event の履歴snapshotを observation key で一意に引ける Map へ変換する。
+ * O5 が履歴行へ attribution を書いた直後の表示・後方互換フィールドを snapshot 化する。
  *
  * 【詳細説明】
- * - snapshot が無い旧形式 event では、Undo 後の履歴表示を完全復元できないため fail-closed する。
+ * - Undo は Confirm/Reassign 直後の状態から後続変更が入っていない場合だけ実行できる。
+ * - `filamentInfo` と `filamentId` は値だけでなくプロパティ存在も比較対象にし、削除や null 化を
+ *   安全に検出する。
+ *
+ * @private
+ * @function _captureHistoryAfter
+ * @param {Object} entry - Confirm/Reassign 後の履歴行。
+ * @param {string} observationKey - candidate debit の observation key。
+ * @returns {Object} Undo 前検証用 snapshot。
+ */
+function _captureHistoryAfter(entry, observationKey) {
+  const hasFilamentInfo = Object.hasOwn(entry, "filamentInfo");
+  const hasFilamentId = Object.hasOwn(entry, "filamentId");
+  return {
+    observationKey: String(observationKey ?? ""),
+    filamentInfoPresent: hasFilamentInfo,
+    filamentInfo: hasFilamentInfo ? _clone(entry.filamentInfo) : null,
+    filamentIdPresent: hasFilamentId,
+    filamentId: hasFilamentId ? _clone(entry.filamentId) : null
+  };
+}
+
+/**
+ * ledger event の履歴snapshot配列を observation key で一意に引ける Map へ変換する。
+ *
+ * 【詳細説明】
+ * - snapshot が無い旧形式 event では、Undo 後の履歴表示や後続変更検出を保証できないため
+ *   fail-closed する。
  * - 同一 observation key が複数ある場合も、どの変更前状態へ戻すべきか決められないため拒否する。
+ *
+ * @private
+ * @function _historySnapshotMap
+ * @param {Object} event - spool.usedLengthLog 内の O5 decision event。
+ * @param {string} fieldName - snapshot 配列の event field 名。
+ * @param {string} missingReason - snapshot が存在しない場合の理由。
+ * @param {string} invalidReason - snapshot が不正な場合の理由。
+ * @param {string} ambiguousReason - snapshot が曖昧な場合の理由。
+ * @returns {{ok:boolean,reason:?string,map:Map<string,Object>}} snapshot Map。
+ */
+function _historySnapshotMap(event, fieldName, missingReason, invalidReason, ambiguousReason) {
+  const items = event?.[fieldName];
+  if (!Array.isArray(items)) {
+    return { ok: false, reason: missingReason, map: new Map() };
+  }
+  const map = new Map();
+  for (const item of items) {
+    const key = String(item?.observationKey ?? "");
+    if (!key) return { ok: false, reason: invalidReason, map: new Map() };
+    if (map.has(key)) return { ok: false, reason: ambiguousReason, map: new Map() };
+    map.set(key, item);
+  }
+  return { ok: true, reason: null, map };
+}
+
+/**
+ * ledger event の変更前履歴snapshotを observation key で一意に引ける Map へ変換する。
+ *
+ * 【詳細説明】
+ * - 変更前 snapshot は Undo の復元元であり、欠損している event は安全に取り消せない。
  *
  * @private
  * @function _historyBeforeMap
@@ -363,17 +392,35 @@ function _captureHistoryBefore(entry, observationKey) {
  * @returns {{ok:boolean,reason:?string,map:Map<string,Object>}} snapshot Map。
  */
 function _historyBeforeMap(event) {
-  if (!Array.isArray(event?.historyBefore)) {
-    return { ok: false, reason: "candidate_history_snapshot_missing", map: new Map() };
-  }
-  const map = new Map();
-  for (const item of event.historyBefore) {
-    const key = String(item?.observationKey ?? "");
-    if (!key) return { ok: false, reason: "candidate_history_snapshot_invalid", map: new Map() };
-    if (map.has(key)) return { ok: false, reason: "candidate_history_snapshot_ambiguous", map: new Map() };
-    map.set(key, item);
-  }
-  return { ok: true, reason: null, map };
+  return _historySnapshotMap(
+    event,
+    "historyBefore",
+    "candidate_history_snapshot_missing",
+    "candidate_history_snapshot_invalid",
+    "candidate_history_snapshot_ambiguous"
+  );
+}
+
+/**
+ * ledger event の変更直後履歴snapshotを observation key で一意に引ける Map へ変換する。
+ *
+ * 【詳細説明】
+ * - 変更直後 snapshot は Undo 前の後続変更検出に使う。
+ * - 欠損している旧形式 event は、合法的な後続 metadata 更新を消さないため fail-closed する。
+ *
+ * @private
+ * @function _historyAfterMap
+ * @param {Object} event - spool.usedLengthLog 内の O5 decision event。
+ * @returns {{ok:boolean,reason:?string,map:Map<string,Object>}} snapshot Map。
+ */
+function _historyAfterMap(event) {
+  return _historySnapshotMap(
+    event,
+    "historyAfter",
+    "candidate_history_after_snapshot_missing",
+    "candidate_history_after_snapshot_invalid",
+    "candidate_history_after_snapshot_ambiguous"
+  );
 }
 
 /**
@@ -417,24 +464,24 @@ function _sameJson(a, b) {
 }
 
 /**
- * Undo 対象履歴行が Confirm/Reassign 直後の期待状態から変化していないか検証する。
+ * Undo 対象履歴行が Confirm/Reassign 直後の snapshot から変化していないか検証する。
  *
  * 【詳細説明】
  * - Undo は Confirm 前 snapshot へ戻すため、Confirm 後に別経路が合法 metadata を追加している場合、
  *   無条件に復元するとその変更を消してしまう。
- * - そこで、現在の履歴行が「snapshot + O5 attribution」だけで構成されているかを確認する。
- * - 色だけの既存 filamentInfo を同じ行へ昇格したケースと、O5 attribution を末尾追加したケースの
- *   両方を許容する。
+ * - Confirm/Reassign 直後に保存した `historyAfter` と現在値を完全比較し、material や colorName の
+ *   ように O5 も触るキーへ後続変更が入った場合も fail-closed する。
+ * - `filamentId` はプロパティの存在も比較し、削除や null 化された状態を見逃さない。
  *
  * @private
  * @function _validateHistoryPostStateBeforeUndo
  * @param {Object} entry - 現在の履歴行。
- * @param {Object} before - Confirm/Reassign 前 snapshot。
+ * @param {Object} after - Confirm/Reassign 直後 snapshot。
  * @param {string} targetSpoolId - Undo 対象 spool ID。
  * @param {string} candidateHash - Undo 対象 candidateHash。
  * @returns {{ok:boolean,reason:string}} 検証結果。
  */
-function _validateHistoryPostStateBeforeUndo(entry, before, targetSpoolId, candidateHash) {
+function _validateHistoryPostStateBeforeUndo(entry, after, targetSpoolId, candidateHash) {
   const info = Array.isArray(entry?.filamentInfo) ? entry.filamentInfo : [];
   const targetId = String(targetSpoolId);
   const matches = [];
@@ -449,35 +496,9 @@ function _validateHistoryPostStateBeforeUndo(entry, before, targetSpoolId, candi
   }
   if (matches.length === 0) return { ok: false, reason: "candidate_history_link_missing" };
   if (matches.length > 1) return { ok: false, reason: "candidate_history_link_ambiguous" };
-  if (entry.filamentId != null && String(entry.filamentId) !== targetId) {
-    return { ok: false, reason: "candidate_history_post_state_changed" };
-  }
 
-  const beforeInfo = before?.filamentInfoPresent === true && Array.isArray(before.filamentInfo)
-    ? before.filamentInfo
-    : [];
-  const targetIndex = matches[0];
-  const withoutTarget = info.filter((_, index) => index !== targetIndex);
-  if (_sameJson(withoutTarget, beforeInfo)) return { ok: true, reason: "history_post_state_ok" };
-  if (info.length !== beforeInfo.length) return { ok: false, reason: "candidate_history_post_state_changed" };
-
-  for (let index = 0; index < info.length; index++) {
-    const current = info[index] || {};
-    const expected = beforeInfo[index] || {};
-    if (index !== targetIndex) {
-      if (!_sameJson(current, expected)) return { ok: false, reason: "candidate_history_post_state_changed" };
-      continue;
-    }
-    for (const key of Object.keys(expected)) {
-      if (O5_ATTRIBUTION_KEYS.has(key)) continue;
-      if (!_sameJson(current[key], expected[key])) return { ok: false, reason: "candidate_history_post_state_changed" };
-    }
-    for (const key of Object.keys(current)) {
-      if (!(key in expected) && !O5_ATTRIBUTION_KEYS.has(key)) {
-        return { ok: false, reason: "candidate_history_post_state_changed" };
-      }
-    }
-  }
+  const current = _captureHistoryAfter(entry, after?.observationKey);
+  if (!_sameJson(current, after)) return { ok: false, reason: "candidate_history_post_state_changed" };
   return { ok: true, reason: "history_post_state_ok" };
 }
 
@@ -643,6 +664,7 @@ export function applyInferredCandidateLedger(candidateRecord, targetSpoolId, opt
   for (const item of updates) {
     _linkHistoryEntryToSpool(item.entry, spool, item.usedMm, metadata);
   }
+  const historyAfter = updates.map(item => _captureHistoryAfter(item.entry, item.debit.observationKey));
 
   spool.remainingLengthMm = Math.max(0, remaining - total.usedMm);
   if (!Array.isArray(spool.usedLengthLog)) spool.usedLengthLog = [];
@@ -658,6 +680,7 @@ export function applyInferredCandidateLedger(candidateRecord, targetSpoolId, opt
     usedMm: total.usedMm,
     observationKeys: Array.isArray(candidateRecord.observationKeys) ? candidateRecord.observationKeys.map(String).sort() : [],
     historyBefore,
+    historyAfter,
     createdAt: now
   };
   spool.usedLengthLog.push(event);
@@ -727,6 +750,8 @@ export function undoInferredCandidateLedger(candidateRecord, options = {}) {
   }
   const beforeMap = _historyBeforeMap(events[0].event);
   if (!beforeMap.ok) return { ok: false, reason: beforeMap.reason, snapshot: null, spool };
+  const afterMap = _historyAfterMap(events[0].event);
+  if (!afterMap.ok) return { ok: false, reason: afterMap.reason, snapshot: null, spool };
 
   const byKey = _historyIndexByObservationKey(history);
   const updates = [];
@@ -746,7 +771,9 @@ export function undoInferredCandidateLedger(candidateRecord, options = {}) {
     const entry = history[index];
     const before = beforeMap.map.get(key);
     if (!before) return { ok: false, reason: "candidate_history_snapshot_missing", snapshot: null, spool, observationKey: key };
-    const probe = _validateHistoryPostStateBeforeUndo(entry, before, targetSpoolId, candidateRecord.candidateHash);
+    const after = afterMap.map.get(key);
+    if (!after) return { ok: false, reason: "candidate_history_after_snapshot_missing", snapshot: null, spool, observationKey: key };
+    const probe = _validateHistoryPostStateBeforeUndo(entry, after, targetSpoolId, candidateRecord.candidateHash);
     if (!probe.ok) return { ok: false, reason: probe.reason, snapshot: null, spool, observationKey: key };
     updates.push({ index, entry, debit, before });
   }

--- a/3dp_lib/dashboard_inferred_candidate_ui.js
+++ b/3dp_lib/dashboard_inferred_candidate_ui.js
@@ -16,9 +16,9 @@
  * 【公開関数一覧】
  * - {@link createInferredCandidateCenterContent}：フィラメント管理モーダル用 Candidate Center を生成する
  *
- * @version 1.390.1268 (PR #419)
+ * @version 1.390.1269 (PR #419)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-07-29 17:25:57
+ * @lastModified 2026-08-01 19:47:47
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -89,6 +89,9 @@ const REASON_LABELS = Object.freeze({
   candidate_history_snapshot_missing: "取り消し前の履歴情報が不足しています",
   candidate_history_snapshot_invalid: "取り消し前の履歴情報が不正です",
   candidate_history_snapshot_ambiguous: "取り消し前の履歴情報が曖昧です",
+  candidate_history_after_snapshot_missing: "確定後の履歴検証情報が不足しています",
+  candidate_history_after_snapshot_invalid: "確定後の履歴検証情報が不正です",
+  candidate_history_after_snapshot_ambiguous: "確定後の履歴検証情報が曖昧です",
   candidate_history_post_state_changed: "確定後に履歴情報が変更されたため取り消しできません",
   candidate_ledger_event_total_mismatch: "台帳イベントと候補の消費量が一致しません",
   invalid_reject_reason: "否認理由が不正です",

--- a/3dp_lib/dashboard_inferred_candidate_ui.js
+++ b/3dp_lib/dashboard_inferred_candidate_ui.js
@@ -16,9 +16,9 @@
  * 【公開関数一覧】
  * - {@link createInferredCandidateCenterContent}：フィラメント管理モーダル用 Candidate Center を生成する
  *
- * @version 1.390.1267 (PR #418)
+ * @version 1.390.1268 (PR #419)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-07-26 15:48:10
+ * @lastModified 2026-07-29 17:25:57
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -73,6 +73,7 @@ const REASON_LABELS = Object.freeze({
   target_spool_same_as_candidate: "候補スプールと同じため再割当てできません",
   target_spool_not_found: "対象スプールが見つかりません",
   confirmed_remaining_unknown: "確定残量が不明なため処理できません",
+  confirmed_remaining_insufficient: "確定残量が候補消費量を下回るため処理できません",
   history_entry_missing: "対象履歴が不足しています",
   history_observation_ambiguous: "対象履歴が曖昧です",
   history_already_attributed: "履歴がすでに別スプールへ確定されています",
@@ -80,6 +81,7 @@ const REASON_LABELS = Object.freeze({
   candidate_not_undoable: "この候補は取り消しできません",
   candidate_ledger_event_missing: "取り消し対象の台帳イベントが見つかりません",
   candidate_ledger_event_ambiguous: "取り消し対象の台帳イベントが曖昧です",
+  candidate_ledger_event_already_undone: "この台帳イベントはすでに取り消し済みです",
   candidate_ledger_event_spool_mismatch: "台帳イベントのスプールが一致しません",
   candidate_ledger_event_host_mismatch: "台帳イベントの端末情報が一致しません",
   candidate_history_link_missing: "取り消し対象の履歴帰属が見つかりません",
@@ -87,6 +89,7 @@ const REASON_LABELS = Object.freeze({
   candidate_history_snapshot_missing: "取り消し前の履歴情報が不足しています",
   candidate_history_snapshot_invalid: "取り消し前の履歴情報が不正です",
   candidate_history_snapshot_ambiguous: "取り消し前の履歴情報が曖昧です",
+  candidate_history_post_state_changed: "確定後に履歴情報が変更されたため取り消しできません",
   candidate_ledger_event_total_mismatch: "台帳イベントと候補の消費量が一致しません",
   invalid_reject_reason: "否認理由が不正です",
   rollback_durable_save_failed: "復旧状態の保存に失敗しました"
@@ -423,7 +426,8 @@ async function _reassignAction(vm) {
  * Undo 操作の確認ダイアログを表示する。
  *
  * 【詳細説明】
- * - Undo は O5 が確定した残量・履歴帰属・usedLengthLog を戻すため、実行前に対象と消費量を表示する。
+ * - Undo は O5 が確定した残量・履歴帰属を戻し、usedLengthLog へ逆仕訳 event を追記するため、
+ *   実行前に対象と消費量を表示する。
  * - 実際に戻せるかどうかは Decision Core / Ledger 側で再検証する。
  *
  * @private

--- a/docs/en/filament_manual.md
+++ b/docs/en/filament_manual.md
@@ -111,7 +111,7 @@ make the decision.
 | **Confirm** | Applies the inferred usage to the candidate spool and updates remaining length, print history and the audit ledger. It fails closed when confirmed remaining length is lower than the candidate debit. |
 | **Reject** | Marks the candidate as rejected without changing remaining length or print history. |
 | **Reassign** | Applies the inferred usage to a different selected spool. It fails closed when the target spool has insufficient confirmed remaining length. |
-| **Undo** | Reverses the remaining length and print history links created by a previous Confirm or Reassign, then appends a reversal ledger event instead of deleting the original audit event. |
+| **Undo** | Reverses the remaining length and print history links created by a previous Confirm or Reassign, then appends a reversal ledger event instead of deleting the original audit event. Undo is refused if the linked print history no longer exactly matches the state recorded immediately after the original decision. |
 
 Candidate statuses are `pending`, `confirmed`, `rejected`, `reassigned`,
 `superseded` and `undone`. Only `pending` candidates can be confirmed,

--- a/docs/en/filament_manual.md
+++ b/docs/en/filament_manual.md
@@ -108,10 +108,10 @@ make the decision.
 
 | Action | Behavior |
 | --- | --- |
-| **Confirm** | Applies the inferred usage to the candidate spool and updates remaining length, print history and the audit ledger. |
+| **Confirm** | Applies the inferred usage to the candidate spool and updates remaining length, print history and the audit ledger. It fails closed when confirmed remaining length is lower than the candidate debit. |
 | **Reject** | Marks the candidate as rejected without changing remaining length or print history. |
-| **Reassign** | Applies the inferred usage to a different selected spool. |
-| **Undo** | Reverses the remaining length, print history links and audit event created by a previous Confirm or Reassign. |
+| **Reassign** | Applies the inferred usage to a different selected spool. It fails closed when the target spool has insufficient confirmed remaining length. |
+| **Undo** | Reverses the remaining length and print history links created by a previous Confirm or Reassign, then appends a reversal ledger event instead of deleting the original audit event. |
 
 Candidate statuses are `pending`, `confirmed`, `rejected`, `reassigned`,
 `superseded` and `undone`. Only `pending` candidates can be confirmed,

--- a/docs/ja/filament_manual.md
+++ b/docs/ja/filament_manual.md
@@ -86,7 +86,7 @@ monitorData.hostSpoolMap = {
 | **Confirm** | 候補スプールへ推定消費量を確定反映し、残量・履歴・台帳イベントを更新します。確定残量が候補消費量より少ない場合は処理しません |
 | **Reject** | 候補を否認します。残量や履歴は変更しません |
 | **Reassign** | 候補とは別のスプールへ推定消費量を確定反映します。再割当て先の確定残量が不足する場合は処理しません |
-| **Undo** | Confirm / Reassign 済みの候補について、O5 が追加した残量・履歴帰属を戻し、台帳には逆仕訳イベントを追記します |
+| **Undo** | Confirm / Reassign 済みの候補について、O5 が追加した残量・履歴帰属を戻し、台帳には逆仕訳イベントを追記します。元の決定直後に記録した履歴状態と現在の履歴状態が完全一致しない場合は、後続変更を消さないため処理しません |
 
 候補には `pending`, `confirmed`, `rejected`, `reassigned`, `superseded`, `undone` の状態があります。`pending` だけが Confirm / Reject / Reassign の対象で、`confirmed` と `reassigned` だけが Undo の対象です。
 

--- a/docs/ja/filament_manual.md
+++ b/docs/ja/filament_manual.md
@@ -83,10 +83,10 @@ monitorData.hostSpoolMap = {
 
 | 操作 | 内容 |
 | --- | --- |
-| **Confirm** | 候補スプールへ推定消費量を確定反映し、残量・履歴・台帳イベントを更新します |
+| **Confirm** | 候補スプールへ推定消費量を確定反映し、残量・履歴・台帳イベントを更新します。確定残量が候補消費量より少ない場合は処理しません |
 | **Reject** | 候補を否認します。残量や履歴は変更しません |
-| **Reassign** | 候補とは別のスプールへ推定消費量を確定反映します |
-| **Undo** | Confirm / Reassign 済みの候補について、O5 が追加した残量・履歴・台帳イベントを取り消します |
+| **Reassign** | 候補とは別のスプールへ推定消費量を確定反映します。再割当て先の確定残量が不足する場合は処理しません |
+| **Undo** | Confirm / Reassign 済みの候補について、O5 が追加した残量・履歴帰属を戻し、台帳には逆仕訳イベントを追記します |
 
 候補には `pending`, `confirmed`, `rejected`, `reassigned`, `superseded`, `undone` の状態があります。`pending` だけが Confirm / Reject / Reassign の対象で、`confirmed` と `reassigned` だけが Undo の対象です。
 

--- a/tests/unit/dashboard_inferred_candidate_decision.test.js
+++ b/tests/unit/dashboard_inferred_candidate_decision.test.js
@@ -131,6 +131,22 @@ function candidate(over = {}) {
   };
 }
 
+/**
+ * 手動で resolve/reject できる Promise を作る。
+ *
+ * @function deferred
+ * @returns {{promise:Promise<*>,resolve:Function,reject:Function}} deferred Promise。
+ */
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 beforeEach(() => {
   mocks.saveUnifiedStorageDurably.mockReset();
   mocks.saveUnifiedStorageDurably.mockResolvedValue({ ok: true, backend: "test", reason: "saved" });
@@ -284,6 +300,18 @@ describe("confirmInferredCandidate", () => {
     expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
   });
 
+  it("対象 spool の確定残量が candidate 使用量未満なら fail-closed する", async () => {
+    mocks.monitorData.filamentSpools[0].remainingLengthMm = 100;
+
+    const result = await confirmInferredCandidate("ic-a", { nowMs: 11000 });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("confirmed_remaining_insufficient");
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(100);
+    expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.PENDING);
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+
   it("履歴が既に帰属済みなら二重反映しない", async () => {
     mocks.monitorData.machines.k1.printStore.history[0].filamentInfo = [{ spoolId: "S9", usedMm: 1000 }];
 
@@ -327,6 +355,78 @@ describe("confirmInferredCandidate", () => {
       action: "confirm",
       reason: "rollback_durable_save_failed"
     });
+  });
+
+  it("同時 decision は直列化され、先行失敗rollback後に後続を開始する", async () => {
+    mocks.monitorData.machines.k1.printStore.history.push(job("kC", 1500), job("kD", 1500));
+    mocks.monitorData.inferredCandidateStore["ic-b"] = candidate({
+      candidateHash: "ic-b",
+      observationKeys: ["kC", "kD"],
+      candidateDebits: [
+        { observationKey: "kC", status: "inferred-debit", usedMm: 1500, reason: "unattributed-usage", confirmedSpoolIds: [] },
+        { observationKey: "kD", status: "inferred-debit", usedMm: 1500, reason: "unattributed-usage", confirmedSpoolIds: [] }
+      ],
+      events: [{ type: "created", at: 9000, status: INFERRED_CANDIDATE_STATUS.PENDING, usedMm: 3000 }]
+    });
+    const firstSave = deferred();
+    mocks.saveUnifiedStorageDurably
+      .mockImplementationOnce(() => firstSave.promise)
+      .mockResolvedValueOnce({ ok: true, backend: "indexedDB", reason: "rollback_saved" })
+      .mockResolvedValueOnce({ ok: true, backend: "indexedDB", reason: "saved-b" });
+
+    const first = confirmInferredCandidate("ic-a", { actor: "operator", nowMs: 11000 });
+    await Promise.resolve();
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(7000);
+    expect(mocks.saveUnifiedStorageDurably).toHaveBeenCalledTimes(1);
+
+    const second = confirmInferredCandidate("ic-b", { actor: "operator", nowMs: 12000 });
+    await Promise.resolve();
+    expect(mocks.saveUnifiedStorageDurably).toHaveBeenCalledTimes(1);
+    expect(mocks.monitorData.inferredCandidateStore["ic-b"].status).toBe(INFERRED_CANDIDATE_STATUS.PENDING);
+
+    firstSave.resolve({ ok: false, backend: "indexedDB", reason: "idb_fail" });
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult.ok).toBe(false);
+    expect(firstResult.reason).toBe("idb_fail");
+    expect(secondResult.ok).toBe(true);
+    expect(secondResult.reason).toBe("confirmed");
+    expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.PENDING);
+    expect(mocks.monitorData.inferredCandidateStore["ic-b"].status).toBe(INFERRED_CANDIDATE_STATUS.CONFIRMED);
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(7000);
+    expect(mocks.monitorData.filamentSpools[0].usedLengthLog).toHaveLength(1);
+    expect(mocks.monitorData.filamentSpools[0].usedLengthLog[0].candidateHash).toBe("ic-b");
+  });
+
+  it("先行 decision 成功後、後続 decision は更新後 remaining を基準に処理する", async () => {
+    mocks.monitorData.machines.k1.printStore.history.push(job("kC", 1500), job("kD", 1500));
+    mocks.monitorData.inferredCandidateStore["ic-b"] = candidate({
+      candidateHash: "ic-b",
+      observationKeys: ["kC", "kD"],
+      candidateDebits: [
+        { observationKey: "kC", status: "inferred-debit", usedMm: 1500, reason: "unattributed-usage", confirmedSpoolIds: [] },
+        { observationKey: "kD", status: "inferred-debit", usedMm: 1500, reason: "unattributed-usage", confirmedSpoolIds: [] }
+      ],
+      events: [{ type: "created", at: 9000, status: INFERRED_CANDIDATE_STATUS.PENDING, usedMm: 3000 }]
+    });
+    const firstSave = deferred();
+    mocks.saveUnifiedStorageDurably
+      .mockImplementationOnce(() => firstSave.promise)
+      .mockResolvedValueOnce({ ok: true, backend: "indexedDB", reason: "saved-b" });
+
+    const first = confirmInferredCandidate("ic-a", { actor: "operator", nowMs: 11000 });
+    await Promise.resolve();
+    const second = confirmInferredCandidate("ic-b", { actor: "operator", nowMs: 12000 });
+    await Promise.resolve();
+    expect(mocks.saveUnifiedStorageDurably).toHaveBeenCalledTimes(1);
+
+    firstSave.resolve({ ok: true, backend: "indexedDB", reason: "saved-a" });
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult.ok).toBe(true);
+    expect(secondResult.ok).toBe(true);
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(4000);
+    expect(mocks.monitorData.filamentSpools[0].usedLengthLog.map(item => item.candidateHash)).toEqual(["ic-a", "ic-b"]);
   });
 });
 
@@ -384,6 +484,18 @@ describe("reassignInferredCandidate", () => {
     expect(result.reason).toBe("target_spool_same_as_candidate");
     expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
   });
+
+  it("再割当て先 spool の確定残量が candidate 使用量未満なら fail-closed する", async () => {
+    mocks.monitorData.filamentSpools.find(s => s.id === "S2").remainingLengthMm = 100;
+
+    const result = await reassignInferredCandidate("ic-a", "S2", { actor: "operator", nowMs: 11000 });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("confirmed_remaining_insufficient");
+    expect(mocks.monitorData.filamentSpools.find(s => s.id === "S2").remainingLengthMm).toBe(100);
+    expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.PENDING);
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
 });
 
 describe("undoInferredCandidateDecision", () => {
@@ -397,7 +509,15 @@ describe("undoInferredCandidateDecision", () => {
     expect(result.ok).toBe(true);
     expect(result.reason).toBe("undone");
     expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(10000);
-    expect(mocks.monitorData.filamentSpools[0].usedLengthLog).toEqual([]);
+    expect(mocks.monitorData.filamentSpools[0].usedLengthLog).toHaveLength(2);
+    expect(mocks.monitorData.filamentSpools[0].usedLengthLog[0].type).toBe("inferred-continuity-confirmed");
+    expect(mocks.monitorData.filamentSpools[0].usedLengthLog[1]).toMatchObject({
+      type: "inferred-continuity-undone",
+      reversesEventId: mocks.monitorData.filamentSpools[0].usedLengthLog[0].eventId,
+      candidateHash: "ic-a",
+      usedMm: 3000,
+      actor: "operator"
+    });
     const history = mocks.monitorData.machines.k1.printStore.history;
     expect(history[0].filamentId).toBeUndefined();
     expect(history[0].filamentInfo).toBeUndefined();
@@ -571,9 +691,50 @@ describe("undoInferredCandidateDecision", () => {
     expect(result.ok).toBe(true);
     expect(mocks.monitorData.filamentSpools.find(s => s.id === "S1").remainingLengthMm).toBe(10000);
     expect(mocks.monitorData.filamentSpools.find(s => s.id === "S2").remainingLengthMm).toBe(8000);
-    expect(mocks.monitorData.filamentSpools.find(s => s.id === "S2").usedLengthLog).toEqual([]);
+    expect(mocks.monitorData.filamentSpools.find(s => s.id === "S2").usedLengthLog).toHaveLength(2);
+    expect(mocks.monitorData.filamentSpools.find(s => s.id === "S2").usedLengthLog[1]).toMatchObject({
+      type: "inferred-continuity-undone",
+      candidateHash: "ic-a"
+    });
     expect(mocks.monitorData.machines.k1.printStore.history[0].filamentId).toBeUndefined();
     expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.UNDONE);
+  });
+
+  it("Confirm 後に別metadataが履歴へ追加された場合は Undo しない", async () => {
+    const confirmed = await confirmInferredCandidate("ic-a", { actor: "operator", nowMs: 11000 });
+    expect(confirmed.ok).toBe(true);
+    mocks.monitorData.machines.k1.printStore.history[0].filamentInfo.push({
+      spoolId: "S9",
+      usedMm: 1,
+      source: "post-confirm-edit"
+    });
+    mocks.saveUnifiedStorageDurably.mockClear();
+
+    const result = await undoInferredCandidateDecision("ic-a", { actor: "operator", nowMs: 12000 });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("candidate_history_post_state_changed");
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(7000);
+    expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.CONFIRMED);
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+
+  it("逆仕訳eventが既にある台帳eventは二重Undoしない", async () => {
+    const confirmed = await confirmInferredCandidate("ic-a", { actor: "operator", nowMs: 11000 });
+    expect(confirmed.ok).toBe(true);
+    const undone = await undoInferredCandidateDecision("ic-a", { actor: "operator", nowMs: 12000 });
+    expect(undone.ok).toBe(true);
+    mocks.monitorData.inferredCandidateStore["ic-a"].status = INFERRED_CANDIDATE_STATUS.CONFIRMED;
+    mocks.monitorData.inferredCandidateStore["ic-a"].resolvedAt = 11000;
+    mocks.saveUnifiedStorageDurably.mockClear();
+
+    const result = await undoInferredCandidateDecision("ic-a", { actor: "operator", nowMs: 13000 });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("candidate_ledger_event_already_undone");
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(10000);
+    expect(mocks.monitorData.filamentSpools[0].usedLengthLog).toHaveLength(2);
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
   });
 
   it("未反映 status の candidate は Undo しない", async () => {

--- a/tests/unit/dashboard_inferred_candidate_decision.test.js
+++ b/tests/unit/dashboard_inferred_candidate_decision.test.js
@@ -275,6 +275,18 @@ describe("confirmInferredCandidate", () => {
       isInferredContinuityConfirmed: true,
       candidateHash: "ic-a"
     });
+    expect(mocks.monitorData.filamentSpools[0].usedLengthLog[0].historyAfter[0]).toMatchObject({
+      observationKey: "kA",
+      filamentInfoPresent: true,
+      filamentIdPresent: true,
+      filamentId: "S1"
+    });
+    expect(mocks.monitorData.filamentSpools[0].usedLengthLog[0].historyAfter[0].filamentInfo[0]).toMatchObject({
+      spoolId: "S1",
+      usedMm: 1000,
+      isInferredContinuityConfirmed: true,
+      candidateHash: "ic-a"
+    });
     expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.CONFIRMED);
     expect(mocks.saveUnifiedStorageDurably).toHaveBeenCalledTimes(1);
   });
@@ -654,6 +666,13 @@ describe("undoInferredCandidateDecision", () => {
         filamentIdPresent: true,
         filamentId: "none"
       }],
+      historyAfter: [{
+        observationKey: "kA",
+        filamentInfoPresent: true,
+        filamentInfo: entry.filamentInfo.map(item => ({ ...item })),
+        filamentIdPresent: true,
+        filamentId: "S1"
+      }],
       createdAt: 11000
     });
     mocks.saveUnifiedStorageDurably.mockClear();
@@ -708,6 +727,60 @@ describe("undoInferredCandidateDecision", () => {
       usedMm: 1,
       source: "post-confirm-edit"
     });
+    mocks.saveUnifiedStorageDurably.mockClear();
+
+    const result = await undoInferredCandidateDecision("ic-a", { actor: "operator", nowMs: 12000 });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("candidate_history_post_state_changed");
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(7000);
+    expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.CONFIRMED);
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["material", "PETG"],
+    ["filamentColor", "#00ff00"],
+    ["colorName", "green"],
+    ["usedMm", 9999]
+  ])("Confirm 後に同一 filamentInfo 行の %s が変更された場合は Undo しない", async (field, value) => {
+    const beforeInfo = [{ color: "#ff0000", material: "PLA", filamentColor: "#ff0000", colorName: "red" }];
+    const entry = mocks.monitorData.machines.k1.printStore.history[0];
+    entry.filamentInfo = beforeInfo.map(item => ({ ...item }));
+
+    const confirmed = await confirmInferredCandidate("ic-a", { actor: "operator", nowMs: 11000 });
+    expect(confirmed.ok).toBe(true);
+    entry.filamentInfo[0][field] = value;
+    mocks.saveUnifiedStorageDurably.mockClear();
+
+    const result = await undoInferredCandidateDecision("ic-a", { actor: "operator", nowMs: 12000 });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("candidate_history_post_state_changed");
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(7000);
+    expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.CONFIRMED);
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+
+  it("Confirm 後に filamentId が削除された場合は Undo しない", async () => {
+    const confirmed = await confirmInferredCandidate("ic-a", { actor: "operator", nowMs: 11000 });
+    expect(confirmed.ok).toBe(true);
+    delete mocks.monitorData.machines.k1.printStore.history[0].filamentId;
+    mocks.saveUnifiedStorageDurably.mockClear();
+
+    const result = await undoInferredCandidateDecision("ic-a", { actor: "operator", nowMs: 12000 });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("candidate_history_post_state_changed");
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(7000);
+    expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.CONFIRMED);
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+
+  it("Confirm 後に filamentId が null へ変更された場合は Undo しない", async () => {
+    const confirmed = await confirmInferredCandidate("ic-a", { actor: "operator", nowMs: 11000 });
+    expect(confirmed.ok).toBe(true);
+    mocks.monitorData.machines.k1.printStore.history[0].filamentId = null;
     mocks.saveUnifiedStorageDurably.mockClear();
 
     const result = await undoInferredCandidateDecision("ic-a", { actor: "operator", nowMs: 12000 });


### PR DESCRIPTION
## Summary
- serialize all local O5 inferred-candidate decisions in Parent/Standalone mode so durable-save waits cannot overlap rollback snapshots
- fail closed when Confirm/Reassign candidate debit exceeds confirmed remaining length
- keep Undo auditable by appending a reversal ledger event instead of deleting the original decision event
- add Undo post-state validation before restoring history metadata and document the behavior in JA/EN manuals

## Review Findings Addressed
- P0: concurrent O5 decisions can rollback another decision
- P1: remaining clamp and Undo were asymmetric
- P1: Undo physically deleted the original ledger event
- P2: Undo could restore over post-confirm history metadata changes

## Validation
- npx vitest run tests/unit/dashboard_inferred_candidate_decision.test.js tests/unit/dashboard_inferred_candidate_view.test.js tests/unit/dashboard_inferred_candidate_ui.test.js tests/unit/dashboard_relay_bridge_filament_ops.test.js tests/unit/dashboard_offline_candidate_store.test.js
- npx vitest run
- npx eslint 3dp_lib/dashboard_inferred_candidate_decision.js 3dp_lib/dashboard_inferred_candidate_ledger.js 3dp_lib/dashboard_inferred_candidate_ui.js tests/unit/dashboard_inferred_candidate_decision.test.js tests/unit/dashboard_inferred_candidate_ui.test.js tests/unit/dashboard_inferred_candidate_view.test.js
- git diff --check

## Notes
- Targeted ESLint has 0 errors; it still reports existing JSDoc-style warnings from the repository configuration.
