### PR TITLE
Repair ambiguous O6 mount intervals

### DIFF
--- a/3dp_lib/dashboard_inferred_candidate_ui.js
+++ b/3dp_lib/dashboard_inferred_candidate_ui.js
@@ -16,9 +16,9 @@
  * 【公開関数一覧】
  * - {@link createInferredCandidateCenterContent}：フィラメント管理モーダル用 Candidate Center を生成する
  *
- * @version 1.390.1272 (PR #422)
+ * @version 1.390.1273 (PR #423)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-08-02 16:45:00
+ * @lastModified 2026-08-02 18:20:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -46,6 +46,7 @@ import {
   canExecuteRecoveryOperation,
   clearInferredDecisionRecoveryRequired,
   clearLedgerRepairRequired,
+  repairLedgerMountIntervals,
   retryInferredRecoveryDurableSave
 } from "./dashboard_inferred_recovery_ops.js";
 import { showAlert } from "./dashboard_notification_manager.js";
@@ -112,6 +113,12 @@ const REASON_LABELS = Object.freeze({
   ledger_repair_host_required: "修復対象ホストが不正です",
   ledger_repair_spool_required: "台帳修復対象スプールが不明です",
   ledger_repair_not_found: "台帳修復フラグは見つかりません",
+  ledger_repair_not_ambiguous: "台帳状態は曖昧ではありません",
+  ledger_repair_survivor_required: "残す装着区間を選択してください",
+  ledger_repair_survivor_not_open: "選択した装着区間は現在openではありません",
+  ledger_repair_supersede_failed: "台帳修復eventを作成できませんでした",
+  ledger_repair_post_status_invalid: "修復後の台帳状態を確認できませんでした",
+  ledger_repair_repair_not_durably_saved: "台帳修復結果を保存できませんでした",
   ledger_repair_still_unresolved: "台帳状態がまだ曖昧または破損しているため解除できません",
   ledger_repair_validation_failed: "台帳修復状態の検証に失敗しました",
   ledger_repair_clear_not_durably_saved: "台帳修復フラグの解除を保存できませんでした",
@@ -298,8 +305,9 @@ function _handleRecoveryResult(result, render, onAfterDecision) {
     const label = result.reason === "recovery_durable_save_retried" ? "復旧状態を再保存しました"
       : result.reason === "decision_recovery_cleared" ? "整合性確認フラグを解除しました"
         : result.reason === "ledger_repair_cleared" ? "台帳修復フラグを解除しました"
-          : result.reason === "mount_history_rejected_events_archived" ? "隔離イベントを監査へ退避しました"
-            : "復旧操作を実行しました";
+            : result.reason === "mount_history_rejected_events_archived" ? "隔離イベントを監査へ退避しました"
+              : result.reason === "ledger_repair_intervals_repaired" ? "台帳装着区間を修復しました"
+                : "復旧操作を実行しました";
     showAlert(label, "success");
     try { onAfterDecision?.(result); } catch { /* noop */ }
     render();
@@ -330,6 +338,45 @@ async function _confirmRecoveryAction(title, summary, confirmText) {
     cancelText: "キャンセル"
   });
   return ok === true;
+}
+
+/**
+ * ledger repair 操作用ダイアログを表示し、残す mount interval を取得する。
+ *
+ * 【詳細説明】
+ * - 操作者が survivor を明示選択しない限り、O6 は曖昧区間を自動解決しない。
+ * - 表示される interval 候補は read-only ViewModel 由来であり、実行時には Recovery Operations 側で
+ *   もう一度現在状態を検証する。
+ *
+ * @private
+ * @function _repairIntervalsAction
+ * @param {Object} card - ledger-repair recovery card。
+ * @returns {Promise<?string>} 残す intervalId。キャンセル時は null。
+ */
+async function _repairIntervalsAction(card) {
+  const intervals = Array.isArray(card.openIntervals) ? card.openIntervals : [];
+  if (intervals.length < 2) {
+    showAlert("修復可能なopen区間が不足しています", "warn");
+    return null;
+  }
+  const formId = `ic-ledger-repair-${++_dialogSeq}`;
+  const options = intervals.map(interval => {
+    const label = `${interval.intervalId} / since ${interval.sinceJobId} / anchor ${interval.anchorRemainingDisplay} / ${interval.boundaryStatus}`;
+    return `<option value="${_escapeHtml(interval.intervalId)}">${_escapeHtml(label)}</option>`;
+  }).join("");
+  const ok = await showConfirmDialog({
+    level: "warn",
+    title: "台帳装着区間を修復",
+    html:
+      `<form id="${formId}" class="ic-dialog-form">` +
+      `<label>Survivor<select name="survivingIntervalId">${options}</select></label>` +
+      `</form>`,
+    confirmText: "修復する",
+    cancelText: "キャンセル"
+  });
+  if (ok !== true) return null;
+  const form = document.getElementById(formId);
+  return form?.elements?.survivingIntervalId?.value || null;
 }
 
 /**
@@ -379,6 +426,16 @@ function _appendRecoveryActions(el, card, render, onAfterDecision) {
     });
     actions.append(retryBtn, clearBtn);
   } else if (card.type === "ledger-repair") {
+    const repairBtn = _el("button", "ic-action-secondary", "Repair intervals");
+    repairBtn.disabled = !canExecute || !card.host || card.repairStatus?.status !== "ambiguous" || !Array.isArray(card.openIntervals) || card.openIntervals.length < 2;
+    repairBtn.addEventListener("click", async () => {
+      await _withBusy(el, async () => {
+        const survivingIntervalId = await _repairIntervalsAction(card);
+        if (!survivingIntervalId) return;
+        const result = await repairLedgerMountIntervals(card.host, survivingIntervalId, { actor: _actor() });
+        _handleRecoveryResult(result, render, onAfterDecision);
+      });
+    });
     const clearBtn = _el("button", "ic-action-secondary", "Clear repair");
     clearBtn.disabled = !canExecute || !card.host;
     clearBtn.addEventListener("click", async () => {
@@ -393,7 +450,7 @@ function _appendRecoveryActions(el, card, render, onAfterDecision) {
         _handleRecoveryResult(result, render, onAfterDecision);
       });
     });
-    actions.appendChild(clearBtn);
+    actions.append(repairBtn, clearBtn);
   } else if (card.type === "mount-history-rejected") {
     const archiveBtn = _el("button", "ic-action-secondary", "Archive rejected");
     archiveBtn.disabled = !canExecute;

--- a/3dp_lib/dashboard_inferred_candidate_view.js
+++ b/3dp_lib/dashboard_inferred_candidate_view.js
@@ -19,9 +19,9 @@
  * - {@link countPendingInferredCandidates}：pending candidate 件数を返す
  * - {@link buildInferredRecoverySurfaceViewModel}：recovery / repair 状態を診断表示モデルへ変換する
  *
- * @version 1.390.1271 (PR #421)
+ * @version 1.390.1273 (PR #423)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-08-02 15:30:00
+ * @lastModified 2026-08-02 18:20:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -30,6 +30,7 @@
 "use strict";
 
 import { monitorData } from "./dashboard_data.js";
+import { getMountIntervalStatus } from "./dashboard_filament_ledger.js";
 import { jobObservationIdentity } from "./dashboard_history_identity.js";
 import { canSubmitLedgerDecision } from "./dashboard_inferred_candidate_decision.js";
 import { INFERRED_CANDIDATE_STATUS } from "./dashboard_offline_candidate_store.js";
@@ -244,6 +245,68 @@ function _recoveryEventTarget(event) {
   if (event?.host) return String(event.host);
   if (Number.isFinite(Number(event?.rejectedEventCount))) return `${Number(event.rejectedEventCount)} rejected events`;
   return "--";
+}
+
+/**
+ * mount interval を Recovery surface 表示用へ整形する。
+ *
+ * 【詳細説明】
+ * - O6 の修復操作では、操作者が残す open interval を明示選択する。
+ * - ViewModel では intervalId、境界、アンカー値だけを提示し、確定台帳の変更は UI から行わない。
+ *
+ * @private
+ * @function _openIntervalOptions
+ * @param {?Object} status - {@link getMountIntervalStatus} の戻り値。
+ * @returns {Array<Object>} 選択可能な open interval 表示モデル。
+ */
+function _openIntervalOptions(status) {
+  const intervals = Array.isArray(status?.intervals) ? status.intervals : [];
+  return intervals
+    .filter(interval => interval && interval.untilJobId == null && !interval.superseded)
+    .map(interval => ({
+      intervalId: String(interval.intervalId || ""),
+      sinceJobId: Number(interval.sinceJobId) || 0,
+      anchorRemainingMm: Number(interval.anchorRemainingMm) || 0,
+      anchorRemainingDisplay: _formatMm(interval.anchorRemainingMm),
+      boundaryStatus: interval.boundaryStatus || "unknown"
+    }))
+    .filter(interval => interval.intervalId)
+    .sort((a, b) => (a.sinceJobId - b.sinceJobId) || a.intervalId.localeCompare(b.intervalId));
+}
+
+/**
+ * ledger repair flag の現在状態を read-only に取得する。
+ *
+ * 【詳細説明】
+ * - 表示層で例外が出ても Candidate Center 全体を壊さないよう、失敗時は error status として返す。
+ * - repair 操作の最終判定は O6 Recovery Operations 側で再取得・再検証する。
+ *
+ * @private
+ * @function _ledgerRepairStatusView
+ * @param {string} host - host key。
+ * @param {Object} item - ledgerRepairRequired の対象 item。
+ * @returns {{status:Object,openIntervals:Array<Object>}} 表示用の現在状態。
+ */
+function _ledgerRepairStatusView(host, item) {
+  const spoolId = item?.spoolId != null ? String(item.spoolId) : "";
+  if (!spoolId) {
+    return {
+      status: { status: "unknown", diagnostics: [{ code: "spoolId-missing" }] },
+      openIntervals: []
+    };
+  }
+  try {
+    const status = getMountIntervalStatus(spoolId, host);
+    return {
+      status,
+      openIntervals: _openIntervalOptions(status)
+    };
+  } catch (error) {
+    return {
+      status: { status: "error", diagnostics: [{ code: "status-read-failed", detail: error?.message || String(error) }] },
+      openIntervals: []
+    };
+  }
 }
 
 /**
@@ -540,19 +603,25 @@ export function buildInferredRecoverySurfaceViewModel(options = {}) {
     : {};
   for (const [host, item] of Object.entries(repair)) {
     if (!item || typeof item !== "object") continue;
+    const repairStatus = _ledgerRepairStatusView(host, item);
     cards.push({
       type: "ledger-repair",
       severity: "blocker",
       title: "Mount ledger repair required",
       summary: `${_hostLabel(host)} の装着区間が曖昧なため、暗黙クローズを停止しています`,
       host,
+      spoolId: item.spoolId || null,
       candidateHash: null,
       createdAt: Number(item.detectedAtEpochMs) || 0,
       createdAtDisplay: _formatTime(item.detectedAtEpochMs),
+      repairStatus: repairStatus.status,
+      openIntervals: repairStatus.openIntervals,
       details: _details([
         { label: "Host", value: _hostLabel(host) },
         { label: "Spool", value: item.spoolId },
         { label: "Status", value: item.status },
+        { label: "Current status", value: repairStatus.status?.status },
+        { label: "Open intervals", value: repairStatus.openIntervals.length },
         { label: "Detected", value: _formatTime(item.detectedAtEpochMs) }
       ])
     });

--- a/3dp_lib/dashboard_inferred_recovery_ops.js
+++ b/3dp_lib/dashboard_inferred_recovery_ops.js
@@ -17,16 +17,16 @@
  * - {@link canExecuteRecoveryOperation}：この端末で O6 recovery 操作を実行できるか判定する
  * - {@link retryInferredRecoveryDurableSave}：現在の recovery / repair 状態を再度耐久保存する
  * - {@link clearInferredDecisionRecoveryRequired}：確認済みの O5 decision recovery flag を解除する
+ * - {@link repairLedgerMountIntervals}：曖昧な mount interval の survivor を明示選択して修復する
  * - {@link clearLedgerRepairRequired}：確認済みの host 単位 ledger repair flag を解除する
  * - {@link archiveMountHistoryRejectedEvents}：隔離済み mount event を監査 event に移して warning を閉じる
  *
- * @version 1.390.1272 (PR #422)
+ * @version 1.390.1273 (PR #423)
  * @since   1.390.1270 (PR #420)
- * @lastModified 2026-08-02 16:45:00
+ * @lastModified 2026-08-02 18:20:00
  * -----------------------------------------------------------
  * @todo
  * - O7 Ledger Reconciliation で、手動解除前の再計算監査と修復案提示を追加する。
- * - mount interval の survivor 明示選択は O6C 以降で実装する。
  */
 
 "use strict";
@@ -36,7 +36,7 @@ import {
   canExecuteLedgerDecision,
   enqueueLedgerDecisionTask
 } from "./dashboard_inferred_candidate_decision.js";
-import { getMountIntervalStatus } from "./dashboard_filament_ledger.js";
+import { appendSupersedeEvent, getMountIntervalStatus } from "./dashboard_filament_ledger.js";
 import { saveUnifiedStorageDurably } from "./dashboard_storage.js";
 import { wallNowMs } from "./dashboard_time.js";
 
@@ -62,6 +62,7 @@ const DECISION_RECOVERY_FIELD = "inferredDecisionRecoveryRequired";
 export const INFERRED_RECOVERY_EVENT_TYPE = Object.freeze({
   DURABLE_SAVE_RETRIED: "recovery-durable-save-retried",
   DECISION_RECOVERY_CLEARED: "decision-recovery-cleared",
+  LEDGER_INTERVALS_REPAIRED: "ledger-intervals-repaired",
   LEDGER_REPAIR_CLEARED: "ledger-repair-cleared",
   REJECTED_MOUNT_EVENTS_ARCHIVED: "mount-history-rejected-events-archived"
 });
@@ -182,15 +183,21 @@ function _hasRecoveryIssues() {
  *
  * @private
  * @function _snapshotRecoveryState
+ * @param {{includeMountHistory?:boolean}} [options] - mountHistory も rollback 対象に含める場合 true。
  * @returns {Object} rollback 用 snapshot。
  */
-function _snapshotRecoveryState() {
-  return {
+function _snapshotRecoveryState(options = {}) {
+  const snapshot = {
     inferredDecisionRecoveryRequired: _clone(monitorData[DECISION_RECOVERY_FIELD] || null),
     ledgerRepairRequired: _clone(_ledgerRepairRequired()),
     mountHistoryRejectedEvents: _clone(_rejectedMountEvents()),
     inferredRecoveryEvents: _clone(_events())
   };
+  if (options.includeMountHistory) {
+    snapshot.mountHistory = _clone(Array.isArray(monitorData.mountHistory) ? monitorData.mountHistory : []);
+    snapshot.mountHistorySeq = Number(monitorData.mountHistorySeq) || 0;
+  }
+  return snapshot;
 }
 
 /**
@@ -219,6 +226,12 @@ function _restoreRecoveryState(snapshot) {
 
   const events = _events();
   events.splice(0, events.length, ..._clone(snapshot.inferredRecoveryEvents || []));
+
+  if (Object.hasOwn(snapshot, "mountHistory")) {
+    if (!Array.isArray(monitorData.mountHistory)) monitorData.mountHistory = [];
+    monitorData.mountHistory.splice(0, monitorData.mountHistory.length, ..._clone(snapshot.mountHistory || []));
+    monitorData.mountHistorySeq = Number(snapshot.mountHistorySeq) || 0;
+  }
 }
 
 /**
@@ -334,6 +347,58 @@ function _validateLedgerRepairClearance(host, repairItem) {
       status: { error: error?.message || String(error) }
     };
   }
+}
+
+/**
+ * mount interval repair 操作用に現在の open 区間を取得する。
+ *
+ * 【詳細説明】
+ * - O6 の repair 操作は曖昧な mount interval だけを対象にする。
+ * - corrupt 状態は参照不整合を含むため、survivor 選択だけでは安全に直せない可能性がある。
+ * - そのためここでは `ambiguous` 以外を fail-closed にし、O7 の再計算監査へ委ねる。
+ *
+ * @private
+ * @function _validateLedgerIntervalRepair
+ * @param {string} host - host key。
+ * @param {Object} repairItem - ledgerRepairRequired の対象 item。
+ * @param {string} survivingIntervalId - 残す intervalId。
+ * @returns {{ok:boolean,reason:string,status?:Object,spoolId?:string,openIntervals?:Array<Object>,targetIntervalIds?:Array<string>}}
+ *   修復入力の検証結果。
+ */
+function _validateLedgerIntervalRepair(host, repairItem, survivingIntervalId) {
+  const spoolId = repairItem?.spoolId != null ? String(repairItem.spoolId) : "";
+  if (!spoolId) return { ok: false, reason: "ledger_repair_spool_required" };
+  const survivorId = String(survivingIntervalId || "");
+  if (!survivorId) return { ok: false, reason: "ledger_repair_survivor_required", spoolId };
+  let status;
+  try {
+    status = getMountIntervalStatus(spoolId, host);
+  } catch (error) {
+    return {
+      ok: false,
+      reason: "ledger_repair_validation_failed",
+      spoolId,
+      status: { error: error?.message || String(error) }
+    };
+  }
+  if (status?.status !== "ambiguous") {
+    return { ok: false, reason: "ledger_repair_not_ambiguous", spoolId, status };
+  }
+  const openIntervals = Array.isArray(status.intervals)
+    ? status.intervals.filter(interval => interval && interval.untilJobId == null && !interval.superseded)
+    : [];
+  const survivor = openIntervals.find(interval => String(interval.intervalId) === survivorId);
+  if (!survivor) {
+    return { ok: false, reason: "ledger_repair_survivor_not_open", spoolId, status, openIntervals };
+  }
+  const targetIntervalIds = openIntervals
+    .map(interval => String(interval.intervalId))
+    .filter(intervalId => intervalId && intervalId !== survivorId)
+    .sort();
+  if (targetIntervalIds.length === 0) {
+    return { ok: false, reason: "ledger_repair_not_ambiguous", spoolId, status, openIntervals };
+  }
+  return { ok: true, reason: "ledger_repair_repairable", spoolId, status, openIntervals, targetIntervalIds };
 }
 
 /**
@@ -458,6 +523,97 @@ export function clearLedgerRepairRequired(host, options = {}) {
     const saved = await _saveOrRollbackRecoveryMutation(snapshot, "ledger_repair_clear_not_durably_saved", options);
     if (!saved.ok) return saved;
     return { ok: true, reason: "ledger_repair_cleared", host: hostKey, event, save: saved.save };
+  });
+}
+
+/**
+ * 曖昧な mount interval を survivor 明示選択で修復する。
+ *
+ * 【詳細説明】
+ * - `ledgerRepairRequired[host]` が存在し、現在の mount interval 状態が `ambiguous` の場合だけ実行する。
+ * - 操作者が選んだ survivor 以外の open interval を `supersede` event で無効化し、投影後に
+ *   open interval が survivor 1件へ収束したことを再検証する。
+ * - 修復 event、ledger repair flag 解除、recovery audit event は同じ耐久保存境界で扱う。
+ * - 保存失敗時は `mountHistory` / `mountHistorySeq` / repair flag / audit event を操作前へ戻す。
+ *
+ * @function repairLedgerMountIntervals
+ * @param {string} host - 修復対象 host key。
+ * @param {string} survivingIntervalId - 残す mount interval ID。
+ * @param {{actor?:string,note?:string,nowMs?:number,save?:boolean}} [options] - 操作者・メモ・保存オプション。
+ * @returns {Promise<Object>} recovery 操作結果。
+ * @example
+ * const result = await repairLedgerMountIntervals("k1max.local", "mount_S1_100", { actor: "operator" });
+ */
+export function repairLedgerMountIntervals(host, survivingIntervalId, options = {}) {
+  return enqueueLedgerDecisionTask(async () => {
+    const guard = _operationGuard();
+    if (guard) return guard;
+    const hostKey = String(host || "");
+    if (!hostKey) return { ok: false, reason: "ledger_repair_host_required" };
+    const repair = _ledgerRepairRequired();
+    const current = repair[hostKey];
+    if (!current || typeof current !== "object") return { ok: false, reason: "ledger_repair_not_found", host: hostKey };
+    const validation = _validateLedgerIntervalRepair(hostKey, current, survivingIntervalId);
+    if (!validation.ok) return { ok: false, reason: validation.reason, host: hostKey, status: validation.status, openIntervals: validation.openIntervals };
+
+    const snapshot = _snapshotRecoveryState({ includeMountHistory: true });
+    const nowMs = _nowMs(options);
+    const supersedeEvent = appendSupersedeEvent({
+      host: hostKey,
+      spoolId: validation.spoolId,
+      targetIntervalIds: validation.targetIntervalIds,
+      survivingIntervalId: String(survivingIntervalId),
+      reason: "operator-selected-survivor",
+      ts: nowMs,
+      opId: `o6_repair_${hostKey}_${validation.spoolId}_${String(survivingIntervalId)}_${nowMs}`
+    });
+    if (!supersedeEvent) {
+      _restoreRecoveryState(snapshot);
+      return { ok: false, reason: "ledger_repair_supersede_failed", host: hostKey, status: validation.status };
+    }
+
+    let afterStatus;
+    try {
+      afterStatus = getMountIntervalStatus(validation.spoolId, hostKey);
+    } catch (error) {
+      _restoreRecoveryState(snapshot);
+      return {
+        ok: false,
+        reason: "ledger_repair_validation_failed",
+        host: hostKey,
+        status: { error: error?.message || String(error) }
+      };
+    }
+    if (afterStatus?.status !== "ok" || String(afterStatus?.openInterval?.intervalId || "") !== String(survivingIntervalId)) {
+      _restoreRecoveryState(snapshot);
+      return { ok: false, reason: "ledger_repair_post_status_invalid", host: hostKey, status: afterStatus };
+    }
+
+    delete repair[hostKey];
+    const event = _appendRecoveryEvent(INFERRED_RECOVERY_EVENT_TYPE.LEDGER_INTERVALS_REPAIRED, {
+      reason: "operator-repaired-ledger-intervals",
+      host: hostKey,
+      spoolId: validation.spoolId,
+      note: options.note || "",
+      repairedRepair: _clone(current),
+      beforeStatus: _clone(validation.status),
+      afterStatus: _clone(afterStatus),
+      survivingIntervalId: String(survivingIntervalId),
+      supersededIntervalIds: _clone(validation.targetIntervalIds),
+      supersedeEvent: _clone(supersedeEvent)
+    }, { ...options, nowMs });
+    const saved = await _saveOrRollbackRecoveryMutation(snapshot, "ledger_repair_repair_not_durably_saved", options);
+    if (!saved.ok) return saved;
+    return {
+      ok: true,
+      reason: "ledger_repair_intervals_repaired",
+      host: hostKey,
+      survivingIntervalId: String(survivingIntervalId),
+      supersededIntervalIds: validation.targetIntervalIds,
+      supersedeEvent,
+      event,
+      save: saved.save
+    };
   });
 }
 

--- a/docs/en/filament_manual.md
+++ b/docs/en/filament_manual.md
@@ -137,14 +137,21 @@ Recovery / repair status surface.
 | --- | --- |
 | **Retry save** | Attempts to durably save the current recovery / repair state again. |
 | **Clear recovery** | Clears `inferredDecisionRecoveryRequired` after the operator has verified the rolled-back state. |
+| **Repair intervals** | Repairs an ambiguous mount interval by explicitly selecting the survivor interval and superseding the other open intervals. |
 | **Clear repair** | Clears `ledgerRepairRequired` for the selected host after the mount ledger has been verified and the current state is no longer `ambiguous` or `corrupt`. |
 | **Archive rejected** | Moves quarantined mountHistory events into `inferredRecoveryEvents` audit history and closes the warning. |
 
+`Repair intervals` only runs when the current state is `ambiguous`, there
+are multiple open intervals, and the selected survivor is still open.
+`corrupt` states can include invalid references, so this operation leaves
+them for O7 reconciliation or manual investigation.
+
 Each recovery operation appends an `inferredRecoveryEvents` audit event
-and rolls memory state back if durable save fails. In Relay setups,
-Satellites mirror the diagnostic state from the Parent authority but keep
-the recovery operation buttons disabled. Run recovery operations on the
-Parent device.
+and rolls memory state back if durable save fails. For `Repair intervals`,
+`mountHistory` and `mountHistorySeq` are also part of the rollback
+snapshot. In Relay setups, Satellites mirror the diagnostic state from the
+Parent authority but keep the recovery operation buttons disabled. Run
+recovery operations on the Parent device.
 
 After recovery operations run, the same Recovery / repair status surface
 shows a **Recovery operation audit** card. It lists recent retry-save,

--- a/docs/ja/filament_manual.md
+++ b/docs/ja/filament_manual.md
@@ -100,10 +100,13 @@ Standalone / Parent では、Recovery / repair status から次の復旧操作�
 | --- | --- |
 | **Retry save** | 現在の recovery / repair 状態を再度耐久保存します |
 | **Clear recovery** | rollback 後の状態を確認済みの場合に `inferredDecisionRecoveryRequired` を解除します |
+| **Repair intervals** | `ledgerRepairRequired` が示す曖昧な mount interval について、残す survivor 区間を明示選択し、それ以外の open 区間を supersede して修復します |
 | **Clear repair** | 対象 host の mount ledger を確認済みで、現在状態が `ambiguous` / `corrupt` ではない場合に `ledgerRepairRequired` を解除します |
 | **Archive rejected** | 隔離済み mountHistory event を `inferredRecoveryEvents` へ監査退避し、warning を閉じます |
 
-これらの復旧操作は `inferredRecoveryEvents` に監査 event を残し、保存失敗時は操作前の状態へ戻します。Relay 構成では Satellite も Parent 権威の診断状態をミラー表示しますが、復旧操作は無効化されます。復旧操作は Parent 端末で実行してください。
+`Repair intervals` は現在状態が `ambiguous` で、open interval が複数あり、選択した survivor が現在も open の場合だけ実行できます。`corrupt` 状態は参照不整合を含むため、この操作では自動修復せず、O7 の再計算監査または手動調査の対象にします。
+
+これらの復旧操作は `inferredRecoveryEvents` に監査 event を残し、保存失敗時は操作前の状態へ戻します。`Repair intervals` では `mountHistory` と `mountHistorySeq` も rollback 対象です。Relay 構成では Satellite も Parent 権威の診断状態をミラー表示しますが、復旧操作は無効化されます。復旧操作は Parent 端末で実行してください。
 
 復旧操作後は、同じ Recovery / repair status に **Recovery operation audit** が表示されます。ここには最新の再保存、recovery flag 解除、ledger repair flag 解除、隔離 event 退避の履歴が残り、対象 candidate、host、件数、操作者、実行時刻を確認できます。未解決 blocker が無い場合でも、直近の復旧操作履歴は INFO として表示されます。
 

--- a/tests/unit/dashboard_inferred_candidate_ui.test.js
+++ b/tests/unit/dashboard_inferred_candidate_ui.test.js
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   retryInferredRecoveryDurableSave: vi.fn(async () => ({ ok: true, reason: "recovery_durable_save_retried" })),
   clearInferredDecisionRecoveryRequired: vi.fn(async () => ({ ok: true, reason: "decision_recovery_cleared" })),
   clearLedgerRepairRequired: vi.fn(async () => ({ ok: true, reason: "ledger_repair_cleared" })),
+  repairLedgerMountIntervals: vi.fn(async () => ({ ok: true, reason: "ledger_repair_intervals_repaired" })),
   archiveMountHistoryRejectedEvents: vi.fn(async () => ({ ok: true, reason: "mount_history_rejected_events_archived" })),
   showConfirmDialog: vi.fn(async () => true),
   showAlert: vi.fn(),
@@ -37,6 +38,7 @@ vi.mock("../../3dp_lib/dashboard_inferred_recovery_ops.js", () => ({
   retryInferredRecoveryDurableSave: mocks.retryInferredRecoveryDurableSave,
   clearInferredDecisionRecoveryRequired: mocks.clearInferredDecisionRecoveryRequired,
   clearLedgerRepairRequired: mocks.clearLedgerRepairRequired,
+  repairLedgerMountIntervals: mocks.repairLedgerMountIntervals,
   archiveMountHistoryRejectedEvents: mocks.archiveMountHistoryRejectedEvents
 }));
 vi.mock("../../3dp_lib/dashboard_inferred_candidate_view.js", () => ({
@@ -155,6 +157,8 @@ beforeEach(() => {
   mocks.clearInferredDecisionRecoveryRequired.mockResolvedValue({ ok: true, reason: "decision_recovery_cleared" });
   mocks.clearLedgerRepairRequired.mockClear();
   mocks.clearLedgerRepairRequired.mockResolvedValue({ ok: true, reason: "ledger_repair_cleared" });
+  mocks.repairLedgerMountIntervals.mockClear();
+  mocks.repairLedgerMountIntervals.mockResolvedValue({ ok: true, reason: "ledger_repair_intervals_repaired" });
   mocks.archiveMountHistoryRejectedEvents.mockClear();
   mocks.archiveMountHistoryRejectedEvents.mockResolvedValue({ ok: true, reason: "mount_history_rejected_events_archived" });
   mocks.showConfirmDialog.mockClear();
@@ -278,8 +282,52 @@ describe("createInferredCandidateCenterContent", () => {
 
     const clear = [...document.querySelectorAll(".ic-recovery-actions button")]
       .find(button => button.textContent === "Clear repair");
+    const repair = [...document.querySelectorAll(".ic-recovery-actions button")]
+      .find(button => button.textContent === "Repair intervals");
     expect(clear.disabled).toBe(true);
+    expect(repair.disabled).toBe(true);
     expect(document.querySelector(".ic-readonly-note").textContent).toContain("親端末");
+  });
+
+  it("#423/O6C: Repair intervals は survivor を選択して O6 repair 操作を呼ぶ", async () => {
+    mocks.recoveryVm = {
+      hasIssues: true,
+      totalCount: 1,
+      blockerCount: 1,
+      warningCount: 0,
+      infoCount: 0,
+      cards: [{
+        type: "ledger-repair",
+        severity: "blocker",
+        title: "Mount ledger repair required",
+        summary: "修復が必要です",
+        host: "k1",
+        repairStatus: { status: "ambiguous" },
+        openIntervals: [
+          { intervalId: "iv-a", sinceJobId: 1, anchorRemainingDisplay: "10,000 mm", boundaryStatus: "known" },
+          { intervalId: "iv-b", sinceJobId: 2, anchorRemainingDisplay: "9,000 mm", boundaryStatus: "unknown" }
+        ],
+        details: [{ label: "Open intervals", value: "2" }]
+      }]
+    };
+    mocks.showConfirmDialog.mockImplementationOnce(async ({ html }) => {
+      const wrap = document.createElement("div");
+      wrap.innerHTML = html;
+      document.body.appendChild(wrap.firstElementChild);
+      document.querySelector("select[name='survivingIntervalId']").value = "iv-b";
+      return true;
+    });
+
+    const center = createInferredCandidateCenterContent();
+    document.body.appendChild(center.el);
+    [...document.querySelectorAll(".ic-recovery-actions button")]
+      .find(button => button.textContent === "Repair intervals")
+      .click();
+
+    await waitForAssertion(() => {
+      expect(mocks.repairLedgerMountIntervals).toHaveBeenCalledWith("k1", "iv-b", { actor: "local-user" });
+      expect(mocks.showAlert).toHaveBeenCalledWith("台帳装着区間を修復しました", "success");
+    });
   });
 
   it("candidate 一覧から詳細を開き、Confirm は Decision Core を呼ぶ", async () => {

--- a/tests/unit/dashboard_inferred_candidate_view.test.js
+++ b/tests/unit/dashboard_inferred_candidate_view.test.js
@@ -10,10 +10,14 @@ const mocks = vi.hoisted(() => ({
     filamentSpools: [],
     inferredCandidateStore: {}
   },
-  canSubmit: true
+  canSubmit: true,
+  getMountIntervalStatus: vi.fn(() => ({ status: "none", openInterval: null, intervals: [], diagnostics: [] }))
 }));
 
 vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mocks.monitorData }));
+vi.mock("../../3dp_lib/dashboard_filament_ledger.js", () => ({
+  getMountIntervalStatus: mocks.getMountIntervalStatus
+}));
 vi.mock("../../3dp_lib/dashboard_inferred_candidate_decision.js", () => ({
   canSubmitLedgerDecision: () => mocks.canSubmit
 }));
@@ -85,6 +89,8 @@ beforeEach(() => {
   mocks.monitorData.inferredRecoveryEvents = [];
   mocks.monitorData.ledgerRepairRequired = {};
   mocks.monitorData.mountHistoryRejectedEvents = [];
+  mocks.getMountIntervalStatus.mockReset();
+  mocks.getMountIntervalStatus.mockReturnValue({ status: "none", openInterval: null, intervals: [], diagnostics: [] });
 });
 
 describe("buildInferredCandidateViewModel", () => {
@@ -178,6 +184,15 @@ describe("buildInferredRecoverySurfaceViewModel", () => {
     mocks.monitorData.ledgerRepairRequired = {
       k1: { spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 5000 }
     };
+    mocks.getMountIntervalStatus.mockReturnValueOnce({
+      status: "ambiguous",
+      openInterval: null,
+      intervals: [
+        { intervalId: "iv-a", untilJobId: null, sinceJobId: 1, anchorRemainingMm: 10000, boundaryStatus: "known" },
+        { intervalId: "iv-b", untilJobId: null, sinceJobId: 2, anchorRemainingMm: 9000, boundaryStatus: "unknown" }
+      ],
+      diagnostics: []
+    });
     mocks.monitorData.mountHistoryRejectedEvents = [
       { reason: "reanchor-invalid-reference", event: { evId: "ev-a", host: "k1", spoolId: "S1" } },
       { reason: "supersede-invalid-survivor", event: { evId: "ev-b", host: "k2", spoolId: "S2" } }
@@ -197,6 +212,9 @@ describe("buildInferredRecoverySurfaceViewModel", () => {
     ]);
     expect(vm.cards[0].details).toContainEqual({ label: "Candidate", value: "ic-new" });
     expect(vm.cards[1].summary).toContain("K1 Max");
+    expect(vm.cards[1].repairStatus.status).toBe("ambiguous");
+    expect(vm.cards[1].openIntervals.map(interval => interval.intervalId)).toEqual(["iv-a", "iv-b"]);
+    expect(vm.cards[1].details).toContainEqual({ label: "Open intervals", value: "2" });
     expect(vm.cards[2].details).toHaveLength(1);
     expect(vm.cards[2].details[0].value).toContain("ev-b");
   });

--- a/tests/unit/dashboard_inferred_recovery_ops.test.js
+++ b/tests/unit/dashboard_inferred_recovery_ops.test.js
@@ -9,11 +9,23 @@ const mocks = vi.hoisted(() => ({
     inferredDecisionRecoveryRequired: null,
     inferredRecoveryEvents: [],
     ledgerRepairRequired: {},
-    mountHistoryRejectedEvents: []
+    mountHistoryRejectedEvents: [],
+    mountHistory: [],
+    mountHistorySeq: 0
   },
   saveUnifiedStorageDurably: vi.fn(async () => ({ ok: true, backend: "test", reason: "saved" })),
   canExecuteLedgerDecision: vi.fn(() => true),
   getMountIntervalStatus: vi.fn(() => ({ status: "none", openInterval: null, intervals: [], diagnostics: [] })),
+  appendSupersedeEvent: vi.fn(() => ({
+    evId: "ev-super",
+    opId: "op-super",
+    seq: 3,
+    type: "supersede",
+    host: "k1",
+    spoolId: "S1",
+    targetIntervalIds: ["iv-a"],
+    survivingIntervalId: "iv-b"
+  })),
   queue: Promise.resolve()
 }));
 
@@ -21,6 +33,7 @@ vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mocks.monitorDa
 vi.mock("../../3dp_lib/dashboard_storage.js", () => ({ saveUnifiedStorageDurably: mocks.saveUnifiedStorageDurably }));
 vi.mock("../../3dp_lib/dashboard_time.js", () => ({ wallNowMs: () => 123456 }));
 vi.mock("../../3dp_lib/dashboard_filament_ledger.js", () => ({
+  appendSupersedeEvent: mocks.appendSupersedeEvent,
   getMountIntervalStatus: mocks.getMountIntervalStatus
 }));
 vi.mock("../../3dp_lib/dashboard_inferred_candidate_decision.js", () => ({
@@ -37,6 +50,7 @@ const {
   canExecuteRecoveryOperation,
   clearInferredDecisionRecoveryRequired,
   clearLedgerRepairRequired,
+  repairLedgerMountIntervals,
   retryInferredRecoveryDurableSave
 } = await import("../../3dp_lib/dashboard_inferred_recovery_ops.js");
 
@@ -51,6 +65,8 @@ function resetRecoveryState() {
   mocks.monitorData.inferredRecoveryEvents = [];
   mocks.monitorData.ledgerRepairRequired = {};
   mocks.monitorData.mountHistoryRejectedEvents = [];
+  mocks.monitorData.mountHistory = [];
+  mocks.monitorData.mountHistorySeq = 0;
 }
 
 beforeEach(() => {
@@ -62,6 +78,23 @@ beforeEach(() => {
   mocks.saveUnifiedStorageDurably.mockResolvedValue({ ok: true, backend: "test", reason: "saved" });
   mocks.getMountIntervalStatus.mockReset();
   mocks.getMountIntervalStatus.mockReturnValue({ status: "none", openInterval: null, intervals: [], diagnostics: [] });
+  mocks.appendSupersedeEvent.mockReset();
+  mocks.appendSupersedeEvent.mockImplementation(({ host, spoolId, targetIntervalIds, survivingIntervalId, ts, opId }) => {
+    const event = {
+      evId: "ev-super",
+      opId,
+      seq: 3,
+      ts,
+      type: "supersede",
+      host,
+      spoolId,
+      targetIntervalIds,
+      survivingIntervalId
+    };
+    mocks.monitorData.mountHistory.push(event);
+    mocks.monitorData.mountHistorySeq = 3;
+    return event;
+  });
 });
 
 describe("canExecuteRecoveryOperation", () => {
@@ -209,6 +242,133 @@ describe("clearLedgerRepairRequired", () => {
     expect(result).toMatchObject({ ok: false, reason: "ledger_repair_clear_not_durably_saved" });
     expect(mocks.monitorData.ledgerRepairRequired).toEqual(repair);
     expect(mocks.monitorData.inferredRecoveryEvents).toHaveLength(0);
+  });
+});
+
+describe("repairLedgerMountIntervals", () => {
+  it("ambiguous な ledger repair を survivor 選択で supersede 修復し flag を解除する", async () => {
+    mocks.monitorData.ledgerRepairRequired = {
+      k1: { spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 100 }
+    };
+    mocks.getMountIntervalStatus
+      .mockReturnValueOnce({
+        status: "ambiguous",
+        openInterval: null,
+        intervals: [
+          { intervalId: "iv-a", host: "k1", untilJobId: null, sinceJobId: 1, anchorRemainingMm: 10000, boundaryStatus: "known" },
+          { intervalId: "iv-b", host: "k1", untilJobId: null, sinceJobId: 2, anchorRemainingMm: 9000, boundaryStatus: "known" }
+        ],
+        diagnostics: []
+      })
+      .mockReturnValueOnce({
+        status: "ok",
+        openInterval: { intervalId: "iv-b", host: "k1", untilJobId: null },
+        intervals: [{ intervalId: "iv-b", host: "k1", untilJobId: null }],
+        diagnostics: []
+      });
+
+    const result = await repairLedgerMountIntervals("k1", "iv-b", { actor: "operator", nowMs: 700 });
+
+    expect(result).toMatchObject({
+      ok: true,
+      reason: "ledger_repair_intervals_repaired",
+      host: "k1",
+      survivingIntervalId: "iv-b",
+      supersededIntervalIds: ["iv-a"]
+    });
+    expect(mocks.appendSupersedeEvent).toHaveBeenCalledWith({
+      host: "k1",
+      spoolId: "S1",
+      targetIntervalIds: ["iv-a"],
+      survivingIntervalId: "iv-b",
+      reason: "operator-selected-survivor",
+      ts: 700,
+      opId: "o6_repair_k1_S1_iv-b_700"
+    });
+    expect(mocks.monitorData.ledgerRepairRequired).toEqual({});
+    expect(mocks.monitorData.inferredRecoveryEvents[0]).toMatchObject({
+      type: "ledger-intervals-repaired",
+      host: "k1",
+      spoolId: "S1",
+      survivingIntervalId: "iv-b",
+      supersededIntervalIds: ["iv-a"]
+    });
+    expect(mocks.saveUnifiedStorageDurably).toHaveBeenCalledTimes(1);
+  });
+
+  it("ambiguous ではない ledger repair は修復しない", async () => {
+    mocks.monitorData.ledgerRepairRequired = {
+      k1: { spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 100 }
+    };
+    mocks.getMountIntervalStatus.mockReturnValueOnce({
+      status: "corrupt",
+      openInterval: null,
+      intervals: [],
+      diagnostics: [{ code: "supersede-invalid-reference" }]
+    });
+
+    const result = await repairLedgerMountIntervals("k1", "iv-b");
+
+    expect(result).toMatchObject({ ok: false, reason: "ledger_repair_not_ambiguous", host: "k1" });
+    expect(mocks.appendSupersedeEvent).not.toHaveBeenCalled();
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+
+  it("選択 survivor が open 区間ではない場合は fail-closed する", async () => {
+    mocks.monitorData.ledgerRepairRequired = {
+      k1: { spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 100 }
+    };
+    mocks.getMountIntervalStatus.mockReturnValueOnce({
+      status: "ambiguous",
+      openInterval: null,
+      intervals: [
+        { intervalId: "iv-a", host: "k1", untilJobId: null, sinceJobId: 1, anchorRemainingMm: 10000, boundaryStatus: "known" },
+        { intervalId: "iv-b", host: "k1", untilJobId: null, sinceJobId: 2, anchorRemainingMm: 9000, boundaryStatus: "known" }
+      ],
+      diagnostics: []
+    });
+
+    const result = await repairLedgerMountIntervals("k1", "iv-c");
+
+    expect(result).toMatchObject({ ok: false, reason: "ledger_repair_survivor_not_open", host: "k1" });
+    expect(mocks.appendSupersedeEvent).not.toHaveBeenCalled();
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+
+  it("保存失敗時は supersede event と repair flag を rollback する", async () => {
+    const repair = { k1: { spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 100 } };
+    const mountHistory = [{ evId: "mount-a", intervalId: "iv-a", type: "mount", host: "k1", spoolId: "S1" }];
+    mocks.monitorData.ledgerRepairRequired = { k1: { ...repair.k1 } };
+    mocks.monitorData.mountHistory = mountHistory.map(item => ({ ...item }));
+    mocks.monitorData.mountHistorySeq = 1;
+    mocks.getMountIntervalStatus
+      .mockReturnValueOnce({
+        status: "ambiguous",
+        openInterval: null,
+        intervals: [
+          { intervalId: "iv-a", host: "k1", untilJobId: null, sinceJobId: 1, anchorRemainingMm: 10000, boundaryStatus: "known" },
+          { intervalId: "iv-b", host: "k1", untilJobId: null, sinceJobId: 2, anchorRemainingMm: 9000, boundaryStatus: "known" }
+        ],
+        diagnostics: []
+      })
+      .mockReturnValueOnce({
+        status: "ok",
+        openInterval: { intervalId: "iv-b", host: "k1", untilJobId: null },
+        intervals: [{ intervalId: "iv-b", host: "k1", untilJobId: null }],
+        diagnostics: []
+      });
+    mocks.saveUnifiedStorageDurably
+      .mockResolvedValueOnce({ ok: false, backend: "indexedDB", reason: "idb_flush_failed" })
+      .mockResolvedValueOnce({ ok: true, backend: "indexedDB", reason: "flushed" });
+
+    const result = await repairLedgerMountIntervals("k1", "iv-b", { nowMs: 800 });
+
+    expect(result).toMatchObject({ ok: false, reason: "ledger_repair_repair_not_durably_saved" });
+    expect(mocks.monitorData.ledgerRepairRequired).toEqual(repair);
+    expect(mocks.monitorData.mountHistory).toEqual(mountHistory);
+    expect(mocks.monitorData.mountHistorySeq).toBe(1);
+    expect(mocks.monitorData.inferredRecoveryEvents).toHaveLength(0);
+    expect(mocks.saveUnifiedStorageDurably).toHaveBeenCalledTimes(2);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add an O6 recovery operation to repair ambiguous mount intervals by explicitly selecting the survivor interval.
- Surface current mount interval status and open interval choices in Candidate Center recovery cards.
- Keep Satellite recovery operations read-only and persist repair audit events with rollback coverage for mountHistory and mountHistorySeq.

## Validation
- npx vitest run tests/unit/dashboard_inferred_recovery_ops.test.js tests/unit/dashboard_inferred_candidate_view.test.js tests/unit/dashboard_inferred_candidate_ui.test.js --silent
- npx eslint 3dp_lib/dashboard_inferred_recovery_ops.js 3dp_lib/dashboard_inferred_candidate_view.js 3dp_lib/dashboard_inferred_candidate_ui.js --quiet
- npx vitest run --silent