### PR TITLE
Gate O6 ledger repair clearance

### DIFF
--- a/3dp_lib/dashboard_inferred_candidate_ui.js
+++ b/3dp_lib/dashboard_inferred_candidate_ui.js
@@ -16,9 +16,9 @@
  * 【公開関数一覧】
  * - {@link createInferredCandidateCenterContent}：フィラメント管理モーダル用 Candidate Center を生成する
  *
- * @version 1.390.1271 (PR #421)
+ * @version 1.390.1272 (PR #422)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-08-02 15:30:00
+ * @lastModified 2026-08-02 16:45:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -110,7 +110,10 @@ const REASON_LABELS = Object.freeze({
   recovery_operation_rollback_save_failed: "復旧操作のrollback状態を保存できませんでした",
   decision_recovery_clear_not_durably_saved: "整合性確認フラグの解除を保存できませんでした",
   ledger_repair_host_required: "修復対象ホストが不正です",
+  ledger_repair_spool_required: "台帳修復対象スプールが不明です",
   ledger_repair_not_found: "台帳修復フラグは見つかりません",
+  ledger_repair_still_unresolved: "台帳状態がまだ曖昧または破損しているため解除できません",
+  ledger_repair_validation_failed: "台帳修復状態の検証に失敗しました",
   ledger_repair_clear_not_durably_saved: "台帳修復フラグの解除を保存できませんでした",
   mount_history_rejected_events_not_found: "隔離済みmount eventは見つかりません",
   mount_history_rejected_archive_not_durably_saved: "隔離済みmount eventの退避を保存できませんでした"

--- a/3dp_lib/dashboard_inferred_recovery_ops.js
+++ b/3dp_lib/dashboard_inferred_recovery_ops.js
@@ -20,13 +20,13 @@
  * - {@link clearLedgerRepairRequired}：確認済みの host 単位 ledger repair flag を解除する
  * - {@link archiveMountHistoryRejectedEvents}：隔離済み mount event を監査 event に移して warning を閉じる
  *
- * @version 1.390.1270 (PR #420)
+ * @version 1.390.1272 (PR #422)
  * @since   1.390.1270 (PR #420)
- * @lastModified 2026-08-02 15:05:22
+ * @lastModified 2026-08-02 16:45:00
  * -----------------------------------------------------------
  * @todo
  * - O7 Ledger Reconciliation で、手動解除前の再計算監査と修復案提示を追加する。
- * - mount interval の survivor 明示選択は O6B 以降で実装する。
+ * - mount interval の survivor 明示選択は O6C 以降で実装する。
  */
 
 "use strict";
@@ -36,6 +36,7 @@ import {
   canExecuteLedgerDecision,
   enqueueLedgerDecisionTask
 } from "./dashboard_inferred_candidate_decision.js";
+import { getMountIntervalStatus } from "./dashboard_filament_ledger.js";
 import { saveUnifiedStorageDurably } from "./dashboard_storage.js";
 import { wallNowMs } from "./dashboard_time.js";
 
@@ -299,6 +300,43 @@ function _operationGuard() {
 }
 
 /**
+ * ledger repair flag を解除してよい状態か検証する。
+ *
+ * 【詳細説明】
+ * - `ledgerRepairRequired` は、mount interval が ambiguous/corrupt のまま暗黙クローズを止めた
+ *   ことを示す blocker である。
+ * - O6B では自動修復や survivor 選択までは行わないが、現在も ambiguous/corrupt なら解除を拒否する。
+ * - 状態が `ok` または `none` へ戻っている場合だけ、オペレーター確認済みとして flag 解除へ進める。
+ *
+ * @private
+ * @function _validateLedgerRepairClearance
+ * @param {string} host - host key。
+ * @param {Object} repairItem - ledgerRepairRequired の対象 item。
+ * @returns {{ok:boolean,reason:string,status?:Object}} 検証結果。
+ */
+function _validateLedgerRepairClearance(host, repairItem) {
+  const spoolId = repairItem?.spoolId != null ? String(repairItem.spoolId) : "";
+  if (!spoolId) return { ok: false, reason: "ledger_repair_spool_required" };
+  try {
+    const status = getMountIntervalStatus(spoolId, host);
+    if (status?.status === "ambiguous" || status?.status === "corrupt") {
+      return {
+        ok: false,
+        reason: "ledger_repair_still_unresolved",
+        status
+      };
+    }
+    return { ok: true, reason: "ledger_repair_clearable", status };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: "ledger_repair_validation_failed",
+      status: { error: error?.message || String(error) }
+    };
+  }
+}
+
+/**
  * この端末で O6 recovery 操作を実行できるか判定する。
  *
  * 【詳細説明】
@@ -384,8 +422,9 @@ export function clearInferredDecisionRecoveryRequired(options = {}) {
  * 確認済みの host 単位 ledger repair flag を解除する。
  *
  * 【詳細説明】
- * - O7 の再計算監査が入るまでは、オペレーターが対象 host の mount ledger を確認済みであることを
- *   前提とする手動解除 API として扱う。
+ * - 現在の mount interval 状態を確認し、まだ ambiguous/corrupt の場合は fail-closed で解除しない。
+ * - O7 の再計算監査が入るまでは、`ok` / `none` に戻っている host について、オペレーターが
+ *   mount ledger を確認済みであることを前提とする手動解除 API として扱う。
  * - 解除対象の元 flag は audit event に保存し、保存失敗時は map を操作前へ戻す。
  *
  * @function clearLedgerRepairRequired
@@ -404,6 +443,8 @@ export function clearLedgerRepairRequired(host, options = {}) {
     const repair = _ledgerRepairRequired();
     const current = repair[hostKey];
     if (!current || typeof current !== "object") return { ok: false, reason: "ledger_repair_not_found", host: hostKey };
+    const clearance = _validateLedgerRepairClearance(hostKey, current);
+    if (!clearance.ok) return { ok: false, reason: clearance.reason, host: hostKey, status: clearance.status };
 
     const snapshot = _snapshotRecoveryState();
     delete repair[hostKey];
@@ -411,7 +452,8 @@ export function clearLedgerRepairRequired(host, options = {}) {
       reason: "operator-cleared-ledger-repair",
       host: hostKey,
       note: options.note || "",
-      clearedRepair: _clone(current)
+      clearedRepair: _clone(current),
+      clearanceStatus: _clone(clearance.status)
     }, options);
     const saved = await _saveOrRollbackRecoveryMutation(snapshot, "ledger_repair_clear_not_durably_saved", options);
     if (!saved.ok) return saved;

--- a/docs/en/filament_manual.md
+++ b/docs/en/filament_manual.md
@@ -137,7 +137,7 @@ Recovery / repair status surface.
 | --- | --- |
 | **Retry save** | Attempts to durably save the current recovery / repair state again. |
 | **Clear recovery** | Clears `inferredDecisionRecoveryRequired` after the operator has verified the rolled-back state. |
-| **Clear repair** | Clears `ledgerRepairRequired` for the selected host after the mount ledger has been verified. |
+| **Clear repair** | Clears `ledgerRepairRequired` for the selected host after the mount ledger has been verified and the current state is no longer `ambiguous` or `corrupt`. |
 | **Archive rejected** | Moves quarantined mountHistory events into `inferredRecoveryEvents` audit history and closes the warning. |
 
 Each recovery operation appends an `inferredRecoveryEvents` audit event

--- a/docs/ja/filament_manual.md
+++ b/docs/ja/filament_manual.md
@@ -100,7 +100,7 @@ Standalone / Parent では、Recovery / repair status から次の復旧操作�
 | --- | --- |
 | **Retry save** | 現在の recovery / repair 状態を再度耐久保存します |
 | **Clear recovery** | rollback 後の状態を確認済みの場合に `inferredDecisionRecoveryRequired` を解除します |
-| **Clear repair** | 対象 host の mount ledger を確認済みの場合に `ledgerRepairRequired` を解除します |
+| **Clear repair** | 対象 host の mount ledger を確認済みで、現在状態が `ambiguous` / `corrupt` ではない場合に `ledgerRepairRequired` を解除します |
 | **Archive rejected** | 隔離済み mountHistory event を `inferredRecoveryEvents` へ監査退避し、warning を閉じます |
 
 これらの復旧操作は `inferredRecoveryEvents` に監査 event を残し、保存失敗時は操作前の状態へ戻します。Relay 構成では Satellite も Parent 権威の診断状態をミラー表示しますが、復旧操作は無効化されます。復旧操作は Parent 端末で実行してください。

--- a/tests/unit/dashboard_inferred_recovery_ops.test.js
+++ b/tests/unit/dashboard_inferred_recovery_ops.test.js
@@ -13,12 +13,16 @@ const mocks = vi.hoisted(() => ({
   },
   saveUnifiedStorageDurably: vi.fn(async () => ({ ok: true, backend: "test", reason: "saved" })),
   canExecuteLedgerDecision: vi.fn(() => true),
+  getMountIntervalStatus: vi.fn(() => ({ status: "none", openInterval: null, intervals: [], diagnostics: [] })),
   queue: Promise.resolve()
 }));
 
 vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mocks.monitorData }));
 vi.mock("../../3dp_lib/dashboard_storage.js", () => ({ saveUnifiedStorageDurably: mocks.saveUnifiedStorageDurably }));
 vi.mock("../../3dp_lib/dashboard_time.js", () => ({ wallNowMs: () => 123456 }));
+vi.mock("../../3dp_lib/dashboard_filament_ledger.js", () => ({
+  getMountIntervalStatus: mocks.getMountIntervalStatus
+}));
 vi.mock("../../3dp_lib/dashboard_inferred_candidate_decision.js", () => ({
   canExecuteLedgerDecision: mocks.canExecuteLedgerDecision,
   enqueueLedgerDecisionTask: (task) => {
@@ -56,6 +60,8 @@ beforeEach(() => {
   mocks.canExecuteLedgerDecision.mockReturnValue(true);
   mocks.saveUnifiedStorageDurably.mockReset();
   mocks.saveUnifiedStorageDurably.mockResolvedValue({ ok: true, backend: "test", reason: "saved" });
+  mocks.getMountIntervalStatus.mockReset();
+  mocks.getMountIntervalStatus.mockReturnValue({ status: "none", openInterval: null, intervals: [], diagnostics: [] });
 });
 
 describe("canExecuteRecoveryOperation", () => {
@@ -145,12 +151,50 @@ describe("clearLedgerRepairRequired", () => {
     const result = await clearLedgerRepairRequired("k1", { actor: "operator", nowMs: 500 });
 
     expect(result).toMatchObject({ ok: true, reason: "ledger_repair_cleared", host: "k1" });
+    expect(mocks.getMountIntervalStatus).toHaveBeenCalledWith("S1", "k1");
     expect(mocks.monitorData.ledgerRepairRequired).toEqual({});
     expect(mocks.monitorData.inferredRecoveryEvents[0]).toMatchObject({
       type: "ledger-repair-cleared",
       host: "k1",
       createdAt: 500
     });
+    expect(mocks.monitorData.inferredRecoveryEvents[0].clearanceStatus.status).toBe("none");
+  });
+
+  it("現在も ambiguous/corrupt の ledger repair flag は解除しない", async () => {
+    mocks.monitorData.ledgerRepairRequired = {
+      k1: { spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 100 }
+    };
+    mocks.getMountIntervalStatus.mockReturnValueOnce({
+      status: "ambiguous",
+      openInterval: null,
+      intervals: [{ intervalId: "iv-a" }, { intervalId: "iv-b" }],
+      diagnostics: []
+    });
+
+    const result = await clearLedgerRepairRequired("k1");
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "ledger_repair_still_unresolved",
+      host: "k1",
+      status: { status: "ambiguous" }
+    });
+    expect(mocks.monitorData.ledgerRepairRequired.k1.status).toBe("ambiguous");
+    expect(mocks.monitorData.inferredRecoveryEvents).toHaveLength(0);
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+
+  it("spoolId がない ledger repair flag は解除しない", async () => {
+    mocks.monitorData.ledgerRepairRequired = {
+      k1: { status: "ambiguous", detectedAtEpochMs: 100 }
+    };
+
+    const result = await clearLedgerRepairRequired("k1");
+
+    expect(result).toMatchObject({ ok: false, reason: "ledger_repair_spool_required", host: "k1" });
+    expect(mocks.getMountIntervalStatus).not.toHaveBeenCalled();
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
   });
 
   it("保存失敗時は ledger repair flag を rollback する", async () => {


### PR DESCRIPTION
## Summary
- validate current mount interval state before clearing ledgerRepairRequired
- fail closed when the target repair is still ambiguous/corrupt, missing spoolId, or cannot be validated
- include clearance status in recovery audit events when repair flags are cleared
- document the stricter Clear repair behavior and add regression coverage

## Validation
- npx vitest run --silent
- npx vitest run tests/unit/dashboard_inferred_recovery_ops.test.js tests/unit/dashboard_inferred_candidate_ui.test.js --silent
- npx eslint 3dp_lib/dashboard_inferred_recovery_ops.js 3dp_lib/dashboard_inferred_candidate_ui.js --quiet