### PR TITLE
Surface O6 recovery audit history

### DIFF
--- a/3dp_lib/dashboard_inferred_candidate_ui.js
+++ b/3dp_lib/dashboard_inferred_candidate_ui.js
@@ -11,14 +11,14 @@
  * - O5B Candidate Center として pending/処理済み candidate の一覧、詳細、監査 timeline を描画する。
  * - Confirm / Reject / Reassign / Undo の操作ダイアログを提供し、実更新は Decision Core へ委譲する。
  * - SATELLITE 子では Parent へ decision request を送り、readonly 子では操作ボタンを disabled にする。
- * - recovery / repair flag は診断カードとして表示し、O6 Recovery Operations を Parent/Standalone へ接続する。
+ * - recovery / repair flag と復旧操作 audit event を表示し、O6 Recovery Operations を Parent/Standalone へ接続する。
  *
  * 【公開関数一覧】
  * - {@link createInferredCandidateCenterContent}：フィラメント管理モーダル用 Candidate Center を生成する
  *
- * @version 1.390.1270 (PR #420)
+ * @version 1.390.1271 (PR #421)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-08-02 15:05:22
+ * @lastModified 2026-08-02 15:30:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -429,8 +429,11 @@ function _appendRecoveryActions(el, card, render, onAfterDecision) {
 function _recoveryCard(card, render, onAfterDecision) {
   const el = _el("article", `ic-recovery-card ic-recovery-${card.severity || "warning"}`);
   const header = _el("div", "ic-recovery-card-header");
+  const severityLabel = card.severity === "blocker" ? "BLOCKER"
+    : card.severity === "info" ? "INFO"
+      : "WARNING";
   header.append(
-    _el("span", "ic-recovery-severity", card.severity === "blocker" ? "BLOCKER" : "WARNING"),
+    _el("span", "ic-recovery-severity", severityLabel),
     _el("strong", "ic-recovery-title", card.title || "Recovery item")
   );
   el.append(header, _el("p", "ic-recovery-summary", card.summary || ""));
@@ -464,7 +467,7 @@ function _renderRecoverySurface(wrap, render, onAfterDecision) {
   panel.appendChild(_el(
     "div",
     "ic-recovery-overview",
-    `Blocker ${model.blockerCount} / Warning ${model.warningCount}`
+    `Blocker ${model.blockerCount} / Warning ${model.warningCount} / Info ${model.infoCount || 0}`
   ));
   for (const card of model.cards) panel.appendChild(_recoveryCard(card, render, onAfterDecision));
   wrap.appendChild(panel);

--- a/3dp_lib/dashboard_inferred_candidate_view.js
+++ b/3dp_lib/dashboard_inferred_candidate_view.js
@@ -10,7 +10,7 @@
  * 【機能内容サマリ】
  * - inferredCandidateStore の保存レコードから O5 UI 用 ViewModel を生成する。
  * - status filter、sort、pending count、残量差分、履歴照合警告、decision/undo 送信可否を計算する。
- * - recovery / repair flag を read-only 診断カードへ変換し、異常系を操作前に見える状態にする。
+ * - recovery / repair flag と O6 復旧操作 audit event を診断カードへ変換し、異常系を操作前後で見える状態にする。
  * - UI が candidate record や確定台帳を直接変更しないための表示専用境界を提供する。
  *
  * 【公開関数一覧】
@@ -19,9 +19,9 @@
  * - {@link countPendingInferredCandidates}：pending candidate 件数を返す
  * - {@link buildInferredRecoverySurfaceViewModel}：recovery / repair 状態を診断表示モデルへ変換する
  *
- * @version 1.390.1267 (PR #418)
+ * @version 1.390.1271 (PR #421)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-07-26 15:48:10
+ * @lastModified 2026-08-02 15:30:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -224,6 +224,26 @@ function _details(entries) {
   return entries
     .filter(item => item && item.value != null && item.value !== "")
     .map(item => ({ label: item.label, value: _formatValue(item.value) }));
+}
+
+/**
+ * recovery audit event から短い対象説明を生成する。
+ *
+ * 【詳細説明】
+ * - event type ごとに見るべき target が異なるため、候補 ID / host / 件数を優先して要約する。
+ * - 表示専用の整形であり、監査 event 本体は `inferredRecoveryEvents` にそのまま残す。
+ *
+ * @private
+ * @function _recoveryEventTarget
+ * @param {Object} event - recovery audit event。
+ * @returns {string} 表示用 target。
+ */
+function _recoveryEventTarget(event) {
+  if (event?.clearedRecovery?.candidateHash) return String(event.clearedRecovery.candidateHash);
+  if (event?.decisionRecovery?.candidateHash) return String(event.decisionRecovery.candidateHash);
+  if (event?.host) return String(event.host);
+  if (Number.isFinite(Number(event?.rejectedEventCount))) return `${Number(event.rejectedEventCount)} rejected events`;
+  return "--";
 }
 
 /**
@@ -475,7 +495,7 @@ export function countPendingInferredCandidates(host = null) {
 }
 
 /**
- * O5/ledger の recovery / repair 状態を read-only 診断表示モデルへ変換する。
+ * O5/ledger の recovery / repair 状態を診断表示モデルへ変換する。
  *
  * 【詳細説明】
  * - この関数は monitorData を参照するだけで、recovery flag の解除や candidate 遷移は行わない。
@@ -483,10 +503,11 @@ export function countPendingInferredCandidates(host = null) {
  * - `ledgerRepairRequired` は host 単位の mount ledger 修復要求として表示する。
  * - `mountHistoryRejectedEvents` は隔離済みイベントの件数と最新数件を表示し、元データが失われていない
  *   ことをオペレーターが確認できるようにする。
+ * - `inferredRecoveryEvents` は復旧操作の監査履歴として、問題が解消済みでも最新数件を表示する。
  *
  * @function buildInferredRecoverySurfaceViewModel
- * @param {{maxRejectedEvents?:number}} [options] - 表示する隔離イベントの最大件数。
- * @returns {{hasIssues:boolean,totalCount:number,blockerCount:number,warningCount:number,cards:Array<Object>}}
+ * @param {{maxRejectedEvents?:number,maxRecoveryEvents?:number}} [options] - 表示する隔離/audit event の最大件数。
+ * @returns {{hasIssues:boolean,totalCount:number,blockerCount:number,warningCount:number,infoCount:number,cards:Array<Object>}}
  *   recovery surface 表示モデル。
  * @example
  * const recovery = buildInferredRecoverySurfaceViewModel();
@@ -564,13 +585,45 @@ export function buildInferredRecoverySurfaceViewModel(options = {}) {
     });
   }
 
+  const recoveryEvents = Array.isArray(monitorData.inferredRecoveryEvents)
+    ? monitorData.inferredRecoveryEvents
+    : [];
+  const maxRecoveryEvents = Math.max(1, Math.min(10, Number(options.maxRecoveryEvents) || 5));
+  if (recoveryEvents.length > 0) {
+    const recentEvents = recoveryEvents
+      .slice()
+      .sort((a, b) => (Number(b?.createdAt) || 0) - (Number(a?.createdAt) || 0))
+      .slice(0, maxRecoveryEvents);
+    cards.push({
+      type: "recovery-audit",
+      severity: "info",
+      title: "Recovery operation audit",
+      summary: `${recoveryEvents.length}件の recovery 操作監査eventがあります`,
+      host: null,
+      candidateHash: null,
+      createdAt: Number(recentEvents[0]?.createdAt) || 0,
+      createdAtDisplay: _formatTime(recentEvents[0]?.createdAt),
+      details: recentEvents.map((event, index) => ({
+        label: `Audit ${index + 1}`,
+        value: _formatValue({
+          type: event?.type || "unknown",
+          target: _recoveryEventTarget(event),
+          actor: event?.actor || null,
+          at: _formatTime(event?.createdAt)
+        })
+      }))
+    });
+  }
+
   const blockerCount = cards.filter(card => card.severity === "blocker").length;
-  const warningCount = cards.filter(card => card.severity !== "blocker").length;
+  const warningCount = cards.filter(card => card.severity === "warning").length;
+  const infoCount = cards.filter(card => card.severity === "info").length;
   return {
     hasIssues: cards.length > 0,
     totalCount: cards.length,
     blockerCount,
     warningCount,
+    infoCount,
     cards
   };
 }

--- a/3dp_panel.css
+++ b/3dp_panel.css
@@ -1,7 +1,7 @@
 /*
   3dp_panel.css
   GridStack パネルシステム用スタイル
-  Version 1.390.1270
+  Version 1.390.1271
 */
 
 /* ===============================================================
@@ -3962,9 +3962,13 @@ body.relay-readonly textarea {
   margin-top: var(--space-2);
 }
 
-.ic-recovery-blocker {
-  border-color: var(--color-danger);
-}
+  .ic-recovery-blocker {
+    border-color: var(--color-danger);
+  }
+
+  .ic-recovery-info {
+    border-color: var(--color-accent);
+  }
 
 .ic-recovery-card-header {
   display: flex;

--- a/docs/en/filament_manual.md
+++ b/docs/en/filament_manual.md
@@ -146,6 +146,13 @@ Satellites mirror the diagnostic state from the Parent authority but keep
 the recovery operation buttons disabled. Run recovery operations on the
 Parent device.
 
+After recovery operations run, the same Recovery / repair status surface
+shows a **Recovery operation audit** card. It lists recent retry-save,
+recovery-flag clear, ledger-repair clear and rejected-event archive
+operations, including the related candidate, host, count, actor and time.
+When no unresolved blocker remains, recent recovery activity is still shown
+as an INFO card.
+
 ### Registered Filament Tab
 
 The Registered Filament tab lists all spools that have been added so far and lets you edit them.

--- a/docs/ja/filament_manual.md
+++ b/docs/ja/filament_manual.md
@@ -105,6 +105,8 @@ Standalone / Parent では、Recovery / repair status から次の復旧操作�
 
 これらの復旧操作は `inferredRecoveryEvents` に監査 event を残し、保存失敗時は操作前の状態へ戻します。Relay 構成では Satellite も Parent 権威の診断状態をミラー表示しますが、復旧操作は無効化されます。復旧操作は Parent 端末で実行してください。
 
+復旧操作後は、同じ Recovery / repair status に **Recovery operation audit** が表示されます。ここには最新の再保存、recovery flag 解除、ledger repair flag 解除、隔離 event 退避の履歴が残り、対象 candidate、host、件数、操作者、実行時刻を確認できます。未解決 blocker が無い場合でも、直近の復旧操作履歴は INFO として表示されます。
+
 ### 登録済みフィラメントタブ
 
 登録済みフィラメントタブでは、過去に登録したスプールを一覧で確認し編集できます。

--- a/tests/unit/dashboard_inferred_candidate_ui.test.js
+++ b/tests/unit/dashboard_inferred_candidate_ui.test.js
@@ -231,6 +231,31 @@ describe("createInferredCandidateCenterContent", () => {
     });
   });
 
+  it("#421/O6B: recovery audit card は INFO として表示し操作ボタンを出さない", () => {
+    mocks.recoveryVm = {
+      hasIssues: true,
+      totalCount: 1,
+      blockerCount: 0,
+      warningCount: 0,
+      infoCount: 1,
+      cards: [{
+        type: "recovery-audit",
+        severity: "info",
+        title: "Recovery operation audit",
+        summary: "2件の recovery 操作監査eventがあります",
+        details: [{ label: "Audit 1", value: "decision-recovery-cleared" }]
+      }]
+    };
+
+    const center = createInferredCandidateCenterContent();
+    document.body.appendChild(center.el);
+
+    expect(document.querySelector(".ic-recovery-surface").textContent).toContain("Blocker 0 / Warning 0 / Info 1");
+    expect(document.querySelector(".ic-recovery-severity").textContent).toBe("INFO");
+    expect(document.querySelector(".ic-recovery-title").textContent).toBe("Recovery operation audit");
+    expect(document.querySelector(".ic-recovery-actions")).toBeNull();
+  });
+
   it("Satellite では recovery 操作を disabled にする", () => {
     mocks.canExecuteRecoveryOperation.mockReturnValue(false);
     mocks.recoveryVm = {

--- a/tests/unit/dashboard_inferred_candidate_view.test.js
+++ b/tests/unit/dashboard_inferred_candidate_view.test.js
@@ -82,6 +82,7 @@ beforeEach(() => {
     "ic-old": record("ic-old", { createdAt: 1000, status: "confirmed" })
   };
   delete mocks.monitorData.inferredDecisionRecoveryRequired;
+  mocks.monitorData.inferredRecoveryEvents = [];
   mocks.monitorData.ledgerRepairRequired = {};
   mocks.monitorData.mountHistoryRejectedEvents = [];
 });
@@ -188,6 +189,7 @@ describe("buildInferredRecoverySurfaceViewModel", () => {
     expect(vm.totalCount).toBe(3);
     expect(vm.blockerCount).toBe(2);
     expect(vm.warningCount).toBe(1);
+    expect(vm.infoCount).toBe(0);
     expect(vm.cards.map(card => card.type)).toEqual([
       "decision-recovery",
       "ledger-repair",
@@ -197,6 +199,37 @@ describe("buildInferredRecoverySurfaceViewModel", () => {
     expect(vm.cards[1].summary).toContain("K1 Max");
     expect(vm.cards[2].details).toHaveLength(1);
     expect(vm.cards[2].details[0].value).toContain("ev-b");
+  });
+
+  it("#421/O6B: recovery 操作 audit event を info card に変換する", () => {
+    mocks.monitorData.inferredRecoveryEvents = [
+      {
+        eventId: "ir-a",
+        type: "recovery-durable-save-retried",
+        actor: "operator-a",
+        createdAt: 1000,
+        decisionRecovery: { candidateHash: "ic-old" }
+      },
+      {
+        eventId: "ir-b",
+        type: "decision-recovery-cleared",
+        actor: "operator-b",
+        createdAt: 3000,
+        clearedRecovery: { candidateHash: "ic-new" }
+      }
+    ];
+
+    const vm = buildInferredRecoverySurfaceViewModel({ maxRecoveryEvents: 1 });
+
+    expect(vm.hasIssues).toBe(true);
+    expect(vm.blockerCount).toBe(0);
+    expect(vm.warningCount).toBe(0);
+    expect(vm.infoCount).toBe(1);
+    expect(vm.cards.map(card => card.type)).toEqual(["recovery-audit"]);
+    expect(vm.cards[0].summary).toContain("2件");
+    expect(vm.cards[0].details).toHaveLength(1);
+    expect(vm.cards[0].details[0].value).toContain("decision-recovery-cleared");
+    expect(vm.cards[0].details[0].value).toContain("ic-new");
   });
 
   it("recovery item がない場合は空の診断モデルを返す", () => {


### PR DESCRIPTION
## Summary
- show inferredRecoveryEvents as an INFO recovery audit card in the Candidate Center recovery surface
- include recent recovery operation type, target, actor and time so cleared recovery state remains reviewable
- update Japanese and English filament manuals to document the audit card
- add ViewModel and UI regression coverage for audit-only recovery surfaces

## Validation
- npx vitest run --silent
- npx vitest run tests/unit/dashboard_inferred_candidate_view.test.js tests/unit/dashboard_inferred_candidate_ui.test.js --silent
- npx eslint 3dp_lib/dashboard_inferred_candidate_view.js 3dp_lib/dashboard_inferred_candidate_ui.js --quiet