### PR TITLE
Add O6 inferred recovery operations

### DIFF
--- a/3dp_lib/dashboard_client_sync.js
+++ b/3dp_lib/dashboard_client_sync.js
@@ -13,6 +13,7 @@
  *   （フィラメント共有状態は親権威の全置換 + mountHistory / recovery 診断同期）
  * - satellite モードでのコマンド/フィラメント操作の送信（操作は親へ RPC 委譲）
  * - O5 inferred candidate decision request を Parent へ送信
+ * - O6 recovery / repair 操作の監査状態を Parent から read-only 同期する
  * - 初回接続は常に readonly。?relay=satellite 要求時は自動昇格リクエスト（PIN 保護）
  *
  * 【公開関数一覧】
@@ -21,9 +22,9 @@
  * - {@link sendRelayCommand}：親経由でプリンタにコマンド送信
  * - {@link sendRelayFilament}：親経由でフィラメント操作
  *
- * @version 1.390.1268 (PR #418)
+ * @version 1.390.1270 (PR #420)
  * @since   1.390.820 (PR #367)
- * @lastModified 2026-08-01 23:20:09
+ * @lastModified 2026-08-02 15:05:22
  * -----------------------------------------------------------
  */
 
@@ -313,7 +314,7 @@ function _applyRelayPrintStore(hostname, ps) {
  * ※ モジュール内部用だが、マージ規則の回帰テストのために export している。
  *
  * @function _applySharedFilamentState
- * @param {{filamentSpools?:Array<Object>, hostSpoolMap?:Object, mountHistory?:Array<Object>, pendingUnattributedUsage?:Array<Object>, inferredCandidateStore?:Object, inferredDecisionRecoveryRequired?:Object|null, ledgerRepairRequired?:Object, mountHistoryRejectedEvents?:Array<Object>}} shared
+ * @param {{filamentSpools?:Array<Object>, hostSpoolMap?:Object, mountHistory?:Array<Object>, pendingUnattributedUsage?:Array<Object>, inferredCandidateStore?:Object, inferredDecisionRecoveryRequired?:Object|null, inferredRecoveryEvents?:Array<Object>, ledgerRepairRequired?:Object, mountHistoryRejectedEvents?:Array<Object>}} shared
  *   - 受信した共有データ
  * @returns {void}
  */
@@ -375,6 +376,10 @@ export function _applySharedFilamentState(shared) {
         ? { ...shared.inferredDecisionRecoveryRequired }
         : null;
   }
+  if (Object.prototype.hasOwnProperty.call(shared, "inferredRecoveryEvents")) {
+    if (!Array.isArray(monitorData.inferredRecoveryEvents)) monitorData.inferredRecoveryEvents = [];
+    _replaceArrayInPlace(monitorData.inferredRecoveryEvents, shared.inferredRecoveryEvents);
+  }
   if (Object.prototype.hasOwnProperty.call(shared, "ledgerRepairRequired")
       && shared.ledgerRepairRequired
       && typeof shared.ledgerRepairRequired === "object") {
@@ -433,6 +438,7 @@ function _maybeNotifyFilamentDomainChanged() {
     monitorData.spoolSerialCounter ?? 0,
     (monitorData.usageHistory || []).length,
     JSON.stringify(monitorData.inferredDecisionRecoveryRequired || null),
+    JSON.stringify(monitorData.inferredRecoveryEvents || []),
     JSON.stringify(monitorData.ledgerRepairRequired || {}),
     JSON.stringify(monitorData.mountHistoryRejectedEvents || []),
   ].join("|");

--- a/3dp_lib/dashboard_data.js
+++ b/3dp_lib/dashboard_data.js
@@ -19,9 +19,9 @@
  * - {@link getDisplayValue}：表示用値取得
  * - {@link markAllKeysDirty}：全キーを変更済みにマーク
  *
-* @version 1.390.1245 (PR #412)
+* @version 1.390.1270 (PR #420)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-07-19 18:45:00
+* @lastModified 2026-08-02 15:05:22
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -301,6 +301,20 @@ export const monitorData = {
    */
   inferredCandidateStore: {},
   /**
+   * ★ #417/O5D: O5 decision rollback 後の状態を耐久保存できなかった場合の復旧要求。
+   * null なら通常状態。object の場合は新規 Confirm/Reject/Reassign/Undo を fail-closed で停止し、
+   * O6 Recovery Operations で状態確認・再保存・解除を行う。
+   * @type {?Object}
+   */
+  inferredDecisionRecoveryRequired: null,
+  /**
+   * ★ #420/O6A: recovery / repair 操作の監査 event。
+   * decision recovery flag 解除、ledger repair flag 解除、隔離 mount event の archive などを追記し、
+   * 復旧操作が通常の candidate decision と同様に追跡できるようにする。
+   * @type {Array<Object>}
+   */
+  inferredRecoveryEvents: [],
+  /**
    * ★ Phase2A: 有効な jobId が無いまま完了した消費の隔離領域。
    * 電源投入直後などで printStartTime が 0/null の「無効ID」ジョブは
    * 履歴・usedLengthLog・境界へ確定記録を作らず（過去全履歴の誤減算＝退行を防ぐ）、
@@ -540,5 +554,4 @@ export function markAllKeysDirty(hostname) {
     dirtySet.add(key);
   }
 }
-
 

--- a/3dp_lib/dashboard_inferred_candidate_decision.js
+++ b/3dp_lib/dashboard_inferred_candidate_decision.js
@@ -19,6 +19,7 @@
  * - Undo も同じ transaction 境界で、O5 が追加した台帳 event と履歴 attribution だけを逆反映する。
  *
  * 【公開関数一覧】
+ * - {@link enqueueLedgerDecisionTask}：O5/O6 の ledger 操作を共通キューで直列化する
  * - {@link canExecuteLedgerDecision}：この端末で O5 decision を実行できるか判定する
  * - {@link canSubmitLedgerDecision}：この端末から O5 decision を送信できるか判定する
  * - {@link confirmInferredCandidate}：candidate spool で推定使用量を確定する
@@ -26,9 +27,9 @@
  * - {@link reassignInferredCandidate}：別 spool へ再割当てして推定使用量を確定する
  * - {@link undoInferredCandidateDecision}：確定済み candidate の台帳反映を取り消す
  *
- * @version 1.390.1268 (PR #419)
+ * @version 1.390.1270 (PR #420)
  * @since   1.390.1261 (PR #414)
- * @lastModified 2026-07-29 17:25:57
+ * @lastModified 2026-08-02 00:00:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -84,12 +85,29 @@ const ALLOWED_REJECT_REASONS = new Set([
 let _decisionQueue = Promise.resolve();
 
 /**
- * ローカル O5 decision を全体キューへ投入する。
+ * O5/O6 の ledger 操作を全体キューへ投入する。
  *
  * 【詳細説明】
  * - 直前 decision が成功しても失敗しても、次の decision は必ずその後に開始する。
  * - 呼び出し元には task の戻り値をそのまま返し、キュー内部では rejection を吸収して後続が詰まらない
  *   ようにする。
+ *
+ * @function enqueueLedgerDecisionTask
+ * @param {Function} task - 実行する decision 本体。
+ * @returns {Promise<*>} decision 本体の戻り値。
+ */
+export function enqueueLedgerDecisionTask(task) {
+  const run = _decisionQueue.then(task, task);
+  _decisionQueue = run.catch(() => {});
+  return run;
+}
+
+/**
+ * ローカル O5 decision を全体キューへ投入する。
+ *
+ * 【詳細説明】
+ * - O6 Recovery Operations も同じキューを使うため、O5 側の呼び出し点は小さな wrapper に集約する。
+ * - public API ではない既存 decision 実装の読みやすさを保つため、関数名は O5 文脈のまま残す。
  *
  * @private
  * @function _enqueueDecision
@@ -97,9 +115,7 @@ let _decisionQueue = Promise.resolve();
  * @returns {Promise<*>} decision 本体の戻り値。
  */
 function _enqueueDecision(task) {
-  const run = _decisionQueue.then(task, task);
-  _decisionQueue = run.catch(() => {});
-  return run;
+  return enqueueLedgerDecisionTask(task);
 }
 
 /**

--- a/3dp_lib/dashboard_inferred_candidate_ui.js
+++ b/3dp_lib/dashboard_inferred_candidate_ui.js
@@ -11,14 +11,14 @@
  * - O5B Candidate Center として pending/処理済み candidate の一覧、詳細、監査 timeline を描画する。
  * - Confirm / Reject / Reassign / Undo の操作ダイアログを提供し、実更新は Decision Core へ委譲する。
  * - SATELLITE 子では Parent へ decision request を送り、readonly 子では操作ボタンを disabled にする。
- * - recovery / repair flag は read-only 診断カードとして表示し、復旧操作は後続PRへ分離する。
+ * - recovery / repair flag は診断カードとして表示し、O6 Recovery Operations を Parent/Standalone へ接続する。
  *
  * 【公開関数一覧】
  * - {@link createInferredCandidateCenterContent}：フィラメント管理モーダル用 Candidate Center を生成する
  *
- * @version 1.390.1269 (PR #419)
+ * @version 1.390.1270 (PR #420)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-08-01 19:47:47
+ * @lastModified 2026-08-02 15:05:22
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -41,6 +41,13 @@ import {
   countPendingInferredCandidates,
   listInferredCandidateViewModels
 } from "./dashboard_inferred_candidate_view.js";
+import {
+  archiveMountHistoryRejectedEvents,
+  canExecuteRecoveryOperation,
+  clearInferredDecisionRecoveryRequired,
+  clearLedgerRepairRequired,
+  retryInferredRecoveryDurableSave
+} from "./dashboard_inferred_recovery_ops.js";
 import { showAlert } from "./dashboard_notification_manager.js";
 import { showConfirmDialog } from "./dashboard_ui_confirm.js";
 import { createEmptyState } from "./dashboard_ui_components.js";
@@ -95,7 +102,18 @@ const REASON_LABELS = Object.freeze({
   candidate_history_post_state_changed: "確定後に履歴情報が変更されたため取り消しできません",
   candidate_ledger_event_total_mismatch: "台帳イベントと候補の消費量が一致しません",
   invalid_reject_reason: "否認理由が不正です",
-  rollback_durable_save_failed: "復旧状態の保存に失敗しました"
+  rollback_durable_save_failed: "復旧状態の保存に失敗しました",
+  recovery_not_authorized: "この端末では復旧操作を実行できません。親端末で実行してください",
+  recovery_not_required: "復旧対象はありません",
+  decision_recovery_not_found: "整合性確認フラグは見つかりません",
+  recovery_retry_not_durably_saved: "復旧状態の再保存に失敗しました",
+  recovery_operation_rollback_save_failed: "復旧操作のrollback状態を保存できませんでした",
+  decision_recovery_clear_not_durably_saved: "整合性確認フラグの解除を保存できませんでした",
+  ledger_repair_host_required: "修復対象ホストが不正です",
+  ledger_repair_not_found: "台帳修復フラグは見つかりません",
+  ledger_repair_clear_not_durably_saved: "台帳修復フラグの解除を保存できませんでした",
+  mount_history_rejected_events_not_found: "隔離済みmount eventは見つかりません",
+  mount_history_rejected_archive_not_durably_saved: "隔離済みmount eventの退避を保存できませんでした"
 });
 
 /**
@@ -263,18 +281,152 @@ function _warningChips(codes) {
 }
 
 /**
+ * recovery 操作結果を通知し、必要なら再描画する。
+ *
+ * @private
+ * @function _handleRecoveryResult
+ * @param {Object} result - O6 Recovery Operations の戻り値。
+ * @param {Function} render - 再描画関数。
+ * @param {Function} [onAfterDecision] - 外部再描画 hook。
+ * @returns {void}
+ */
+function _handleRecoveryResult(result, render, onAfterDecision) {
+  if (result?.ok) {
+    const label = result.reason === "recovery_durable_save_retried" ? "復旧状態を再保存しました"
+      : result.reason === "decision_recovery_cleared" ? "整合性確認フラグを解除しました"
+        : result.reason === "ledger_repair_cleared" ? "台帳修復フラグを解除しました"
+          : result.reason === "mount_history_rejected_events_archived" ? "隔離イベントを監査へ退避しました"
+            : "復旧操作を実行しました";
+    showAlert(label, "success");
+    try { onAfterDecision?.(result); } catch { /* noop */ }
+    render();
+    return;
+  }
+  showAlert(_reasonLabel(result?.reason), "error");
+  render();
+}
+
+/**
+ * recovery 操作の確認ダイアログを表示する。
+ *
+ * @private
+ * @function _confirmRecoveryAction
+ * @param {string} title - ダイアログタイトル。
+ * @param {string} summary - 表示する説明。
+ * @param {string} confirmText - 実行ボタン文言。
+ * @returns {Promise<boolean>} 実行する場合 true。
+ */
+async function _confirmRecoveryAction(title, summary, confirmText) {
+  const body = _el("div", "ic-confirm-summary");
+  body.appendChild(_el("p", "", summary));
+  const ok = await showConfirmDialog({
+    level: "warn",
+    title,
+    html: body.outerHTML,
+    confirmText,
+    cancelText: "キャンセル"
+  });
+  return ok === true;
+}
+
+/**
+ * recovery card の操作ボタンを追加する。
+ *
+ * 【詳細説明】
+ * - O6A では Parent/Standalone だけが復旧操作を実行できる。
+ * - Satellite は親の診断を read-only 表示するため、ボタンは disabled としローカル書き込みを行わない。
+ *
+ * @private
+ * @function _appendRecoveryActions
+ * @param {HTMLElement} el - card 要素。
+ * @param {Object} card - recovery surface card ViewModel。
+ * @param {Function} render - 再描画関数。
+ * @param {Function} [onAfterDecision] - 外部再描画 hook。
+ * @returns {void}
+ */
+function _appendRecoveryActions(el, card, render, onAfterDecision) {
+  const canExecute = canExecuteRecoveryOperation();
+  const actions = _el("div", "ic-recovery-actions");
+  if (!canExecute) {
+    actions.appendChild(_el("div", "ic-readonly-note", "この端末はSatellite/閲覧専用です。復旧操作は親端末で実行してください。"));
+  }
+
+  if (card.type === "decision-recovery") {
+    const retryBtn = _el("button", "ic-action-secondary", "Retry save");
+    retryBtn.disabled = !canExecute;
+    retryBtn.addEventListener("click", async () => {
+      await _withBusy(el, async () => {
+        const result = await retryInferredRecoveryDurableSave({ actor: _actor() });
+        _handleRecoveryResult(result, render, onAfterDecision);
+      });
+    });
+    const clearBtn = _el("button", "ic-action-secondary", "Clear recovery");
+    clearBtn.disabled = !canExecute;
+    clearBtn.addEventListener("click", async () => {
+      await _withBusy(el, async () => {
+        const ok = await _confirmRecoveryAction(
+          "整合性確認フラグを解除",
+          "rollback後のcandidate・残量・履歴状態を確認済みの場合だけ解除してください。",
+          "解除する"
+        );
+        if (!ok) return;
+        const result = await clearInferredDecisionRecoveryRequired({ actor: _actor() });
+        _handleRecoveryResult(result, render, onAfterDecision);
+      });
+    });
+    actions.append(retryBtn, clearBtn);
+  } else if (card.type === "ledger-repair") {
+    const clearBtn = _el("button", "ic-action-secondary", "Clear repair");
+    clearBtn.disabled = !canExecute || !card.host;
+    clearBtn.addEventListener("click", async () => {
+      await _withBusy(el, async () => {
+        const ok = await _confirmRecoveryAction(
+          "台帳修復フラグを解除",
+          "対象hostのmount ledgerを確認済みの場合だけ解除してください。",
+          "解除する"
+        );
+        if (!ok) return;
+        const result = await clearLedgerRepairRequired(card.host, { actor: _actor() });
+        _handleRecoveryResult(result, render, onAfterDecision);
+      });
+    });
+    actions.appendChild(clearBtn);
+  } else if (card.type === "mount-history-rejected") {
+    const archiveBtn = _el("button", "ic-action-secondary", "Archive rejected");
+    archiveBtn.disabled = !canExecute;
+    archiveBtn.addEventListener("click", async () => {
+      await _withBusy(el, async () => {
+        const ok = await _confirmRecoveryAction(
+          "隔離イベントを監査へ退避",
+          "隔離済みmount eventをrecovery audit eventへ退避し、warningを閉じます。",
+          "退避する"
+        );
+        if (!ok) return;
+        const result = await archiveMountHistoryRejectedEvents({ actor: _actor() });
+        _handleRecoveryResult(result, render, onAfterDecision);
+      });
+    });
+    actions.appendChild(archiveBtn);
+  }
+
+  if (actions.childNodes.length > 0) el.appendChild(actions);
+}
+
+/**
  * recovery / repair 診断カードを生成する。
  *
  * 【詳細説明】
- * - #418 では復旧操作を持たせず、異常状態を read-only で見えるようにする。
- * - card.details は ViewModel 層で表示可能な文字列へ整形済みなので、ここでは DOM を組み立てるだけにする。
+ * - #420 では Parent/Standalone に限定して復旧操作を接続する。
+ * - card.details は ViewModel 層で表示可能な文字列へ整形済みなので、ここでは DOM と操作ボタンを組み立てる。
  *
  * @private
  * @function _recoveryCard
  * @param {Object} card - recovery surface card ViewModel。
+ * @param {Function} render - 再描画関数。
+ * @param {Function} [onAfterDecision] - 外部再描画 hook。
  * @returns {HTMLElement} card 要素。
  */
-function _recoveryCard(card) {
+function _recoveryCard(card, render, onAfterDecision) {
   const el = _el("article", `ic-recovery-card ic-recovery-${card.severity || "warning"}`);
   const header = _el("div", "ic-recovery-card-header");
   header.append(
@@ -287,6 +439,7 @@ function _recoveryCard(card) {
     detailWrap.appendChild(_kv(detail.label, detail.value));
   }
   if (detailWrap.childNodes.length > 0) el.appendChild(detailWrap);
+  _appendRecoveryActions(el, card, render, onAfterDecision);
   return el;
 }
 
@@ -302,7 +455,7 @@ function _recoveryCard(card) {
  * @param {HTMLElement} wrap - 描画先。
  * @returns {void}
  */
-function _renderRecoverySurface(wrap) {
+function _renderRecoverySurface(wrap, render, onAfterDecision) {
   const model = buildInferredRecoverySurfaceViewModel();
   wrap.innerHTML = "";
   if (!model.hasIssues) return;
@@ -313,7 +466,7 @@ function _renderRecoverySurface(wrap) {
     "ic-recovery-overview",
     `Blocker ${model.blockerCount} / Warning ${model.warningCount}`
   ));
-  for (const card of model.cards) panel.appendChild(_recoveryCard(card));
+  for (const card of model.cards) panel.appendChild(_recoveryCard(card, render, onAfterDecision));
   wrap.appendChild(panel);
 }
 
@@ -721,7 +874,7 @@ export function createInferredCandidateCenterContent(options = {}) {
    * @returns {void} 戻り値はない。
    */
   function render() {
-    _renderRecoverySurface(recoveryWrap);
+    _renderRecoverySurface(recoveryWrap, render, options.onAfterDecision);
     const models = listInferredCandidateViewModels({
       status: statusSelect.value,
       sort: sortSelect.value,

--- a/3dp_lib/dashboard_inferred_recovery_ops.js
+++ b/3dp_lib/dashboard_inferred_recovery_ops.js
@@ -1,0 +1,462 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 O6 Recovery Operations モジュール
+ * @file dashboard_inferred_recovery_ops.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * @author pumpCurry
+ * -----------------------------------------------------------
+ * @module dashboard_inferred_recovery_ops
+ *
+ * 【機能内容サマリ】
+ * - O6A として、O5 decision recovery / mount ledger repair / rejected mount event の復旧操作を提供する。
+ * - STAND ALONE と PARENT だけが復旧操作を実行し、SATELLITE は親権威の診断を閲覧するだけにする。
+ * - 各操作は O5 decision と同じ直列化キューを使い、保存境界や rollback 境界の競合を避ける。
+ * - 復旧操作は `inferredRecoveryEvents` へ監査 event を追記し、耐久保存失敗時はメモリ状態を rollback する。
+ *
+ * 【公開関数一覧】
+ * - {@link canExecuteRecoveryOperation}：この端末で O6 recovery 操作を実行できるか判定する
+ * - {@link retryInferredRecoveryDurableSave}：現在の recovery / repair 状態を再度耐久保存する
+ * - {@link clearInferredDecisionRecoveryRequired}：確認済みの O5 decision recovery flag を解除する
+ * - {@link clearLedgerRepairRequired}：確認済みの host 単位 ledger repair flag を解除する
+ * - {@link archiveMountHistoryRejectedEvents}：隔離済み mount event を監査 event に移して warning を閉じる
+ *
+ * @version 1.390.1270 (PR #420)
+ * @since   1.390.1270 (PR #420)
+ * @lastModified 2026-08-02 15:05:22
+ * -----------------------------------------------------------
+ * @todo
+ * - O7 Ledger Reconciliation で、手動解除前の再計算監査と修復案提示を追加する。
+ * - mount interval の survivor 明示選択は O6B 以降で実装する。
+ */
+
+"use strict";
+
+import { monitorData } from "./dashboard_data.js";
+import {
+  canExecuteLedgerDecision,
+  enqueueLedgerDecisionTask
+} from "./dashboard_inferred_candidate_decision.js";
+import { saveUnifiedStorageDurably } from "./dashboard_storage.js";
+import { wallNowMs } from "./dashboard_time.js";
+
+/**
+ * O6 recovery audit event の保持上限。
+ *
+ * @constant {number}
+ */
+const RECOVERY_EVENT_CAP = 1000;
+
+/**
+ * O5 decision recovery flag の monitorData field 名。
+ *
+ * @constant {string}
+ */
+const DECISION_RECOVERY_FIELD = "inferredDecisionRecoveryRequired";
+
+/**
+ * O6 recovery audit event の type 一覧。
+ *
+ * @enum {string}
+ */
+export const INFERRED_RECOVERY_EVENT_TYPE = Object.freeze({
+  DURABLE_SAVE_RETRIED: "recovery-durable-save-retried",
+  DECISION_RECOVERY_CLEARED: "decision-recovery-cleared",
+  LEDGER_REPAIR_CLEARED: "ledger-repair-cleared",
+  REJECTED_MOUNT_EVENTS_ARCHIVED: "mount-history-rejected-events-archived"
+});
+
+/**
+ * recovery audit event ID 生成用の単調カウンタ。
+ *
+ * @private
+ * @type {number}
+ */
+let _eventSeq = 0;
+
+/**
+ * JSON 互換値を deep clone する。
+ *
+ * @private
+ * @function _clone
+ * @param {*} value - clone 対象。
+ * @returns {*} clone 済みの値。
+ */
+function _clone(value) {
+  if (value === undefined) return undefined;
+  if (typeof structuredClone === "function") return structuredClone(value);
+  return JSON.parse(JSON.stringify(value));
+}
+
+/**
+ * epoch ms の現在時刻を返す。
+ *
+ * @private
+ * @function _nowMs
+ * @param {{nowMs?:number}} [options] - clock 注入オプション。
+ * @returns {number} epoch ms。
+ */
+function _nowMs(options = {}) {
+  const injected = Number(options.nowMs);
+  if (Number.isFinite(injected) && injected > 0) return injected;
+  return wallNowMs();
+}
+
+/**
+ * recovery audit event ID を生成する。
+ *
+ * 【詳細説明】
+ * - crypto.randomUUID が使える環境では UUID を使う。
+ * - テスト環境や古いブラウザでは時刻とページ内カウンタで一意化し、監査 event の重複を避ける。
+ *
+ * @private
+ * @function _eventId
+ * @param {number} nowMs - event 作成時刻。
+ * @returns {string} recovery event ID。
+ */
+function _eventId(nowMs) {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `ir-${crypto.randomUUID()}`;
+  }
+  _eventSeq += 1;
+  return `ir-${Math.floor(nowMs)}-${_eventSeq}`;
+}
+
+/**
+ * recovery audit event 配列を取得する。
+ *
+ * @private
+ * @function _events
+ * @returns {Array<Object>} recovery audit event 配列。
+ */
+function _events() {
+  if (!Array.isArray(monitorData.inferredRecoveryEvents)) {
+    monitorData.inferredRecoveryEvents = [];
+  }
+  return monitorData.inferredRecoveryEvents;
+}
+
+/**
+ * host 単位の ledger repair map を取得する。
+ *
+ * @private
+ * @function _ledgerRepairRequired
+ * @returns {Object.<string,Object>} ledger repair map。
+ */
+function _ledgerRepairRequired() {
+  if (!monitorData.ledgerRepairRequired || typeof monitorData.ledgerRepairRequired !== "object") {
+    monitorData.ledgerRepairRequired = {};
+  }
+  return monitorData.ledgerRepairRequired;
+}
+
+/**
+ * 隔離済み mountHistory event 配列を取得する。
+ *
+ * @private
+ * @function _rejectedMountEvents
+ * @returns {Array<Object>} 隔離済み event 配列。
+ */
+function _rejectedMountEvents() {
+  if (!Array.isArray(monitorData.mountHistoryRejectedEvents)) {
+    monitorData.mountHistoryRejectedEvents = [];
+  }
+  return monitorData.mountHistoryRejectedEvents;
+}
+
+/**
+ * 復旧対象が存在するかを判定する。
+ *
+ * @private
+ * @function _hasRecoveryIssues
+ * @returns {boolean} recovery / repair / rejected event のいずれかが存在すれば true。
+ */
+function _hasRecoveryIssues() {
+  return !!monitorData[DECISION_RECOVERY_FIELD]
+    || Object.keys(_ledgerRepairRequired()).length > 0
+    || _rejectedMountEvents().length > 0;
+}
+
+/**
+ * recovery 関連フィールドの rollback snapshot を取得する。
+ *
+ * @private
+ * @function _snapshotRecoveryState
+ * @returns {Object} rollback 用 snapshot。
+ */
+function _snapshotRecoveryState() {
+  return {
+    inferredDecisionRecoveryRequired: _clone(monitorData[DECISION_RECOVERY_FIELD] || null),
+    ledgerRepairRequired: _clone(_ledgerRepairRequired()),
+    mountHistoryRejectedEvents: _clone(_rejectedMountEvents()),
+    inferredRecoveryEvents: _clone(_events())
+  };
+}
+
+/**
+ * recovery 関連フィールドを snapshot へ戻す。
+ *
+ * 【詳細説明】
+ * - 配列と object は可能な限り参照を保ったまま中身だけ置換し、開いている UI の参照を壊さない。
+ * - decision recovery flag は単一 object / null なので field を直接戻す。
+ *
+ * @private
+ * @function _restoreRecoveryState
+ * @param {Object} snapshot - {@link _snapshotRecoveryState} の戻り値。
+ * @returns {void}
+ */
+function _restoreRecoveryState(snapshot) {
+  monitorData[DECISION_RECOVERY_FIELD] = snapshot.inferredDecisionRecoveryRequired
+    ? _clone(snapshot.inferredDecisionRecoveryRequired)
+    : null;
+
+  const repair = _ledgerRepairRequired();
+  for (const key of Object.keys(repair)) delete repair[key];
+  Object.assign(repair, _clone(snapshot.ledgerRepairRequired || {}));
+
+  const rejected = _rejectedMountEvents();
+  rejected.splice(0, rejected.length, ..._clone(snapshot.mountHistoryRejectedEvents || []));
+
+  const events = _events();
+  events.splice(0, events.length, ..._clone(snapshot.inferredRecoveryEvents || []));
+}
+
+/**
+ * recovery audit event を追記する。
+ *
+ * @private
+ * @function _appendRecoveryEvent
+ * @param {string} type - event type。
+ * @param {Object} data - event metadata。
+ * @param {{actor?:string,nowMs?:number}} [options] - 操作者・clock オプション。
+ * @returns {Object} 追記した audit event。
+ */
+function _appendRecoveryEvent(type, data = {}, options = {}) {
+  const nowMs = _nowMs(options);
+  const event = {
+    eventId: _eventId(nowMs),
+    type,
+    actor: options.actor || "local-user",
+    createdAt: nowMs,
+    ..._clone(data)
+  };
+  const events = _events();
+  events.push(event);
+  if (events.length > RECOVERY_EVENT_CAP) {
+    events.splice(0, events.length - RECOVERY_EVENT_CAP);
+  }
+  return event;
+}
+
+/**
+ * 変更後状態を耐久保存し、失敗した場合は snapshot へ rollback する。
+ *
+ * 【詳細説明】
+ * - 操作本体の変更と audit event は同じ保存境界で扱う。
+ * - 保存失敗時はメモリ状態を操作前へ戻し、その rollback 状態の耐久保存も試みる。
+ * - rollback 保存にも失敗した場合、呼び出し元は returned reason を blocker として扱える。
+ *
+ * @private
+ * @function _saveOrRollbackRecoveryMutation
+ * @param {Object} snapshot - 操作前 snapshot。
+ * @param {string} failureReason - 保存失敗時に返す reason。
+ * @param {{save?:boolean}} [options] - 保存オプション。
+ * @returns {Promise<{ok:boolean,reason:string,save?:Object,rollbackSave?:Object}>} 保存結果。
+ */
+async function _saveOrRollbackRecoveryMutation(snapshot, failureReason, options = {}) {
+  const save = options.save === false
+    ? { ok: true, backend: "disabled", reason: "save_disabled" }
+    : await saveUnifiedStorageDurably();
+  if (!save || save.ok !== false) {
+    return { ok: true, reason: "recovery_operation_saved", save };
+  }
+
+  _restoreRecoveryState(snapshot);
+  const rollbackSave = options.save === false
+    ? { ok: true, backend: "disabled", reason: "save_disabled" }
+    : await saveUnifiedStorageDurably();
+  return {
+    ok: false,
+    reason: rollbackSave && rollbackSave.ok === false
+      ? "recovery_operation_rollback_save_failed"
+      : failureReason,
+    save,
+    rollbackSave
+  };
+}
+
+/**
+ * recovery 操作の権限ガードを適用する。
+ *
+ * @private
+ * @function _operationGuard
+ * @returns {?{ok:boolean,reason:string}} 実行不可なら結果 object。実行可能なら null。
+ */
+function _operationGuard() {
+  if (!canExecuteRecoveryOperation()) {
+    return { ok: false, reason: "recovery_not_authorized" };
+  }
+  return null;
+}
+
+/**
+ * この端末で O6 recovery 操作を実行できるか判定する。
+ *
+ * 【詳細説明】
+ * - Recovery Operations は確定台帳・recovery flag・隔離 event を変更するため、初期 O6 では
+ *   STAND ALONE / PARENT のみ許可する。
+ * - SATELLITE は親から同期された診断を閲覧するだけで、復旧操作は親端末で実行する。
+ *
+ * @function canExecuteRecoveryOperation
+ * @returns {boolean} ローカルで recovery 操作を実行できる場合 true。
+ * @example
+ * if (canExecuteRecoveryOperation()) enableRecoveryButtons();
+ */
+export function canExecuteRecoveryOperation() {
+  return canExecuteLedgerDecision();
+}
+
+/**
+ * 現在の recovery / repair 状態を再度耐久保存する。
+ *
+ * 【詳細説明】
+ * - rollback 保存失敗などで「現在メモリ上にある復旧状態をもう一度 durable store へ書く」ための操作。
+ * - 新しい candidate decision は行わず、監査 event を追記して保存完了だけを確認する。
+ *
+ * @function retryInferredRecoveryDurableSave
+ * @param {{actor?:string,nowMs?:number,save?:boolean}} [options] - 操作者・clock・保存オプション。
+ * @returns {Promise<Object>} recovery 操作結果。
+ * @example
+ * const result = await retryInferredRecoveryDurableSave({ actor: "operator" });
+ */
+export function retryInferredRecoveryDurableSave(options = {}) {
+  return enqueueLedgerDecisionTask(async () => {
+    const guard = _operationGuard();
+    if (guard) return guard;
+    if (!_hasRecoveryIssues()) return { ok: false, reason: "recovery_not_required" };
+
+    const snapshot = _snapshotRecoveryState();
+    const event = _appendRecoveryEvent(INFERRED_RECOVERY_EVENT_TYPE.DURABLE_SAVE_RETRIED, {
+      reason: "operator-retry",
+      decisionRecovery: monitorData[DECISION_RECOVERY_FIELD] ? _clone(monitorData[DECISION_RECOVERY_FIELD]) : null,
+      ledgerRepairHosts: Object.keys(_ledgerRepairRequired()),
+      rejectedMountEventCount: _rejectedMountEvents().length
+    }, options);
+    const saved = await _saveOrRollbackRecoveryMutation(snapshot, "recovery_retry_not_durably_saved", options);
+    if (!saved.ok) return saved;
+    return { ok: true, reason: "recovery_durable_save_retried", event, save: saved.save };
+  });
+}
+
+/**
+ * 確認済みの O5 decision recovery flag を解除する。
+ *
+ * 【詳細説明】
+ * - rollback 後の状態をオペレーターが確認した場合だけ呼ぶ。
+ * - flag 解除と audit event 追記は同一保存境界で行い、保存失敗時は flag を戻す。
+ *
+ * @function clearInferredDecisionRecoveryRequired
+ * @param {{actor?:string,note?:string,nowMs?:number,save?:boolean}} [options] - 操作者・メモ・保存オプション。
+ * @returns {Promise<Object>} recovery 操作結果。
+ * @example
+ * const result = await clearInferredDecisionRecoveryRequired({ actor: "operator", note: "checked" });
+ */
+export function clearInferredDecisionRecoveryRequired(options = {}) {
+  return enqueueLedgerDecisionTask(async () => {
+    const guard = _operationGuard();
+    if (guard) return guard;
+    const current = monitorData[DECISION_RECOVERY_FIELD];
+    if (!current || typeof current !== "object") return { ok: false, reason: "decision_recovery_not_found" };
+
+    const snapshot = _snapshotRecoveryState();
+    monitorData[DECISION_RECOVERY_FIELD] = null;
+    const event = _appendRecoveryEvent(INFERRED_RECOVERY_EVENT_TYPE.DECISION_RECOVERY_CLEARED, {
+      reason: "operator-cleared-decision-recovery",
+      note: options.note || "",
+      clearedRecovery: _clone(current)
+    }, options);
+    const saved = await _saveOrRollbackRecoveryMutation(snapshot, "decision_recovery_clear_not_durably_saved", options);
+    if (!saved.ok) return saved;
+    return { ok: true, reason: "decision_recovery_cleared", event, save: saved.save };
+  });
+}
+
+/**
+ * 確認済みの host 単位 ledger repair flag を解除する。
+ *
+ * 【詳細説明】
+ * - O7 の再計算監査が入るまでは、オペレーターが対象 host の mount ledger を確認済みであることを
+ *   前提とする手動解除 API として扱う。
+ * - 解除対象の元 flag は audit event に保存し、保存失敗時は map を操作前へ戻す。
+ *
+ * @function clearLedgerRepairRequired
+ * @param {string} host - 解除する host key。
+ * @param {{actor?:string,note?:string,nowMs?:number,save?:boolean}} [options] - 操作者・メモ・保存オプション。
+ * @returns {Promise<Object>} recovery 操作結果。
+ * @example
+ * const result = await clearLedgerRepairRequired("k1max.local", { actor: "operator" });
+ */
+export function clearLedgerRepairRequired(host, options = {}) {
+  return enqueueLedgerDecisionTask(async () => {
+    const guard = _operationGuard();
+    if (guard) return guard;
+    const hostKey = String(host || "");
+    if (!hostKey) return { ok: false, reason: "ledger_repair_host_required" };
+    const repair = _ledgerRepairRequired();
+    const current = repair[hostKey];
+    if (!current || typeof current !== "object") return { ok: false, reason: "ledger_repair_not_found", host: hostKey };
+
+    const snapshot = _snapshotRecoveryState();
+    delete repair[hostKey];
+    const event = _appendRecoveryEvent(INFERRED_RECOVERY_EVENT_TYPE.LEDGER_REPAIR_CLEARED, {
+      reason: "operator-cleared-ledger-repair",
+      host: hostKey,
+      note: options.note || "",
+      clearedRepair: _clone(current)
+    }, options);
+    const saved = await _saveOrRollbackRecoveryMutation(snapshot, "ledger_repair_clear_not_durably_saved", options);
+    if (!saved.ok) return saved;
+    return { ok: true, reason: "ledger_repair_cleared", host: hostKey, event, save: saved.save };
+  });
+}
+
+/**
+ * 隔離済み mountHistory event を recovery audit event へ退避し、warning を閉じる。
+ *
+ * 【詳細説明】
+ * - `mountHistoryRejectedEvents` は有効 projection から外した event の隔離領域であり、確認済み後も
+ *   元情報を失わないよう audit event 内へ snapshot を保存してから配列を空にする。
+ * - 保存失敗時は隔離配列と audit event を操作前へ戻す。
+ *
+ * @function archiveMountHistoryRejectedEvents
+ * @param {{actor?:string,note?:string,nowMs?:number,save?:boolean}} [options] - 操作者・メモ・保存オプション。
+ * @returns {Promise<Object>} recovery 操作結果。
+ * @example
+ * const result = await archiveMountHistoryRejectedEvents({ actor: "operator" });
+ */
+export function archiveMountHistoryRejectedEvents(options = {}) {
+  return enqueueLedgerDecisionTask(async () => {
+    const guard = _operationGuard();
+    if (guard) return guard;
+    const rejected = _rejectedMountEvents();
+    if (rejected.length === 0) return { ok: false, reason: "mount_history_rejected_events_not_found" };
+
+    const rejectedSnapshot = _clone(rejected);
+    const snapshot = _snapshotRecoveryState();
+    rejected.splice(0, rejected.length);
+    const event = _appendRecoveryEvent(INFERRED_RECOVERY_EVENT_TYPE.REJECTED_MOUNT_EVENTS_ARCHIVED, {
+      reason: "operator-archived-rejected-mount-events",
+      note: options.note || "",
+      rejectedEventCount: rejectedSnapshot.length,
+      rejectedEvents: rejectedSnapshot
+    }, options);
+    const saved = await _saveOrRollbackRecoveryMutation(snapshot, "mount_history_rejected_archive_not_durably_saved", options);
+    if (!saved.ok) return saved;
+    return {
+      ok: true,
+      reason: "mount_history_rejected_events_archived",
+      archivedCount: rejectedSnapshot.length,
+      event,
+      save: saved.save
+    };
+  });
+}

--- a/3dp_lib/dashboard_relay_bridge.js
+++ b/3dp_lib/dashboard_relay_bridge.js
@@ -12,6 +12,7 @@
  *   （filamentSpools / hostSpoolMap / mountHistory / recovery 診断の共有状態を含む）
  * - 子（satellite）からのコマンド/フィラメント操作 RPC を受信し親側で実行
  * - 子（satellite）からの O5 inferred candidate decision request を親側で実行
+ * - O6 recovery / repair 操作の監査状態を子へ read-only 配信する
  * - 新規子クライアント接続時にフルスナップショットを送信
  *
  * 【公開関数一覧】
@@ -21,9 +22,9 @@
  * - {@link buildCameraEndpoints}：カメラパススルー用エンドポイントを構築する
  * - {@link relayBroadcastIfNeeded}：変更があれば子へデルタ配信する
  *
- * @version 1.390.1268 (PR #418)
+ * @version 1.390.1270 (PR #420)
  * @since   1.390.820 (PR #367)
- * @lastModified 2026-08-01 23:20:09
+ * @lastModified 2026-08-02 15:05:22
  * -----------------------------------------------------------
  */
 
@@ -698,6 +699,7 @@ function _buildDelta() {
   //   candidate store とは別ハッシュで低頻度同期する。
   const recoveryHash = _quickHash(
     monitorData.inferredDecisionRecoveryRequired || null,
+    monitorData.inferredRecoveryEvents || [],
     monitorData.ledgerRepairRequired || {},
     monitorData.mountHistoryRejectedEvents || []
   );
@@ -705,6 +707,7 @@ function _buildDelta() {
     _prevRecoveryHash = recoveryHash;
     sharedDelta = sharedDelta || {};
     sharedDelta.inferredDecisionRecoveryRequired = monitorData.inferredDecisionRecoveryRequired || null;
+    sharedDelta.inferredRecoveryEvents = monitorData.inferredRecoveryEvents || [];
     sharedDelta.ledgerRepairRequired = monitorData.ledgerRepairRequired || {};
     sharedDelta.mountHistoryRejectedEvents = monitorData.mountHistoryRejectedEvents || [];
     hasChanges = true;
@@ -821,6 +824,7 @@ function _buildFullSnapshot() {
     inferredCandidateStore: monitorData.inferredCandidateStore || {},
     // ★ #418: Candidate Center の Recovery / repair 診断も親権威で子へ同梱する。
     inferredDecisionRecoveryRequired: monitorData.inferredDecisionRecoveryRequired || null,
+    inferredRecoveryEvents: monitorData.inferredRecoveryEvents || [],
     ledgerRepairRequired: monitorData.ledgerRepairRequired || {},
     mountHistoryRejectedEvents: monitorData.mountHistoryRejectedEvents || [],
     // ★ 監査 P0(第2報): フィラメント補助ドメインをスナップショットにも同梱（親=権威）。

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -27,9 +27,9 @@
  * - {@link loadPrintCurrent}：現ジョブ読込
  * - {@link savePrintCurrent}：現ジョブ保存
  *
-* @version 1.390.1256 (PR #413)
+* @version 1.390.1270 (PR #420)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-07-25 11:15:54
+* @lastModified 2026-08-02 15:05:22
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -276,6 +276,32 @@ export async function importAllData(data) {
         monitorData.inferredCandidateStore[hash] = { ...value };
       }
     }
+  }
+
+  // ── ★ #420/O6A: O5 recovery flag と recovery 操作 audit event をインポート ──
+  //   recovery flag は未解決 blocker なので、既存より新しい createdAt を持つ場合だけ採用する。
+  if (Object.prototype.hasOwnProperty.call(data, "inferredDecisionRecoveryRequired")) {
+    const incoming = data.inferredDecisionRecoveryRequired;
+    if (incoming && typeof incoming === "object") {
+      const current = monitorData.inferredDecisionRecoveryRequired;
+      if (!current || (Number(incoming.createdAt) || 0) >= (Number(current.createdAt) || 0)) {
+        monitorData.inferredDecisionRecoveryRequired = { ...incoming };
+      }
+    } else if (!monitorData.inferredDecisionRecoveryRequired) {
+      monitorData.inferredDecisionRecoveryRequired = null;
+    }
+  }
+  if (Array.isArray(data.inferredRecoveryEvents)) {
+    if (!Array.isArray(monitorData.inferredRecoveryEvents)) monitorData.inferredRecoveryEvents = [];
+    const seen = new Set(monitorData.inferredRecoveryEvents.map(event => event?.eventId));
+    for (const event of data.inferredRecoveryEvents) {
+      const key = event?.eventId;
+      if (event && key != null && !seen.has(key)) {
+        monitorData.inferredRecoveryEvents.push({ ...event });
+        seen.add(key);
+      }
+    }
+    monitorData.inferredRecoveryEvents.sort((a, b) => (Number(a?.createdAt) || 0) - (Number(b?.createdAt) || 0));
   }
 
   // ── プリセット: presetId ベースで新規のみ追加 (ユーザー編集版を保持) ──
@@ -677,6 +703,8 @@ const LS_GLOBAL_FIELDS = [
   "hostObservationWatermark", "hostObservationCurrent",
   // ★ #412-O4: オフライン継続推定 candidate（親権威・状態遷移つき）
   "inferredCandidateStore",
+  // ★ #420/O6A: O5 recovery blocker と復旧操作 audit event
+  "inferredDecisionRecoveryRequired", "inferredRecoveryEvents",
   // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない）
   "pendingUnattributedUsage", "pendingUnattributedUsageArchive",
   // ★ RR-2: 台帳修復要求フラグ（破損時に暗黙クローズせず可視化）
@@ -932,6 +960,8 @@ function _flushStorage() {
       queueSharedWrite("hostObservationWatermark", monitorData.hostObservationWatermark);
       queueSharedWrite("hostObservationCurrent",   monitorData.hostObservationCurrent);
       queueSharedWrite("inferredCandidateStore",   monitorData.inferredCandidateStore);
+      queueSharedWrite("inferredDecisionRecoveryRequired", monitorData.inferredDecisionRecoveryRequired || null);
+      queueSharedWrite("inferredRecoveryEvents", monitorData.inferredRecoveryEvents || []);
       // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない・子へも配信）
       queueSharedWrite("pendingUnattributedUsage",        monitorData.pendingUnattributedUsage);
       queueSharedWrite("pendingUnattributedUsageArchive", monitorData.pendingUnattributedUsageArchive);
@@ -1331,6 +1361,27 @@ function _restoreFromData(shared, machines) {
         monitorData.inferredCandidateStore[hash] = { ...value };
       }
     }
+  }
+
+  // ★ #420/O6A: O5 recovery flag と復旧操作 audit event を復元する。
+  //   recovery flag は blocker なので、ストレージ値が明示 null の場合も状態を消す。
+  if (shared && Object.prototype.hasOwnProperty.call(shared, "inferredDecisionRecoveryRequired")) {
+    monitorData.inferredDecisionRecoveryRequired =
+      shared.inferredDecisionRecoveryRequired && typeof shared.inferredDecisionRecoveryRequired === "object"
+        ? { ...shared.inferredDecisionRecoveryRequired }
+        : null;
+  }
+  if (Array.isArray(shared?.inferredRecoveryEvents)) {
+    if (!Array.isArray(monitorData.inferredRecoveryEvents)) monitorData.inferredRecoveryEvents = [];
+    const seen = new Set(monitorData.inferredRecoveryEvents.map(event => event?.eventId));
+    for (const event of shared.inferredRecoveryEvents) {
+      const key = event?.eventId;
+      if (event && key != null && !seen.has(key)) {
+        monitorData.inferredRecoveryEvents.push({ ...event });
+        seen.add(key);
+      }
+    }
+    monitorData.inferredRecoveryEvents.sort((a, b) => (Number(a?.createdAt) || 0) - (Number(b?.createdAt) || 0));
   }
 
   // ★ filamentInventory: IDベースマージ

--- a/3dp_lib/dashboard_storage_idb.js
+++ b/3dp_lib/dashboard_storage_idb.js
@@ -23,9 +23,9 @@
  * - {@link exportAllIdb}：全データを単一オブジェクトとして読み出し
  * - {@link importAllIdb}：単一オブジェクトから全データを書き込み
  *
- * @version 1.390.1246 (PR #413)
+ * @version 1.390.1270 (PR #420)
  * @since   1.390.787 (PR #366)
- * @lastModified 2026-07-22 12:00:00
+ * @lastModified 2026-08-02 15:05:22
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -108,6 +108,9 @@ const SHARED_KEYS = [
   "hostObservationCurrent",
   // #412-O4: candidate store は baseline commit 前の耐久保存対象。
   "inferredCandidateStore",
+  // #420/O6A: recovery blocker と復旧操作 audit event。
+  "inferredDecisionRecoveryRequired",
+  "inferredRecoveryEvents",
   // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない）
   "pendingUnattributedUsage",
   "pendingUnattributedUsageArchive",

--- a/3dp_panel.css
+++ b/3dp_panel.css
@@ -1,7 +1,7 @@
 /*
   3dp_panel.css
   GridStack パネルシステム用スタイル
-  Version 1.390.1173
+  Version 1.390.1270
 */
 
 /* ===============================================================
@@ -3987,9 +3987,16 @@ body.relay-readonly textarea {
   font-size: var(--font-sm);
 }
 
-.ic-recovery-details {
-  margin-top: var(--space-1);
-}
+  .ic-recovery-details {
+    margin-top: var(--space-1);
+  }
+  .ic-recovery-actions {
+    display: flex;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+    align-items: center;
+    margin-top: var(--space-2);
+  }
 .ic-list-wrap {
   flex: 1;
   min-height: 0;

--- a/docs/en/filament_manual.md
+++ b/docs/en/filament_manual.md
@@ -124,14 +124,27 @@ Satellite is promoted to operation mode, decision requests are sent to
 the Parent; readonly Satellites keep the action buttons disabled.
 
 When required, the top of the Inferred Candidate tab shows a Recovery /
-repair status surface. This is a read-only diagnostic view for states
-such as `inferredDecisionRecoveryRequired`, `ledgerRepairRequired` and
+repair status surface. This is a diagnostic view for states such as
+`inferredDecisionRecoveryRequired`, `ledgerRepairRequired` and
 `mountHistoryRejectedEvents`, where the app must not continue
 automatically. It shows the related candidate, host, spool, save-failure
-reason and quarantined mountHistory events. In Relay setups, Satellites
-mirror this diagnostic state from the Parent authority. In #418 this
-surface does not run repair or clear flags; those actions are intentionally
-left for the later Recovery Actions slice.
+reason and quarantined mountHistory events.
+
+Standalone and Parent devices can run these recovery operations from the
+Recovery / repair status surface.
+
+| Recovery action | Behavior |
+| --- | --- |
+| **Retry save** | Attempts to durably save the current recovery / repair state again. |
+| **Clear recovery** | Clears `inferredDecisionRecoveryRequired` after the operator has verified the rolled-back state. |
+| **Clear repair** | Clears `ledgerRepairRequired` for the selected host after the mount ledger has been verified. |
+| **Archive rejected** | Moves quarantined mountHistory events into `inferredRecoveryEvents` audit history and closes the warning. |
+
+Each recovery operation appends an `inferredRecoveryEvents` audit event
+and rolls memory state back if durable save fails. In Relay setups,
+Satellites mirror the diagnostic state from the Parent authority but keep
+the recovery operation buttons disabled. Run recovery operations on the
+Parent device.
 
 ### Registered Filament Tab
 

--- a/docs/ja/filament_manual.md
+++ b/docs/ja/filament_manual.md
@@ -92,7 +92,18 @@ monitorData.hostSpoolMap = {
 
 Relay 構成では、Standalone と Parent は Confirm / Reject / Reassign / Undo を実行できます。Satellite は候補を閲覧でき、操作モードに昇格している場合は Parent へ decision request を送ります。Readonly の Satellite では操作ボタンは無効化されます。
 
-推定候補タブの上部には、必要に応じて Recovery / repair status が表示されます。これは `inferredDecisionRecoveryRequired`、`ledgerRepairRequired`、`mountHistoryRejectedEvents` など、自動継続してはいけない状態を確認するための読み取り専用診断です。表示された場合は、原因となった candidate、host、spool、保存失敗理由、隔離された mountHistory event を確認できます。Relay 構成では Satellite も Parent 権威の診断状態をミラー表示します。#418 時点ではこの画面から修復や解除は実行せず、整合確認と復旧操作は後続の Recovery Actions で扱います。
+推定候補タブの上部には、必要に応じて Recovery / repair status が表示されます。これは `inferredDecisionRecoveryRequired`、`ledgerRepairRequired`、`mountHistoryRejectedEvents` など、自動継続してはいけない状態を確認するための診断です。表示された場合は、原因となった candidate、host、spool、保存失敗理由、隔離された mountHistory event を確認できます。
+
+Standalone / Parent では、Recovery / repair status から次の復旧操作を実行できます。
+
+| 復旧操作 | 内容 |
+| --- | --- |
+| **Retry save** | 現在の recovery / repair 状態を再度耐久保存します |
+| **Clear recovery** | rollback 後の状態を確認済みの場合に `inferredDecisionRecoveryRequired` を解除します |
+| **Clear repair** | 対象 host の mount ledger を確認済みの場合に `ledgerRepairRequired` を解除します |
+| **Archive rejected** | 隔離済み mountHistory event を `inferredRecoveryEvents` へ監査退避し、warning を閉じます |
+
+これらの復旧操作は `inferredRecoveryEvents` に監査 event を残し、保存失敗時は操作前の状態へ戻します。Relay 構成では Satellite も Parent 権威の診断状態をミラー表示しますが、復旧操作は無効化されます。復旧操作は Parent 端末で実行してください。
 
 ### 登録済みフィラメントタブ
 

--- a/tests/unit/dashboard_client_sync_filament_sync.test.js
+++ b/tests/unit/dashboard_client_sync_filament_sync.test.js
@@ -158,6 +158,8 @@ describe("_applySharedFilamentState — フィラメント補助ドメイン（�
     }
     for (const k of Object.keys(monitorData.inferredCandidateStore)) delete monitorData.inferredCandidateStore[k];
     monitorData.inferredDecisionRecoveryRequired = null;
+    if (!Array.isArray(monitorData.inferredRecoveryEvents)) monitorData.inferredRecoveryEvents = [];
+    monitorData.inferredRecoveryEvents.splice(0, monitorData.inferredRecoveryEvents.length);
     if (!monitorData.ledgerRepairRequired || typeof monitorData.ledgerRepairRequired !== "object") {
       monitorData.ledgerRepairRequired = {};
     }
@@ -209,11 +211,13 @@ describe("_applySharedFilamentState — フィラメント補助ドメイン（�
 
   it("#418: recovery / repair 診断を親から全置換ミラーする", () => {
     monitorData.inferredDecisionRecoveryRequired = { candidateHash: "stale", reason: "old" };
+    monitorData.inferredRecoveryEvents.push({ eventId: "ir-old", type: "old" });
     monitorData.ledgerRepairRequired.stale = { status: "old" };
     monitorData.mountHistoryRejectedEvents.push({ reason: "old", event: { evId: "old" } });
 
     _applySharedFilamentState({
       inferredDecisionRecoveryRequired: { candidateHash: "ic-a", action: "confirm", reason: "rollback_durable_save_failed" },
+      inferredRecoveryEvents: [{ eventId: "ir-a", type: "recovery-durable-save-retried", createdAt: 123 }],
       ledgerRepairRequired: { k1: { spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 123 } },
       mountHistoryRejectedEvents: [{ reason: "reanchor-invalid-reference", event: { evId: "ev-a", host: "k1" } }],
     });
@@ -223,6 +227,9 @@ describe("_applySharedFilamentState — フィラメント補助ドメイン（�
       action: "confirm",
       reason: "rollback_durable_save_failed",
     });
+    expect(monitorData.inferredRecoveryEvents).toEqual([
+      { eventId: "ir-a", type: "recovery-durable-save-retried", createdAt: 123 },
+    ]);
     expect(monitorData.ledgerRepairRequired.stale).toBeUndefined();
     expect(monitorData.ledgerRepairRequired.k1).toEqual({ spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 123 });
     expect(monitorData.mountHistoryRejectedEvents).toEqual([
@@ -232,16 +239,19 @@ describe("_applySharedFilamentState — フィラメント補助ドメイン（�
 
   it("#418: 親で解消済みの recovery / repair 診断を Satellite 側から消す", () => {
     monitorData.inferredDecisionRecoveryRequired = { candidateHash: "ic-a", reason: "old" };
+    monitorData.inferredRecoveryEvents.push({ eventId: "ir-a", type: "old" });
     monitorData.ledgerRepairRequired.k1 = { status: "ambiguous" };
     monitorData.mountHistoryRejectedEvents.push({ reason: "old" });
 
     _applySharedFilamentState({
       inferredDecisionRecoveryRequired: null,
+      inferredRecoveryEvents: [],
       ledgerRepairRequired: {},
       mountHistoryRejectedEvents: [],
     });
 
     expect(monitorData.inferredDecisionRecoveryRequired).toBeNull();
+    expect(monitorData.inferredRecoveryEvents).toEqual([]);
     expect(monitorData.ledgerRepairRequired).toEqual({});
     expect(monitorData.mountHistoryRejectedEvents).toEqual([]);
   });
@@ -250,11 +260,13 @@ describe("_applySharedFilamentState — フィラメント補助ドメイン（�
     globalThis.window._refreshFilamentManagerIfOpen = vi.fn();
     _applySharedFilamentState({
       inferredDecisionRecoveryRequired: { candidateHash: "ic-a", reason: "rollback_failed" },
+      inferredRecoveryEvents: [{ eventId: "ir-a", type: "retry" }],
     });
     const firstCount = globalThis.window._refreshFilamentManagerIfOpen.mock.calls.length;
 
     _applySharedFilamentState({
       inferredDecisionRecoveryRequired: { candidateHash: "ic-b", reason: "rollback_failed" },
+      inferredRecoveryEvents: [{ eventId: "ir-b", type: "retry" }],
     });
 
     expect(globalThis.window._refreshFilamentManagerIfOpen.mock.calls.length).toBeGreaterThan(firstCount);

--- a/tests/unit/dashboard_inferred_candidate_ui.test.js
+++ b/tests/unit/dashboard_inferred_candidate_ui.test.js
@@ -15,6 +15,11 @@ const mocks = vi.hoisted(() => ({
   rejectInferredCandidate: vi.fn(async () => ({ ok: true, reason: "rejected" })),
   reassignInferredCandidate: vi.fn(async () => ({ ok: true, reason: "reassigned" })),
   undoInferredCandidateDecision: vi.fn(async () => ({ ok: true, reason: "undone" })),
+  canExecuteRecoveryOperation: vi.fn(() => true),
+  retryInferredRecoveryDurableSave: vi.fn(async () => ({ ok: true, reason: "recovery_durable_save_retried" })),
+  clearInferredDecisionRecoveryRequired: vi.fn(async () => ({ ok: true, reason: "decision_recovery_cleared" })),
+  clearLedgerRepairRequired: vi.fn(async () => ({ ok: true, reason: "ledger_repair_cleared" })),
+  archiveMountHistoryRejectedEvents: vi.fn(async () => ({ ok: true, reason: "mount_history_rejected_events_archived" })),
   showConfirmDialog: vi.fn(async () => true),
   showAlert: vi.fn(),
   recoveryVm: { hasIssues: false, totalCount: 0, blockerCount: 0, warningCount: 0, cards: [] }
@@ -26,6 +31,13 @@ vi.mock("../../3dp_lib/dashboard_inferred_candidate_decision.js", () => ({
   rejectInferredCandidate: mocks.rejectInferredCandidate,
   reassignInferredCandidate: mocks.reassignInferredCandidate,
   undoInferredCandidateDecision: mocks.undoInferredCandidateDecision
+}));
+vi.mock("../../3dp_lib/dashboard_inferred_recovery_ops.js", () => ({
+  canExecuteRecoveryOperation: mocks.canExecuteRecoveryOperation,
+  retryInferredRecoveryDurableSave: mocks.retryInferredRecoveryDurableSave,
+  clearInferredDecisionRecoveryRequired: mocks.clearInferredDecisionRecoveryRequired,
+  clearLedgerRepairRequired: mocks.clearLedgerRepairRequired,
+  archiveMountHistoryRejectedEvents: mocks.archiveMountHistoryRejectedEvents
 }));
 vi.mock("../../3dp_lib/dashboard_inferred_candidate_view.js", () => ({
   INFERRED_CANDIDATE_FILTER: {
@@ -135,13 +147,23 @@ beforeEach(() => {
   mocks.rejectInferredCandidate.mockClear();
   mocks.reassignInferredCandidate.mockClear();
   mocks.undoInferredCandidateDecision.mockClear();
+  mocks.canExecuteRecoveryOperation.mockClear();
+  mocks.canExecuteRecoveryOperation.mockReturnValue(true);
+  mocks.retryInferredRecoveryDurableSave.mockClear();
+  mocks.retryInferredRecoveryDurableSave.mockResolvedValue({ ok: true, reason: "recovery_durable_save_retried" });
+  mocks.clearInferredDecisionRecoveryRequired.mockClear();
+  mocks.clearInferredDecisionRecoveryRequired.mockResolvedValue({ ok: true, reason: "decision_recovery_cleared" });
+  mocks.clearLedgerRepairRequired.mockClear();
+  mocks.clearLedgerRepairRequired.mockResolvedValue({ ok: true, reason: "ledger_repair_cleared" });
+  mocks.archiveMountHistoryRejectedEvents.mockClear();
+  mocks.archiveMountHistoryRejectedEvents.mockResolvedValue({ ok: true, reason: "mount_history_rejected_events_archived" });
   mocks.showConfirmDialog.mockClear();
   mocks.showConfirmDialog.mockResolvedValue(true);
   mocks.showAlert.mockClear();
 });
 
 describe("createInferredCandidateCenterContent", () => {
-  it("recovery surface を read-only 診断として表示する", () => {
+  it("recovery surface を診断カードと復旧操作として表示する", () => {
     mocks.recoveryVm = {
       hasIssues: true,
       totalCount: 2,
@@ -149,6 +171,7 @@ describe("createInferredCandidateCenterContent", () => {
       warningCount: 1,
       cards: [
         {
+          type: "decision-recovery",
           severity: "blocker",
           title: "O5 decision recovery required",
           summary: "rollback状態の確認が必要です",
@@ -158,6 +181,7 @@ describe("createInferredCandidateCenterContent", () => {
           ]
         },
         {
+          type: "mount-history-rejected",
           severity: "warning",
           title: "Rejected mount history events",
           summary: "2件の mountHistory event が隔離されています",
@@ -172,10 +196,65 @@ describe("createInferredCandidateCenterContent", () => {
     expect(document.querySelector(".ic-recovery-surface").textContent).toContain("Blocker 1 / Warning 1");
     expect(document.querySelector(".ic-recovery-surface").textContent).toContain("O5 decision recovery required");
     expect(document.querySelector(".ic-recovery-surface").textContent).toContain("Rejected mount history events");
+    expect(document.querySelector(".ic-recovery-surface").textContent).toContain("Retry save");
+    expect(document.querySelector(".ic-recovery-surface").textContent).toContain("Archive rejected");
     expect(mocks.confirmInferredCandidate).not.toHaveBeenCalled();
     expect(mocks.rejectInferredCandidate).not.toHaveBeenCalled();
     expect(mocks.reassignInferredCandidate).not.toHaveBeenCalled();
     expect(mocks.undoInferredCandidateDecision).not.toHaveBeenCalled();
+  });
+
+  it("recovery card の Retry save は O6 Recovery Operations を呼ぶ", async () => {
+    mocks.recoveryVm = {
+      hasIssues: true,
+      totalCount: 1,
+      blockerCount: 1,
+      warningCount: 0,
+      cards: [{
+        type: "decision-recovery",
+        severity: "blocker",
+        title: "O5 decision recovery required",
+        summary: "rollback状態の確認が必要です",
+        details: [{ label: "Candidate", value: "ic-a" }]
+      }]
+    };
+    const center = createInferredCandidateCenterContent();
+    document.body.appendChild(center.el);
+
+    [...document.querySelectorAll(".ic-recovery-actions button")]
+      .find(button => button.textContent === "Retry save")
+      .click();
+
+    await waitForAssertion(() => {
+      expect(mocks.retryInferredRecoveryDurableSave).toHaveBeenCalledWith({ actor: "local-user" });
+      expect(mocks.showAlert).toHaveBeenCalledWith("復旧状態を再保存しました", "success");
+    });
+  });
+
+  it("Satellite では recovery 操作を disabled にする", () => {
+    mocks.canExecuteRecoveryOperation.mockReturnValue(false);
+    mocks.recoveryVm = {
+      hasIssues: true,
+      totalCount: 1,
+      blockerCount: 1,
+      warningCount: 0,
+      cards: [{
+        type: "ledger-repair",
+        severity: "blocker",
+        title: "Mount ledger repair required",
+        summary: "修復が必要です",
+        host: "k1",
+        details: [{ label: "Host", value: "k1" }]
+      }]
+    };
+
+    const center = createInferredCandidateCenterContent();
+    document.body.appendChild(center.el);
+
+    const clear = [...document.querySelectorAll(".ic-recovery-actions button")]
+      .find(button => button.textContent === "Clear repair");
+    expect(clear.disabled).toBe(true);
+    expect(document.querySelector(".ic-readonly-note").textContent).toContain("親端末");
   });
 
   it("candidate 一覧から詳細を開き、Confirm は Decision Core を呼ぶ", async () => {

--- a/tests/unit/dashboard_inferred_recovery_ops.test.js
+++ b/tests/unit/dashboard_inferred_recovery_ops.test.js
@@ -1,0 +1,193 @@
+/**
+ * @fileoverview dashboard_inferred_recovery_ops.js（#420/O6A Recovery Operations）の単体テスト
+ * recovery / repair flag の解除、耐久保存失敗時 rollback、Satellite 拒否を検証する。
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  monitorData: {
+    inferredDecisionRecoveryRequired: null,
+    inferredRecoveryEvents: [],
+    ledgerRepairRequired: {},
+    mountHistoryRejectedEvents: []
+  },
+  saveUnifiedStorageDurably: vi.fn(async () => ({ ok: true, backend: "test", reason: "saved" })),
+  canExecuteLedgerDecision: vi.fn(() => true),
+  queue: Promise.resolve()
+}));
+
+vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mocks.monitorData }));
+vi.mock("../../3dp_lib/dashboard_storage.js", () => ({ saveUnifiedStorageDurably: mocks.saveUnifiedStorageDurably }));
+vi.mock("../../3dp_lib/dashboard_time.js", () => ({ wallNowMs: () => 123456 }));
+vi.mock("../../3dp_lib/dashboard_inferred_candidate_decision.js", () => ({
+  canExecuteLedgerDecision: mocks.canExecuteLedgerDecision,
+  enqueueLedgerDecisionTask: (task) => {
+    const run = mocks.queue.then(task, task);
+    mocks.queue = run.catch(() => {});
+    return run;
+  }
+}));
+
+const {
+  archiveMountHistoryRejectedEvents,
+  canExecuteRecoveryOperation,
+  clearInferredDecisionRecoveryRequired,
+  clearLedgerRepairRequired,
+  retryInferredRecoveryDurableSave
+} = await import("../../3dp_lib/dashboard_inferred_recovery_ops.js");
+
+/**
+ * monitorData の recovery 関連 field を初期状態へ戻す。
+ *
+ * @function resetRecoveryState
+ * @returns {void}
+ */
+function resetRecoveryState() {
+  mocks.monitorData.inferredDecisionRecoveryRequired = null;
+  mocks.monitorData.inferredRecoveryEvents = [];
+  mocks.monitorData.ledgerRepairRequired = {};
+  mocks.monitorData.mountHistoryRejectedEvents = [];
+}
+
+beforeEach(() => {
+  resetRecoveryState();
+  mocks.queue = Promise.resolve();
+  mocks.canExecuteLedgerDecision.mockReset();
+  mocks.canExecuteLedgerDecision.mockReturnValue(true);
+  mocks.saveUnifiedStorageDurably.mockReset();
+  mocks.saveUnifiedStorageDurably.mockResolvedValue({ ok: true, backend: "test", reason: "saved" });
+});
+
+describe("canExecuteRecoveryOperation", () => {
+  it("Parent/Standalone 権威では true、Satellite では false を返す", () => {
+    mocks.canExecuteLedgerDecision.mockReturnValueOnce(true);
+    expect(canExecuteRecoveryOperation()).toBe(true);
+
+    mocks.canExecuteLedgerDecision.mockReturnValueOnce(false);
+    expect(canExecuteRecoveryOperation()).toBe(false);
+  });
+});
+
+describe("retryInferredRecoveryDurableSave", () => {
+  it("recovery 状態を audit event 付きで再保存する", async () => {
+    mocks.monitorData.inferredDecisionRecoveryRequired = {
+      candidateHash: "ic-a",
+      reason: "rollback_durable_save_failed",
+      createdAt: 100
+    };
+
+    const result = await retryInferredRecoveryDurableSave({ actor: "operator", nowMs: 200 });
+
+    expect(result).toMatchObject({ ok: true, reason: "recovery_durable_save_retried" });
+    expect(mocks.saveUnifiedStorageDurably).toHaveBeenCalledTimes(1);
+    expect(mocks.monitorData.inferredRecoveryEvents).toHaveLength(1);
+    expect(mocks.monitorData.inferredRecoveryEvents[0]).toMatchObject({
+      type: "recovery-durable-save-retried",
+      actor: "operator",
+      createdAt: 200,
+      rejectedMountEventCount: 0
+    });
+  });
+
+  it("Satellite 権威では保存せず拒否する", async () => {
+    mocks.canExecuteLedgerDecision.mockReturnValue(false);
+    mocks.monitorData.inferredDecisionRecoveryRequired = { candidateHash: "ic-a" };
+
+    const result = await retryInferredRecoveryDurableSave();
+
+    expect(result).toEqual({ ok: false, reason: "recovery_not_authorized" });
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+    expect(mocks.monitorData.inferredRecoveryEvents).toHaveLength(0);
+  });
+});
+
+describe("clearInferredDecisionRecoveryRequired", () => {
+  it("decision recovery flag を解除し audit event を保存する", async () => {
+    mocks.monitorData.inferredDecisionRecoveryRequired = {
+      candidateHash: "ic-a",
+      reason: "rollback_durable_save_failed",
+      createdAt: 100
+    };
+
+    const result = await clearInferredDecisionRecoveryRequired({ actor: "operator", note: "checked", nowMs: 300 });
+
+    expect(result).toMatchObject({ ok: true, reason: "decision_recovery_cleared" });
+    expect(mocks.monitorData.inferredDecisionRecoveryRequired).toBeNull();
+    expect(mocks.monitorData.inferredRecoveryEvents[0]).toMatchObject({
+      type: "decision-recovery-cleared",
+      note: "checked",
+      createdAt: 300
+    });
+  });
+
+  it("保存失敗時は recovery flag と audit event を rollback する", async () => {
+    const flag = { candidateHash: "ic-a", reason: "rollback_durable_save_failed", createdAt: 100 };
+    mocks.monitorData.inferredDecisionRecoveryRequired = { ...flag };
+    mocks.saveUnifiedStorageDurably
+      .mockResolvedValueOnce({ ok: false, backend: "localStorage", reason: "quota" })
+      .mockResolvedValueOnce({ ok: true, backend: "localStorage", reason: "saved" });
+
+    const result = await clearInferredDecisionRecoveryRequired({ nowMs: 400 });
+
+    expect(result).toMatchObject({ ok: false, reason: "decision_recovery_clear_not_durably_saved" });
+    expect(mocks.monitorData.inferredDecisionRecoveryRequired).toEqual(flag);
+    expect(mocks.monitorData.inferredRecoveryEvents).toHaveLength(0);
+    expect(mocks.saveUnifiedStorageDurably).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("clearLedgerRepairRequired", () => {
+  it("host 単位の ledger repair flag を解除する", async () => {
+    mocks.monitorData.ledgerRepairRequired = {
+      k1: { spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 100 }
+    };
+
+    const result = await clearLedgerRepairRequired("k1", { actor: "operator", nowMs: 500 });
+
+    expect(result).toMatchObject({ ok: true, reason: "ledger_repair_cleared", host: "k1" });
+    expect(mocks.monitorData.ledgerRepairRequired).toEqual({});
+    expect(mocks.monitorData.inferredRecoveryEvents[0]).toMatchObject({
+      type: "ledger-repair-cleared",
+      host: "k1",
+      createdAt: 500
+    });
+  });
+
+  it("保存失敗時は ledger repair flag を rollback する", async () => {
+    const repair = { k1: { spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 100 } };
+    mocks.monitorData.ledgerRepairRequired = { k1: { ...repair.k1 } };
+    mocks.saveUnifiedStorageDurably
+      .mockResolvedValueOnce({ ok: false, backend: "indexedDB", reason: "idb_flush_failed" })
+      .mockResolvedValueOnce({ ok: true, backend: "indexedDB", reason: "flushed" });
+
+    const result = await clearLedgerRepairRequired("k1");
+
+    expect(result).toMatchObject({ ok: false, reason: "ledger_repair_clear_not_durably_saved" });
+    expect(mocks.monitorData.ledgerRepairRequired).toEqual(repair);
+    expect(mocks.monitorData.inferredRecoveryEvents).toHaveLength(0);
+  });
+});
+
+describe("archiveMountHistoryRejectedEvents", () => {
+  it("隔離済み mount event を audit event へ退避して warning を閉じる", async () => {
+    mocks.monitorData.mountHistoryRejectedEvents = [
+      { reason: "reanchor-invalid-reference", event: { evId: "ev-a", host: "k1" } },
+      { reason: "supersede-invalid-survivor", event: { evId: "ev-b", host: "k2" } }
+    ];
+
+    const result = await archiveMountHistoryRejectedEvents({ actor: "operator", nowMs: 600 });
+
+    expect(result).toMatchObject({
+      ok: true,
+      reason: "mount_history_rejected_events_archived",
+      archivedCount: 2
+    });
+    expect(mocks.monitorData.mountHistoryRejectedEvents).toEqual([]);
+    expect(mocks.monitorData.inferredRecoveryEvents[0]).toMatchObject({
+      type: "mount-history-rejected-events-archived",
+      rejectedEventCount: 2,
+      createdAt: 600
+    });
+    expect(mocks.monitorData.inferredRecoveryEvents[0].rejectedEvents).toHaveLength(2);
+  });
+});

--- a/tests/unit/dashboard_relay_bridge_filament_ops.test.js
+++ b/tests/unit/dashboard_relay_bridge_filament_ops.test.js
@@ -17,6 +17,7 @@ vi.mock("../../3dp_lib/dashboard_data.js", () => ({
     hostSpoolMap: {},
     mountHistory: [],
     inferredDecisionRecoveryRequired: null,
+    inferredRecoveryEvents: [],
     ledgerRepairRequired: {},
     mountHistoryRejectedEvents: [],
     inferredCandidateStore: {},
@@ -121,6 +122,9 @@ describe("relayBroadcastIfNeeded — #418 recovery 診断同期", () => {
     monitorData.ledgerRepairRequired = {
       k1: { spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 123 },
     };
+    monitorData.inferredRecoveryEvents = [
+      { eventId: "ir-a", type: "recovery-durable-save-retried", createdAt: 124 },
+    ];
     monitorData.mountHistoryRejectedEvents = [
       { reason: "reanchor-invalid-reference", event: { evId: "ev-a", host: "k1", spoolId: "S1" } },
     ];
@@ -130,6 +134,7 @@ describe("relayBroadcastIfNeeded — #418 recovery 診断同期", () => {
 
     const snapshot = globalThis.window.electronAPI.relaySendSnapshot.mock.calls[0][1];
     expect(snapshot.inferredDecisionRecoveryRequired).toEqual(monitorData.inferredDecisionRecoveryRequired);
+    expect(snapshot.inferredRecoveryEvents).toEqual(monitorData.inferredRecoveryEvents);
     expect(snapshot.ledgerRepairRequired).toEqual(monitorData.ledgerRepairRequired);
     expect(snapshot.mountHistoryRejectedEvents).toEqual(monitorData.mountHistoryRejectedEvents);
 
@@ -137,6 +142,7 @@ describe("relayBroadcastIfNeeded — #418 recovery 診断同期", () => {
 
     const delta = globalThis.window.electronAPI.relayBroadcast.mock.calls[0][0];
     expect(delta.shared.inferredDecisionRecoveryRequired).toEqual(monitorData.inferredDecisionRecoveryRequired);
+    expect(delta.shared.inferredRecoveryEvents).toEqual(monitorData.inferredRecoveryEvents);
     expect(delta.shared.ledgerRepairRequired).toEqual(monitorData.ledgerRepairRequired);
     expect(delta.shared.mountHistoryRejectedEvents).toEqual(monitorData.mountHistoryRejectedEvents);
   });

--- a/tests/unit/dashboard_storage_durable.test.js
+++ b/tests/unit/dashboard_storage_durable.test.js
@@ -34,6 +34,8 @@ const mocks = vi.hoisted(() => ({
     hostObservationWatermark: {},
     hostObservationCurrent: {},
     inferredCandidateStore: {},
+    inferredDecisionRecoveryRequired: null,
+    inferredRecoveryEvents: [],
     pendingUnattributedUsage: [],
     pendingUnattributedUsageArchive: {},
     ledgerRepairRequired: {},
@@ -76,6 +78,8 @@ beforeEach(async () => {
   mocks.idbAvailable = true;
   mocks.monitorData.machines = { k1: { storedData: {}, printStore: { history: [] }, runtimeData: { transient: true } } };
   mocks.monitorData.inferredCandidateStore = { "ic-a": { candidateHash: "ic-a", usedMm: 1200 } };
+  mocks.monitorData.inferredDecisionRecoveryRequired = { candidateHash: "ic-a", reason: "rollback_durable_save_failed" };
+  mocks.monitorData.inferredRecoveryEvents = [{ eventId: "ir-a", type: "recovery-durable-save-retried" }];
   mocks.monitorData.hostObservationWatermark = { k1: { observationSequence: 1 } };
   mocks.queueSharedWrite.mockClear();
   mocks.queueMachineWrite.mockClear();
@@ -90,6 +94,8 @@ describe("saveUnifiedStorageDurably", () => {
 
     expect(result).toEqual({ ok: true, backend: "indexedDB", reason: "flushed" });
     expect(mocks.queueSharedWrite).toHaveBeenCalledWith("inferredCandidateStore", mocks.monitorData.inferredCandidateStore);
+    expect(mocks.queueSharedWrite).toHaveBeenCalledWith("inferredDecisionRecoveryRequired", mocks.monitorData.inferredDecisionRecoveryRequired);
+    expect(mocks.queueSharedWrite).toHaveBeenCalledWith("inferredRecoveryEvents", mocks.monitorData.inferredRecoveryEvents);
     expect(mocks.queueSharedWrite).toHaveBeenCalledWith("hostObservationWatermark", mocks.monitorData.hostObservationWatermark);
     expect(mocks.events.indexOf("queue:inferredCandidateStore")).toBeGreaterThanOrEqual(0);
     expect(mocks.events[mocks.events.length - 1]).toBe("flush");

--- a/tests/unit/dashboard_storage_migration.test.js
+++ b/tests/unit/dashboard_storage_migration.test.js
@@ -42,6 +42,8 @@ const monitorData = {
   pendingUnattributedUsage: [],
   pendingUnattributedUsageArchive: {},
   inferredCandidateStore: {},
+  inferredDecisionRecoveryRequired: null,
+  inferredRecoveryEvents: [],
   ledgerRepairRequired: {},
   filamentEventContext: {},
   hostSpoolMap: {},
@@ -66,6 +68,8 @@ function resetMonitorData() {
   monitorData.pendingUnattributedUsage = [];
   monitorData.pendingUnattributedUsageArchive = {};
   monitorData.inferredCandidateStore = {};
+  monitorData.inferredDecisionRecoveryRequired = null;
+  monitorData.inferredRecoveryEvents = [];
   monitorData.ledgerRepairRequired = {};
   monitorData.hostSpoolMap = {};
   monitorData.hostCameraToggle = {};
@@ -167,6 +171,15 @@ describe('v2.2.1027 追加フィールドの round-trip', () => {
     monitorData.inferredCandidateStore = {
       "ic-a": { candidateHash: "ic-a", host: "h", windowId: "w1", candidateSpoolId: "S", usedMm: 1234, status: "pending", updatedAt: 111 },
     };
+    monitorData.inferredDecisionRecoveryRequired = {
+      candidateHash: "ic-a",
+      action: "confirmInferredCandidate",
+      reason: "rollback_durable_save_failed",
+      createdAt: 120,
+    };
+    monitorData.inferredRecoveryEvents = [
+      { eventId: "ir-a", type: "decision-recovery-cleared", createdAt: 130, actor: "operator" },
+    ];
 
     saveUnifiedStorage(true);
     resetMonitorData(); // リロード模擬（隔離・アーカイブ・seq・修復要求を空へ）
@@ -185,6 +198,11 @@ describe('v2.2.1027 追加フィールドの round-trip', () => {
     expect(monitorData.ledgerRepairRequired.h.status).toBe("ambiguous");
     // #412-O4: 推定 candidate store も往復で保持
     expect(monitorData.inferredCandidateStore["ic-a"].usedMm).toBe(1234);
+    // #420/O6A: recovery flag と audit event も往復で保持
+    expect(monitorData.inferredDecisionRecoveryRequired.reason).toBe("rollback_durable_save_failed");
+    expect(monitorData.inferredRecoveryEvents).toEqual([
+      { eventId: "ir-a", type: "decision-recovery-cleared", createdAt: 130, actor: "operator" },
+    ]);
   });
 
   it('#412-O4: import は candidateHash 単位で冪等マージし updatedAt が新しい方を採用する', async () => {
@@ -202,6 +220,32 @@ describe('v2.2.1027 追加フィールドの round-trip', () => {
     expect(monitorData.inferredCandidateStore["ic-a"].status).toBe("confirmed");
     expect(monitorData.inferredCandidateStore["ic-old"].status).toBe("pending");
     expect(monitorData.inferredCandidateStore["ic-b"].usedMm).toBe(200);
+  });
+
+  it('#420/O6A: import は recovery flag と audit event を安全にマージする', async () => {
+    monitorData.inferredDecisionRecoveryRequired = {
+      candidateHash: "ic-old",
+      reason: "old",
+      createdAt: 10,
+    };
+    monitorData.inferredRecoveryEvents = [
+      { eventId: "ir-a", type: "recovery-durable-save-retried", createdAt: 20 },
+    ];
+
+    await importAllData({
+      inferredDecisionRecoveryRequired: {
+        candidateHash: "ic-new",
+        reason: "rollback_durable_save_failed",
+        createdAt: 30,
+      },
+      inferredRecoveryEvents: [
+        { eventId: "ir-a", type: "recovery-durable-save-retried", createdAt: 20 },
+        { eventId: "ir-b", type: "decision-recovery-cleared", createdAt: 40 },
+      ],
+    });
+
+    expect(monitorData.inferredDecisionRecoveryRequired.candidateHash).toBe("ic-new");
+    expect(monitorData.inferredRecoveryEvents.map(event => event.eventId)).toEqual(["ir-a", "ir-b"]);
   });
 
   it('P1-1: import は同一 opId(別evId)の mount を1件に畳む', async () => {


### PR DESCRIPTION
## Summary
- add O6 recovery operations for retrying durable recovery saves, clearing decision recovery flags, clearing host ledger repair flags, and archiving rejected mount events
- persist and relay-sync inferred recovery audit events alongside existing recovery diagnostics
- wire Recovery / repair status actions into Candidate Center for Parent/Standalone while keeping Satellite read-only
- update filament manuals and add regression coverage for storage, relay sync, UI actions, and rollback-on-save-failure paths

## Validation
- npx vitest run --silent
- npx vitest run tests/unit/dashboard_inferred_recovery_ops.test.js tests/unit/dashboard_inferred_candidate_ui.test.js tests/unit/dashboard_storage_migration.test.js tests/unit/dashboard_client_sync_filament_sync.test.js tests/unit/dashboard_relay_bridge_filament_ops.test.js --silent
- npx eslint 3dp_lib/dashboard_client_sync.js 3dp_lib/dashboard_data.js 3dp_lib/dashboard_inferred_candidate_decision.js 3dp_lib/dashboard_inferred_candidate_ui.js 3dp_lib/dashboard_inferred_recovery_ops.js 3dp_lib/dashboard_relay_bridge.js 3dp_lib/dashboard_storage.js 3dp_lib/dashboard_storage_idb.js --quiet

## Notes
- Full `npm run lint -- --quiet` still fails on pre-existing issues in dashboard_storage_ui.js and dashboard_ui_mapping.js outside this PR.
- Full `npm run lint:css` still fails on pre-existing stylelint debt across existing CSS files; the new CSS uses existing tokens only.