### PR TITLE
Block unsafe O6 recovery follow-ups

### DIFF
--- a/3dp_lib/dashboard_client_sync.js
+++ b/3dp_lib/dashboard_client_sync.js
@@ -22,9 +22,9 @@
  * - {@link sendRelayCommand}：親経由でプリンタにコマンド送信
  * - {@link sendRelayFilament}：親経由でフィラメント操作
  *
- * @version 1.390.1270 (PR #420)
+ * @version 1.390.1274 (PR #424)
  * @since   1.390.820 (PR #367)
- * @lastModified 2026-08-02 15:05:22
+ * @lastModified 2026-08-02 18:33:44
  * -----------------------------------------------------------
  */
 
@@ -314,7 +314,7 @@ function _applyRelayPrintStore(hostname, ps) {
  * ※ モジュール内部用だが、マージ規則の回帰テストのために export している。
  *
  * @function _applySharedFilamentState
- * @param {{filamentSpools?:Array<Object>, hostSpoolMap?:Object, mountHistory?:Array<Object>, pendingUnattributedUsage?:Array<Object>, inferredCandidateStore?:Object, inferredDecisionRecoveryRequired?:Object|null, inferredRecoveryEvents?:Array<Object>, ledgerRepairRequired?:Object, mountHistoryRejectedEvents?:Array<Object>}} shared
+ * @param {{filamentSpools?:Array<Object>, hostSpoolMap?:Object, mountHistory?:Array<Object>, pendingUnattributedUsage?:Array<Object>, inferredCandidateStore?:Object, inferredDecisionRecoveryRequired?:Object|null, inferredRecoveryOperationRecoveryRequired?:Object|null, inferredRecoveryEvents?:Array<Object>, ledgerRepairRequired?:Object, mountHistoryRejectedEvents?:Array<Object>}} shared
  *   - 受信した共有データ
  * @returns {void}
  */
@@ -374,6 +374,12 @@ export function _applySharedFilamentState(shared) {
     monitorData.inferredDecisionRecoveryRequired =
       shared.inferredDecisionRecoveryRequired && typeof shared.inferredDecisionRecoveryRequired === "object"
         ? { ...shared.inferredDecisionRecoveryRequired }
+        : null;
+  }
+  if (Object.prototype.hasOwnProperty.call(shared, "inferredRecoveryOperationRecoveryRequired")) {
+    monitorData.inferredRecoveryOperationRecoveryRequired =
+      shared.inferredRecoveryOperationRecoveryRequired && typeof shared.inferredRecoveryOperationRecoveryRequired === "object"
+        ? { ...shared.inferredRecoveryOperationRecoveryRequired }
         : null;
   }
   if (Object.prototype.hasOwnProperty.call(shared, "inferredRecoveryEvents")) {
@@ -438,6 +444,7 @@ function _maybeNotifyFilamentDomainChanged() {
     monitorData.spoolSerialCounter ?? 0,
     (monitorData.usageHistory || []).length,
     JSON.stringify(monitorData.inferredDecisionRecoveryRequired || null),
+    JSON.stringify(monitorData.inferredRecoveryOperationRecoveryRequired || null),
     JSON.stringify(monitorData.inferredRecoveryEvents || []),
     JSON.stringify(monitorData.ledgerRepairRequired || {}),
     JSON.stringify(monitorData.mountHistoryRejectedEvents || []),

--- a/3dp_lib/dashboard_data.js
+++ b/3dp_lib/dashboard_data.js
@@ -19,9 +19,9 @@
  * - {@link getDisplayValue}：表示用値取得
  * - {@link markAllKeysDirty}：全キーを変更済みにマーク
  *
-* @version 1.390.1270 (PR #420)
+* @version 1.390.1274 (PR #424)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-08-02 15:05:22
+* @lastModified 2026-08-02 18:33:44
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -308,6 +308,13 @@ export const monitorData = {
    */
   inferredDecisionRecoveryRequired: null,
   /**
+   * ★ #424/O6D: O6 recovery operation 自体の rollback 状態を耐久保存できなかった場合の復旧要求。
+   * null なら通常状態。object の場合は O5 decision と通常 O6 operation を fail-closed で停止し、
+   * recovery 状態の再保存または operator 確認後の解除だけを許可する。
+   * @type {?Object}
+   */
+  inferredRecoveryOperationRecoveryRequired: null,
+  /**
    * ★ #420/O6A: recovery / repair 操作の監査 event。
    * decision recovery flag 解除、ledger repair flag 解除、隔離 mount event の archive などを追記し、
    * 復旧操作が通常の candidate decision と同様に追跡できるようにする。
@@ -554,4 +561,3 @@ export function markAllKeysDirty(hostname) {
     dirtySet.add(key);
   }
 }
-

--- a/3dp_lib/dashboard_inferred_candidate_decision.js
+++ b/3dp_lib/dashboard_inferred_candidate_decision.js
@@ -27,9 +27,9 @@
  * - {@link reassignInferredCandidate}：別 spool へ再割当てして推定使用量を確定する
  * - {@link undoInferredCandidateDecision}：確定済み candidate の台帳反映を取り消す
  *
- * @version 1.390.1270 (PR #420)
+ * @version 1.390.1274 (PR #424)
  * @since   1.390.1261 (PR #414)
- * @lastModified 2026-08-02 00:00:00
+ * @lastModified 2026-08-02 18:33:44
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -57,6 +57,13 @@ import { wallNowMs } from "./dashboard_time.js";
  * @constant {string}
  */
 const RECOVERY_FIELD = "inferredDecisionRecoveryRequired";
+
+/**
+ * O6 recovery operation 復旧要求を保存する monitorData field 名。
+ *
+ * @constant {string}
+ */
+const RECOVERY_OPERATION_FIELD = "inferredRecoveryOperationRecoveryRequired";
 
 /**
  * Reject の理由として受け付ける短い識別子。
@@ -291,6 +298,28 @@ function _markRecoveryRequired(data, options = {}) {
 }
 
 /**
+ * 未解決の recovery blocker を取得する。
+ *
+ * 【詳細説明】
+ * - O5 decision rollback が耐久保存できなかった場合と、O6 recovery operation rollback が
+ *   耐久保存できなかった場合のどちらも、確定台帳に対する後続操作を止める。
+ * - null 以外を返した場合、呼び出し側は先に Recovery / repair status で状態確認と再保存を行う。
+ *
+ * @private
+ * @function _activeRecoveryBlocker
+ * @returns {?Object} 未解決 recovery blocker。無い場合は null。
+ */
+function _activeRecoveryBlocker() {
+  if (monitorData[RECOVERY_FIELD]) {
+    return { type: RECOVERY_FIELD, recovery: monitorData[RECOVERY_FIELD] };
+  }
+  if (monitorData[RECOVERY_OPERATION_FIELD]) {
+    return { type: RECOVERY_OPERATION_FIELD, recovery: monitorData[RECOVERY_OPERATION_FIELD] };
+  }
+  return null;
+}
+
+/**
  * decision 実行前の共通ガードを適用する。
  *
  * 【詳細説明】
@@ -304,7 +333,16 @@ function _markRecoveryRequired(data, options = {}) {
  */
 function _decisionGuard(candidateHash) {
   if (!canExecuteLedgerDecision()) return { ok: false, reason: "decision_not_authorized", candidateHash };
-  if (monitorData[RECOVERY_FIELD]) return { ok: false, reason: "decision_recovery_required", candidateHash, recovery: monitorData[RECOVERY_FIELD] };
+  const blocker = _activeRecoveryBlocker();
+  if (blocker) {
+    return {
+      ok: false,
+      reason: blocker.type === RECOVERY_FIELD ? "decision_recovery_required" : "recovery_required",
+      candidateHash,
+      recovery: blocker.recovery,
+      recoveryField: blocker.type
+    };
+  }
   return null;
 }
 
@@ -451,6 +489,7 @@ export function canExecuteLedgerDecision() {
  * if (canSubmitLedgerDecision()) enableDecisionButtons();
  */
 export function canSubmitLedgerDecision() {
+  if (_activeRecoveryBlocker()) return false;
   return canExecuteLedgerDecision() || _canRequestLedgerDecision();
 }
 

--- a/3dp_lib/dashboard_inferred_candidate_ui.js
+++ b/3dp_lib/dashboard_inferred_candidate_ui.js
@@ -16,9 +16,9 @@
  * 【公開関数一覧】
  * - {@link createInferredCandidateCenterContent}：フィラメント管理モーダル用 Candidate Center を生成する
  *
- * @version 1.390.1273 (PR #423)
+ * @version 1.390.1274 (PR #424)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-08-02 18:20:00
+ * @lastModified 2026-08-02 18:33:44
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -45,6 +45,7 @@ import {
   archiveMountHistoryRejectedEvents,
   canExecuteRecoveryOperation,
   clearInferredDecisionRecoveryRequired,
+  clearInferredRecoveryOperationRecoveryRequired,
   clearLedgerRepairRequired,
   repairLedgerMountIntervals,
   retryInferredRecoveryDurableSave
@@ -104,12 +105,15 @@ const REASON_LABELS = Object.freeze({
   candidate_ledger_event_total_mismatch: "台帳イベントと候補の消費量が一致しません",
   invalid_reject_reason: "否認理由が不正です",
   rollback_durable_save_failed: "復旧状態の保存に失敗しました",
+  recovery_required: "復旧状態の確認が必要です",
   recovery_not_authorized: "この端末では復旧操作を実行できません。親端末で実行してください",
   recovery_not_required: "復旧対象はありません",
   decision_recovery_not_found: "整合性確認フラグは見つかりません",
+  recovery_operation_recovery_not_found: "復旧操作の整合性確認フラグは見つかりません",
   recovery_retry_not_durably_saved: "復旧状態の再保存に失敗しました",
   recovery_operation_rollback_save_failed: "復旧操作のrollback状態を保存できませんでした",
   decision_recovery_clear_not_durably_saved: "整合性確認フラグの解除を保存できませんでした",
+  recovery_operation_recovery_clear_not_durably_saved: "復旧操作の整合性確認フラグを保存できませんでした",
   ledger_repair_host_required: "修復対象ホストが不正です",
   ledger_repair_spool_required: "台帳修復対象スプールが不明です",
   ledger_repair_not_found: "台帳修復フラグは見つかりません",
@@ -304,7 +308,8 @@ function _handleRecoveryResult(result, render, onAfterDecision) {
   if (result?.ok) {
     const label = result.reason === "recovery_durable_save_retried" ? "復旧状態を再保存しました"
       : result.reason === "decision_recovery_cleared" ? "整合性確認フラグを解除しました"
-        : result.reason === "ledger_repair_cleared" ? "台帳修復フラグを解除しました"
+        : result.reason === "recovery_operation_recovery_cleared" ? "復旧操作の整合性確認フラグを解除しました"
+          : result.reason === "ledger_repair_cleared" ? "台帳修復フラグを解除しました"
             : result.reason === "mount_history_rejected_events_archived" ? "隔離イベントを監査へ退避しました"
               : result.reason === "ledger_repair_intervals_repaired" ? "台帳装着区間を修復しました"
                 : "復旧操作を実行しました";
@@ -421,6 +426,30 @@ function _appendRecoveryActions(el, card, render, onAfterDecision) {
         );
         if (!ok) return;
         const result = await clearInferredDecisionRecoveryRequired({ actor: _actor() });
+        _handleRecoveryResult(result, render, onAfterDecision);
+      });
+    });
+    actions.append(retryBtn, clearBtn);
+  } else if (card.type === "recovery-operation-recovery") {
+    const retryBtn = _el("button", "ic-action-secondary", "Retry save");
+    retryBtn.disabled = !canExecute;
+    retryBtn.addEventListener("click", async () => {
+      await _withBusy(el, async () => {
+        const result = await retryInferredRecoveryDurableSave({ actor: _actor() });
+        _handleRecoveryResult(result, render, onAfterDecision);
+      });
+    });
+    const clearBtn = _el("button", "ic-action-secondary", "Clear operation recovery");
+    clearBtn.disabled = !canExecute;
+    clearBtn.addEventListener("click", async () => {
+      await _withBusy(el, async () => {
+        const ok = await _confirmRecoveryAction(
+          "復旧操作の整合性確認フラグを解除",
+          "rollback後の復旧状態、保存状態、relay同期状態を確認済みの場合だけ解除してください。",
+          "解除する"
+        );
+        if (!ok) return;
+        const result = await clearInferredRecoveryOperationRecoveryRequired({ actor: _actor() });
         _handleRecoveryResult(result, render, onAfterDecision);
       });
     });

--- a/3dp_lib/dashboard_inferred_candidate_view.js
+++ b/3dp_lib/dashboard_inferred_candidate_view.js
@@ -19,9 +19,9 @@
  * - {@link countPendingInferredCandidates}：pending candidate 件数を返す
  * - {@link buildInferredRecoverySurfaceViewModel}：recovery / repair 状態を診断表示モデルへ変換する
  *
- * @version 1.390.1273 (PR #423)
+ * @version 1.390.1274 (PR #424)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-08-02 18:20:00
+ * @lastModified 2026-08-02 18:33:44
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -241,6 +241,7 @@ function _details(entries) {
  */
 function _recoveryEventTarget(event) {
   if (event?.clearedRecovery?.candidateHash) return String(event.clearedRecovery.candidateHash);
+  if (event?.clearedRecovery?.operation) return String(event.clearedRecovery.operation);
   if (event?.decisionRecovery?.candidateHash) return String(event.decisionRecovery.candidateHash);
   if (event?.host) return String(event.host);
   if (Number.isFinite(Number(event?.rejectedEventCount))) return `${Number(event.rejectedEventCount)} rejected events`;
@@ -459,8 +460,10 @@ export function buildInferredCandidateViewModel(record, options = {}) {
     warnings.add("remaining-insufficient");
   }
   if (confidenceLevel === "low") warnings.add("low-confidence");
-  if (monitorData.inferredDecisionRecoveryRequired) warnings.add("decision-recovery-required");
-  const canSubmit = options.canSubmit ?? canSubmitLedgerDecision();
+  const hasRecoveryBlocker = !!monitorData.inferredDecisionRecoveryRequired
+    || !!monitorData.inferredRecoveryOperationRecoveryRequired;
+  if (hasRecoveryBlocker) warnings.add("decision-recovery-required");
+  const canSubmit = !hasRecoveryBlocker && (options.canSubmit ?? canSubmitLedgerDecision());
   if (!canSubmit) warnings.add("relay-readonly");
   const isPending = status === INFERRED_CANDIDATE_STATUS.PENDING;
   const isUndoable = status === INFERRED_CANDIDATE_STATUS.CONFIRMED
@@ -501,7 +504,7 @@ export function buildInferredCandidateViewModel(record, options = {}) {
     canReject: canSubmit && isPending,
     canReassign: canSubmit && isPending,
     canUndo: canSubmit && isUndoable,
-    readOnlyReason: canSubmit ? null : "relay-readonly",
+    readOnlyReason: canSubmit ? null : (hasRecoveryBlocker ? "recovery-required" : "relay-readonly"),
     warningCodes: [...warnings].sort()
   };
 }
@@ -594,6 +597,28 @@ export function buildInferredRecoverySurfaceViewModel(options = {}) {
         { label: "Candidate", value: recovery.candidateHash },
         { label: "Save", value: recovery.save?.reason },
         { label: "Rollback save", value: recovery.rollbackSave?.reason }
+      ])
+    });
+  }
+
+  const operationRecovery = monitorData.inferredRecoveryOperationRecoveryRequired;
+  if (operationRecovery && typeof operationRecovery === "object") {
+    cards.push({
+      type: "recovery-operation-recovery",
+      severity: "blocker",
+      title: "O6 recovery operation recovery required",
+      summary: "復旧操作のrollback状態を保存できなかったため、状態確認まで新しい操作は停止されます",
+      host: operationRecovery.target?.host || null,
+      candidateHash: null,
+      createdAt: Number(operationRecovery.createdAt) || 0,
+      createdAtDisplay: _formatTime(operationRecovery.createdAt),
+      details: _details([
+        { label: "Operation", value: operationRecovery.operation },
+        { label: "Reason", value: operationRecovery.reason },
+        { label: "Failure", value: operationRecovery.failureReason },
+        { label: "Target", value: operationRecovery.target },
+        { label: "Save", value: operationRecovery.save?.reason },
+        { label: "Rollback save", value: operationRecovery.rollbackSave?.reason }
       ])
     });
   }

--- a/3dp_lib/dashboard_inferred_recovery_ops.js
+++ b/3dp_lib/dashboard_inferred_recovery_ops.js
@@ -12,18 +12,20 @@
  * - STAND ALONE と PARENT だけが復旧操作を実行し、SATELLITE は親権威の診断を閲覧するだけにする。
  * - 各操作は O5 decision と同じ直列化キューを使い、保存境界や rollback 境界の競合を避ける。
  * - 復旧操作は `inferredRecoveryEvents` へ監査 event を追記し、耐久保存失敗時はメモリ状態を rollback する。
+ * - 復旧操作の rollback 状態も耐久保存できない場合は O6 専用 blocker を残し、通常操作を停止する。
  *
  * 【公開関数一覧】
  * - {@link canExecuteRecoveryOperation}：この端末で O6 recovery 操作を実行できるか判定する
  * - {@link retryInferredRecoveryDurableSave}：現在の recovery / repair 状態を再度耐久保存する
  * - {@link clearInferredDecisionRecoveryRequired}：確認済みの O5 decision recovery flag を解除する
+ * - {@link clearInferredRecoveryOperationRecoveryRequired}：確認済みの O6 recovery operation blocker を解除する
  * - {@link repairLedgerMountIntervals}：曖昧な mount interval の survivor を明示選択して修復する
  * - {@link clearLedgerRepairRequired}：確認済みの host 単位 ledger repair flag を解除する
  * - {@link archiveMountHistoryRejectedEvents}：隔離済み mount event を監査 event に移して warning を閉じる
  *
- * @version 1.390.1273 (PR #423)
+ * @version 1.390.1274 (PR #424)
  * @since   1.390.1270 (PR #420)
- * @lastModified 2026-08-02 18:20:00
+ * @lastModified 2026-08-02 18:33:44
  * -----------------------------------------------------------
  * @todo
  * - O7 Ledger Reconciliation で、手動解除前の再計算監査と修復案提示を追加する。
@@ -55,6 +57,13 @@ const RECOVERY_EVENT_CAP = 1000;
 const DECISION_RECOVERY_FIELD = "inferredDecisionRecoveryRequired";
 
 /**
+ * O6 recovery operation 復旧要求の monitorData field 名。
+ *
+ * @constant {string}
+ */
+const RECOVERY_OPERATION_FIELD = "inferredRecoveryOperationRecoveryRequired";
+
+/**
  * O6 recovery audit event の type 一覧。
  *
  * @enum {string}
@@ -62,6 +71,7 @@ const DECISION_RECOVERY_FIELD = "inferredDecisionRecoveryRequired";
 export const INFERRED_RECOVERY_EVENT_TYPE = Object.freeze({
   DURABLE_SAVE_RETRIED: "recovery-durable-save-retried",
   DECISION_RECOVERY_CLEARED: "decision-recovery-cleared",
+  RECOVERY_OPERATION_RECOVERY_CLEARED: "recovery-operation-recovery-cleared",
   LEDGER_INTERVALS_REPAIRED: "ledger-intervals-repaired",
   LEDGER_REPAIR_CLEARED: "ledger-repair-cleared",
   REJECTED_MOUNT_EVENTS_ARCHIVED: "mount-history-rejected-events-archived"
@@ -174,6 +184,7 @@ function _rejectedMountEvents() {
  */
 function _hasRecoveryIssues() {
   return !!monitorData[DECISION_RECOVERY_FIELD]
+    || !!monitorData[RECOVERY_OPERATION_FIELD]
     || Object.keys(_ledgerRepairRequired()).length > 0
     || _rejectedMountEvents().length > 0;
 }
@@ -189,6 +200,7 @@ function _hasRecoveryIssues() {
 function _snapshotRecoveryState(options = {}) {
   const snapshot = {
     inferredDecisionRecoveryRequired: _clone(monitorData[DECISION_RECOVERY_FIELD] || null),
+    inferredRecoveryOperationRecoveryRequired: _clone(monitorData[RECOVERY_OPERATION_FIELD] || null),
     ledgerRepairRequired: _clone(_ledgerRepairRequired()),
     mountHistoryRejectedEvents: _clone(_rejectedMountEvents()),
     inferredRecoveryEvents: _clone(_events())
@@ -215,6 +227,9 @@ function _snapshotRecoveryState(options = {}) {
 function _restoreRecoveryState(snapshot) {
   monitorData[DECISION_RECOVERY_FIELD] = snapshot.inferredDecisionRecoveryRequired
     ? _clone(snapshot.inferredDecisionRecoveryRequired)
+    : null;
+  monitorData[RECOVERY_OPERATION_FIELD] = snapshot.inferredRecoveryOperationRecoveryRequired
+    ? _clone(snapshot.inferredRecoveryOperationRecoveryRequired)
     : null;
 
   const repair = _ledgerRepairRequired();
@@ -262,6 +277,29 @@ function _appendRecoveryEvent(type, data = {}, options = {}) {
 }
 
 /**
+ * O6 recovery operation の rollback 保存失敗 blocker を記録する。
+ *
+ * 【詳細説明】
+ * - O6 操作で保存失敗後にメモリ rollback までは完了しても、その rollback 状態を耐久保存できない
+ *   場合は、保存済み snapshot とメモリ状態のどちらが権威か判断できない。
+ * - そのため独立 blocker を残し、O5 decision と通常 O6 操作を止める。
+ *
+ * @private
+ * @function _markRecoveryOperationRequired
+ * @param {Object} data - blocker metadata。
+ * @param {{nowMs?:number}} [options] - clock 注入オプション。
+ * @returns {Object} 記録した blocker。
+ */
+function _markRecoveryOperationRequired(data, options = {}) {
+  monitorData[RECOVERY_OPERATION_FIELD] = {
+    ..._clone(data || {}),
+    reason: "rollback_durable_save_failed",
+    createdAt: _nowMs(options)
+  };
+  return monitorData[RECOVERY_OPERATION_FIELD];
+}
+
+/**
  * 変更後状態を耐久保存し、失敗した場合は snapshot へ rollback する。
  *
  * 【詳細説明】
@@ -274,9 +312,10 @@ function _appendRecoveryEvent(type, data = {}, options = {}) {
  * @param {Object} snapshot - 操作前 snapshot。
  * @param {string} failureReason - 保存失敗時に返す reason。
  * @param {{save?:boolean}} [options] - 保存オプション。
+ * @param {{operation?:string,target?:Object}} [blockerData] - rollback 保存失敗時に blocker へ残す操作情報。
  * @returns {Promise<{ok:boolean,reason:string,save?:Object,rollbackSave?:Object}>} 保存結果。
  */
-async function _saveOrRollbackRecoveryMutation(snapshot, failureReason, options = {}) {
+async function _saveOrRollbackRecoveryMutation(snapshot, failureReason, options = {}, blockerData = {}) {
   const save = options.save === false
     ? { ok: true, backend: "disabled", reason: "save_disabled" }
     : await saveUnifiedStorageDurably();
@@ -288,11 +327,29 @@ async function _saveOrRollbackRecoveryMutation(snapshot, failureReason, options 
   const rollbackSave = options.save === false
     ? { ok: true, backend: "disabled", reason: "save_disabled" }
     : await saveUnifiedStorageDurably();
+  if (rollbackSave && rollbackSave.ok === false) {
+    const recovery = _markRecoveryOperationRequired({
+      operation: blockerData.operation || "unknown",
+      target: blockerData.target || null,
+      failureReason,
+      save,
+      rollbackSave
+    }, options);
+    const recoverySave = options.save === false
+      ? { ok: true, backend: "disabled", reason: "save_disabled" }
+      : await saveUnifiedStorageDurably();
+    return {
+      ok: false,
+      reason: "recovery_operation_rollback_save_failed",
+      save,
+      rollbackSave,
+      recovery,
+      recoverySave
+    };
+  }
   return {
     ok: false,
-    reason: rollbackSave && rollbackSave.ok === false
-      ? "recovery_operation_rollback_save_failed"
-      : failureReason,
+    reason: failureReason,
     save,
     rollbackSave
   };
@@ -303,11 +360,26 @@ async function _saveOrRollbackRecoveryMutation(snapshot, failureReason, options 
  *
  * @private
  * @function _operationGuard
+ * @param {{allowDecisionRecoveryBlocker?:boolean,allowRecoveryOperationBlocker?:boolean}} [options] - 復旧確認操作用の例外。
  * @returns {?{ok:boolean,reason:string}} 実行不可なら結果 object。実行可能なら null。
  */
-function _operationGuard() {
+function _operationGuard(options = {}) {
   if (!canExecuteRecoveryOperation()) {
     return { ok: false, reason: "recovery_not_authorized" };
+  }
+  if (monitorData[DECISION_RECOVERY_FIELD] && !options.allowDecisionRecoveryBlocker) {
+    return {
+      ok: false,
+      reason: "decision_recovery_required",
+      recovery: monitorData[DECISION_RECOVERY_FIELD]
+    };
+  }
+  if (monitorData[RECOVERY_OPERATION_FIELD] && !options.allowRecoveryOperationBlocker) {
+    return {
+      ok: false,
+      reason: "recovery_required",
+      recovery: monitorData[RECOVERY_OPERATION_FIELD]
+    };
   }
   return null;
 }
@@ -332,7 +404,7 @@ function _validateLedgerRepairClearance(host, repairItem) {
   if (!spoolId) return { ok: false, reason: "ledger_repair_spool_required" };
   try {
     const status = getMountIntervalStatus(spoolId, host);
-    if (status?.status === "ambiguous" || status?.status === "corrupt") {
+    if (status?.status !== "ok" && status?.status !== "none") {
       return {
         ok: false,
         reason: "ledger_repair_still_unresolved",
@@ -433,7 +505,10 @@ export function canExecuteRecoveryOperation() {
  */
 export function retryInferredRecoveryDurableSave(options = {}) {
   return enqueueLedgerDecisionTask(async () => {
-    const guard = _operationGuard();
+    const guard = _operationGuard({
+      allowDecisionRecoveryBlocker: true,
+      allowRecoveryOperationBlocker: true
+    });
     if (guard) return guard;
     if (!_hasRecoveryIssues()) return { ok: false, reason: "recovery_not_required" };
 
@@ -444,7 +519,13 @@ export function retryInferredRecoveryDurableSave(options = {}) {
       ledgerRepairHosts: Object.keys(_ledgerRepairRequired()),
       rejectedMountEventCount: _rejectedMountEvents().length
     }, options);
-    const saved = await _saveOrRollbackRecoveryMutation(snapshot, "recovery_retry_not_durably_saved", options);
+    const saved = await _saveOrRollbackRecoveryMutation(snapshot, "recovery_retry_not_durably_saved", options, {
+      operation: "retryInferredRecoveryDurableSave",
+      target: {
+        hasDecisionRecovery: !!monitorData[DECISION_RECOVERY_FIELD],
+        hasRecoveryOperationRecovery: !!monitorData[RECOVERY_OPERATION_FIELD]
+      }
+    });
     if (!saved.ok) return saved;
     return { ok: true, reason: "recovery_durable_save_retried", event, save: saved.save };
   });
@@ -465,7 +546,7 @@ export function retryInferredRecoveryDurableSave(options = {}) {
  */
 export function clearInferredDecisionRecoveryRequired(options = {}) {
   return enqueueLedgerDecisionTask(async () => {
-    const guard = _operationGuard();
+    const guard = _operationGuard({ allowDecisionRecoveryBlocker: true });
     if (guard) return guard;
     const current = monitorData[DECISION_RECOVERY_FIELD];
     if (!current || typeof current !== "object") return { ok: false, reason: "decision_recovery_not_found" };
@@ -477,9 +558,52 @@ export function clearInferredDecisionRecoveryRequired(options = {}) {
       note: options.note || "",
       clearedRecovery: _clone(current)
     }, options);
-    const saved = await _saveOrRollbackRecoveryMutation(snapshot, "decision_recovery_clear_not_durably_saved", options);
+    const saved = await _saveOrRollbackRecoveryMutation(snapshot, "decision_recovery_clear_not_durably_saved", options, {
+      operation: "clearInferredDecisionRecoveryRequired",
+      target: { candidateHash: current.candidateHash || null }
+    });
     if (!saved.ok) return saved;
     return { ok: true, reason: "decision_recovery_cleared", event, save: saved.save };
+  });
+}
+
+/**
+ * 確認済みの O6 recovery operation blocker を解除する。
+ *
+ * 【詳細説明】
+ * - rollback 保存失敗後、オペレーターが保存状態とメモリ状態を確認した場合だけ呼ぶ。
+ * - この操作は `inferredRecoveryOperationRecoveryRequired` が存在する状態でも実行できる例外であり、
+ *   blocker 解除と audit event 追記を同じ耐久保存境界で扱う。
+ *
+ * @function clearInferredRecoveryOperationRecoveryRequired
+ * @param {{actor?:string,note?:string,nowMs?:number,save?:boolean}} [options] - 操作者・メモ・保存オプション。
+ * @returns {Promise<Object>} recovery 操作結果。
+ * @example
+ * const result = await clearInferredRecoveryOperationRecoveryRequired({ actor: "operator", note: "checked" });
+ */
+export function clearInferredRecoveryOperationRecoveryRequired(options = {}) {
+  return enqueueLedgerDecisionTask(async () => {
+    const guard = _operationGuard({
+      allowDecisionRecoveryBlocker: true,
+      allowRecoveryOperationBlocker: true
+    });
+    if (guard) return guard;
+    const current = monitorData[RECOVERY_OPERATION_FIELD];
+    if (!current || typeof current !== "object") return { ok: false, reason: "recovery_operation_recovery_not_found" };
+
+    const snapshot = _snapshotRecoveryState();
+    monitorData[RECOVERY_OPERATION_FIELD] = null;
+    const event = _appendRecoveryEvent(INFERRED_RECOVERY_EVENT_TYPE.RECOVERY_OPERATION_RECOVERY_CLEARED, {
+      reason: "operator-cleared-recovery-operation-recovery",
+      note: options.note || "",
+      clearedRecovery: _clone(current)
+    }, options);
+    const saved = await _saveOrRollbackRecoveryMutation(snapshot, "recovery_operation_recovery_clear_not_durably_saved", options, {
+      operation: "clearInferredRecoveryOperationRecoveryRequired",
+      target: { operation: current.operation || null }
+    });
+    if (!saved.ok) return saved;
+    return { ok: true, reason: "recovery_operation_recovery_cleared", event, save: saved.save };
   });
 }
 
@@ -520,7 +644,10 @@ export function clearLedgerRepairRequired(host, options = {}) {
       clearedRepair: _clone(current),
       clearanceStatus: _clone(clearance.status)
     }, options);
-    const saved = await _saveOrRollbackRecoveryMutation(snapshot, "ledger_repair_clear_not_durably_saved", options);
+    const saved = await _saveOrRollbackRecoveryMutation(snapshot, "ledger_repair_clear_not_durably_saved", options, {
+      operation: "clearLedgerRepairRequired",
+      target: { host: hostKey, spoolId: current.spoolId || null }
+    });
     if (!saved.ok) return saved;
     return { ok: true, reason: "ledger_repair_cleared", host: hostKey, event, save: saved.save };
   });
@@ -602,7 +729,14 @@ export function repairLedgerMountIntervals(host, survivingIntervalId, options = 
       supersededIntervalIds: _clone(validation.targetIntervalIds),
       supersedeEvent: _clone(supersedeEvent)
     }, { ...options, nowMs });
-    const saved = await _saveOrRollbackRecoveryMutation(snapshot, "ledger_repair_repair_not_durably_saved", options);
+    const saved = await _saveOrRollbackRecoveryMutation(snapshot, "ledger_repair_repair_not_durably_saved", options, {
+      operation: "repairLedgerMountIntervals",
+      target: {
+        host: hostKey,
+        spoolId: validation.spoolId,
+        survivingIntervalId: String(survivingIntervalId)
+      }
+    });
     if (!saved.ok) return saved;
     return {
       ok: true,
@@ -647,7 +781,10 @@ export function archiveMountHistoryRejectedEvents(options = {}) {
       rejectedEventCount: rejectedSnapshot.length,
       rejectedEvents: rejectedSnapshot
     }, options);
-    const saved = await _saveOrRollbackRecoveryMutation(snapshot, "mount_history_rejected_archive_not_durably_saved", options);
+    const saved = await _saveOrRollbackRecoveryMutation(snapshot, "mount_history_rejected_archive_not_durably_saved", options, {
+      operation: "archiveMountHistoryRejectedEvents",
+      target: { rejectedEventCount: rejectedSnapshot.length }
+    });
     if (!saved.ok) return saved;
     return {
       ok: true,

--- a/3dp_lib/dashboard_relay_bridge.js
+++ b/3dp_lib/dashboard_relay_bridge.js
@@ -22,9 +22,9 @@
  * - {@link buildCameraEndpoints}：カメラパススルー用エンドポイントを構築する
  * - {@link relayBroadcastIfNeeded}：変更があれば子へデルタ配信する
  *
- * @version 1.390.1270 (PR #420)
+ * @version 1.390.1274 (PR #424)
  * @since   1.390.820 (PR #367)
- * @lastModified 2026-08-02 15:05:22
+ * @lastModified 2026-08-02 18:33:44
  * -----------------------------------------------------------
  */
 
@@ -699,6 +699,7 @@ function _buildDelta() {
   //   candidate store とは別ハッシュで低頻度同期する。
   const recoveryHash = _quickHash(
     monitorData.inferredDecisionRecoveryRequired || null,
+    monitorData.inferredRecoveryOperationRecoveryRequired || null,
     monitorData.inferredRecoveryEvents || [],
     monitorData.ledgerRepairRequired || {},
     monitorData.mountHistoryRejectedEvents || []
@@ -707,6 +708,7 @@ function _buildDelta() {
     _prevRecoveryHash = recoveryHash;
     sharedDelta = sharedDelta || {};
     sharedDelta.inferredDecisionRecoveryRequired = monitorData.inferredDecisionRecoveryRequired || null;
+    sharedDelta.inferredRecoveryOperationRecoveryRequired = monitorData.inferredRecoveryOperationRecoveryRequired || null;
     sharedDelta.inferredRecoveryEvents = monitorData.inferredRecoveryEvents || [];
     sharedDelta.ledgerRepairRequired = monitorData.ledgerRepairRequired || {};
     sharedDelta.mountHistoryRejectedEvents = monitorData.mountHistoryRejectedEvents || [];
@@ -824,6 +826,7 @@ function _buildFullSnapshot() {
     inferredCandidateStore: monitorData.inferredCandidateStore || {},
     // ★ #418: Candidate Center の Recovery / repair 診断も親権威で子へ同梱する。
     inferredDecisionRecoveryRequired: monitorData.inferredDecisionRecoveryRequired || null,
+    inferredRecoveryOperationRecoveryRequired: monitorData.inferredRecoveryOperationRecoveryRequired || null,
     inferredRecoveryEvents: monitorData.inferredRecoveryEvents || [],
     ledgerRepairRequired: monitorData.ledgerRepairRequired || {},
     mountHistoryRejectedEvents: monitorData.mountHistoryRejectedEvents || [],

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -27,9 +27,9 @@
  * - {@link loadPrintCurrent}：現ジョブ読込
  * - {@link savePrintCurrent}：現ジョブ保存
  *
-* @version 1.390.1270 (PR #420)
+* @version 1.390.1274 (PR #424)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-08-02 15:05:22
+* @lastModified 2026-08-02 18:33:44
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -289,6 +289,17 @@ export async function importAllData(data) {
       }
     } else if (!monitorData.inferredDecisionRecoveryRequired) {
       monitorData.inferredDecisionRecoveryRequired = null;
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(data, "inferredRecoveryOperationRecoveryRequired")) {
+    const incoming = data.inferredRecoveryOperationRecoveryRequired;
+    if (incoming && typeof incoming === "object") {
+      const current = monitorData.inferredRecoveryOperationRecoveryRequired;
+      if (!current || (Number(incoming.createdAt) || 0) >= (Number(current.createdAt) || 0)) {
+        monitorData.inferredRecoveryOperationRecoveryRequired = { ...incoming };
+      }
+    } else if (!monitorData.inferredRecoveryOperationRecoveryRequired) {
+      monitorData.inferredRecoveryOperationRecoveryRequired = null;
     }
   }
   if (Array.isArray(data.inferredRecoveryEvents)) {
@@ -704,7 +715,7 @@ const LS_GLOBAL_FIELDS = [
   // ★ #412-O4: オフライン継続推定 candidate（親権威・状態遷移つき）
   "inferredCandidateStore",
   // ★ #420/O6A: O5 recovery blocker と復旧操作 audit event
-  "inferredDecisionRecoveryRequired", "inferredRecoveryEvents",
+  "inferredDecisionRecoveryRequired", "inferredRecoveryOperationRecoveryRequired", "inferredRecoveryEvents",
   // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない）
   "pendingUnattributedUsage", "pendingUnattributedUsageArchive",
   // ★ RR-2: 台帳修復要求フラグ（破損時に暗黙クローズせず可視化）
@@ -961,6 +972,7 @@ function _flushStorage() {
       queueSharedWrite("hostObservationCurrent",   monitorData.hostObservationCurrent);
       queueSharedWrite("inferredCandidateStore",   monitorData.inferredCandidateStore);
       queueSharedWrite("inferredDecisionRecoveryRequired", monitorData.inferredDecisionRecoveryRequired || null);
+      queueSharedWrite("inferredRecoveryOperationRecoveryRequired", monitorData.inferredRecoveryOperationRecoveryRequired || null);
       queueSharedWrite("inferredRecoveryEvents", monitorData.inferredRecoveryEvents || []);
       // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない・子へも配信）
       queueSharedWrite("pendingUnattributedUsage",        monitorData.pendingUnattributedUsage);
@@ -1369,6 +1381,12 @@ function _restoreFromData(shared, machines) {
     monitorData.inferredDecisionRecoveryRequired =
       shared.inferredDecisionRecoveryRequired && typeof shared.inferredDecisionRecoveryRequired === "object"
         ? { ...shared.inferredDecisionRecoveryRequired }
+        : null;
+  }
+  if (shared && Object.prototype.hasOwnProperty.call(shared, "inferredRecoveryOperationRecoveryRequired")) {
+    monitorData.inferredRecoveryOperationRecoveryRequired =
+      shared.inferredRecoveryOperationRecoveryRequired && typeof shared.inferredRecoveryOperationRecoveryRequired === "object"
+        ? { ...shared.inferredRecoveryOperationRecoveryRequired }
         : null;
   }
   if (Array.isArray(shared?.inferredRecoveryEvents)) {

--- a/3dp_lib/dashboard_storage_idb.js
+++ b/3dp_lib/dashboard_storage_idb.js
@@ -23,9 +23,9 @@
  * - {@link exportAllIdb}：全データを単一オブジェクトとして読み出し
  * - {@link importAllIdb}：単一オブジェクトから全データを書き込み
  *
- * @version 1.390.1270 (PR #420)
+ * @version 1.390.1274 (PR #424)
  * @since   1.390.787 (PR #366)
- * @lastModified 2026-08-02 15:05:22
+ * @lastModified 2026-08-02 18:33:44
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -110,6 +110,7 @@ const SHARED_KEYS = [
   "inferredCandidateStore",
   // #420/O6A: recovery blocker と復旧操作 audit event。
   "inferredDecisionRecoveryRequired",
+  "inferredRecoveryOperationRecoveryRequired",
   "inferredRecoveryEvents",
   // ★ P0-1: 未帰属消費の隔離領域とアーカイブ（再起動後も失わない）
   "pendingUnattributedUsage",

--- a/docs/en/filament_manual.md
+++ b/docs/en/filament_manual.md
@@ -125,7 +125,8 @@ the Parent; readonly Satellites keep the action buttons disabled.
 
 When required, the top of the Inferred Candidate tab shows a Recovery /
 repair status surface. This is a diagnostic view for states such as
-`inferredDecisionRecoveryRequired`, `ledgerRepairRequired` and
+`inferredDecisionRecoveryRequired`,
+`inferredRecoveryOperationRecoveryRequired`, `ledgerRepairRequired` and
 `mountHistoryRejectedEvents`, where the app must not continue
 automatically. It shows the related candidate, host, spool, save-failure
 reason and quarantined mountHistory events.
@@ -137,6 +138,7 @@ Recovery / repair status surface.
 | --- | --- |
 | **Retry save** | Attempts to durably save the current recovery / repair state again. |
 | **Clear recovery** | Clears `inferredDecisionRecoveryRequired` after the operator has verified the rolled-back state. |
+| **Clear operation recovery** | Clears `inferredRecoveryOperationRecoveryRequired` after the operator has verified a failed O6 recovery-operation rollback save. |
 | **Repair intervals** | Repairs an ambiguous mount interval by explicitly selecting the survivor interval and superseding the other open intervals. |
 | **Clear repair** | Clears `ledgerRepairRequired` for the selected host after the mount ledger has been verified and the current state is no longer `ambiguous` or `corrupt`. |
 | **Archive rejected** | Moves quarantined mountHistory events into `inferredRecoveryEvents` audit history and closes the warning. |
@@ -149,9 +151,12 @@ them for O7 reconciliation or manual investigation.
 Each recovery operation appends an `inferredRecoveryEvents` audit event
 and rolls memory state back if durable save fails. For `Repair intervals`,
 `mountHistory` and `mountHistorySeq` are also part of the rollback
-snapshot. In Relay setups, Satellites mirror the diagnostic state from the
-Parent authority but keep the recovery operation buttons disabled. Run
-recovery operations on the Parent device.
+snapshot. If that rollback state also cannot be saved,
+`inferredRecoveryOperationRecoveryRequired` is raised and normal O5/O6
+operations stop until retry-save or operator clearance resolves it. In
+Relay setups, Satellites mirror the diagnostic state from the Parent
+authority but keep the recovery operation buttons disabled. Run recovery
+operations on the Parent device.
 
 After recovery operations run, the same Recovery / repair status surface
 shows a **Recovery operation audit** card. It lists recent retry-save,

--- a/docs/ja/filament_manual.md
+++ b/docs/ja/filament_manual.md
@@ -92,7 +92,7 @@ monitorData.hostSpoolMap = {
 
 Relay 構成では、Standalone と Parent は Confirm / Reject / Reassign / Undo を実行できます。Satellite は候補を閲覧でき、操作モードに昇格している場合は Parent へ decision request を送ります。Readonly の Satellite では操作ボタンは無効化されます。
 
-推定候補タブの上部には、必要に応じて Recovery / repair status が表示されます。これは `inferredDecisionRecoveryRequired`、`ledgerRepairRequired`、`mountHistoryRejectedEvents` など、自動継続してはいけない状態を確認するための診断です。表示された場合は、原因となった candidate、host、spool、保存失敗理由、隔離された mountHistory event を確認できます。
+推定候補タブの上部には、必要に応じて Recovery / repair status が表示されます。これは `inferredDecisionRecoveryRequired`、`inferredRecoveryOperationRecoveryRequired`、`ledgerRepairRequired`、`mountHistoryRejectedEvents` など、自動継続してはいけない状態を確認するための診断です。表示された場合は、原因となった candidate、host、spool、保存失敗理由、隔離された mountHistory event を確認できます。
 
 Standalone / Parent では、Recovery / repair status から次の復旧操作を実行できます。
 
@@ -100,13 +100,14 @@ Standalone / Parent では、Recovery / repair status から次の復旧操作�
 | --- | --- |
 | **Retry save** | 現在の recovery / repair 状態を再度耐久保存します |
 | **Clear recovery** | rollback 後の状態を確認済みの場合に `inferredDecisionRecoveryRequired` を解除します |
+| **Clear operation recovery** | O6復旧操作そのもののrollback保存失敗を確認済みの場合に `inferredRecoveryOperationRecoveryRequired` を解除します |
 | **Repair intervals** | `ledgerRepairRequired` が示す曖昧な mount interval について、残す survivor 区間を明示選択し、それ以外の open 区間を supersede して修復します |
 | **Clear repair** | 対象 host の mount ledger を確認済みで、現在状態が `ambiguous` / `corrupt` ではない場合に `ledgerRepairRequired` を解除します |
 | **Archive rejected** | 隔離済み mountHistory event を `inferredRecoveryEvents` へ監査退避し、warning を閉じます |
 
 `Repair intervals` は現在状態が `ambiguous` で、open interval が複数あり、選択した survivor が現在も open の場合だけ実行できます。`corrupt` 状態は参照不整合を含むため、この操作では自動修復せず、O7 の再計算監査または手動調査の対象にします。
 
-これらの復旧操作は `inferredRecoveryEvents` に監査 event を残し、保存失敗時は操作前の状態へ戻します。`Repair intervals` では `mountHistory` と `mountHistorySeq` も rollback 対象です。Relay 構成では Satellite も Parent 権威の診断状態をミラー表示しますが、復旧操作は無効化されます。復旧操作は Parent 端末で実行してください。
+これらの復旧操作は `inferredRecoveryEvents` に監査 event を残し、保存失敗時は操作前の状態へ戻します。`Repair intervals` では `mountHistory` と `mountHistorySeq` も rollback 対象です。復旧操作のrollback状態も保存できなかった場合は `inferredRecoveryOperationRecoveryRequired` が立ち、Retry save と確認後の解除以外の O5/O6 操作を停止します。Relay 構成では Satellite も Parent 権威の診断状態をミラー表示しますが、復旧操作は無効化されます。復旧操作は Parent 端末で実行してください。
 
 復旧操作後は、同じ Recovery / repair status に **Recovery operation audit** が表示されます。ここには最新の再保存、recovery flag 解除、ledger repair flag 解除、隔離 event 退避の履歴が残り、対象 candidate、host、件数、操作者、実行時刻を確認できます。未解決 blocker が無い場合でも、直近の復旧操作履歴は INFO として表示されます。
 

--- a/tests/unit/dashboard_client_sync_filament_sync.test.js
+++ b/tests/unit/dashboard_client_sync_filament_sync.test.js
@@ -158,6 +158,7 @@ describe("_applySharedFilamentState — フィラメント補助ドメイン（�
     }
     for (const k of Object.keys(monitorData.inferredCandidateStore)) delete monitorData.inferredCandidateStore[k];
     monitorData.inferredDecisionRecoveryRequired = null;
+    monitorData.inferredRecoveryOperationRecoveryRequired = null;
     if (!Array.isArray(monitorData.inferredRecoveryEvents)) monitorData.inferredRecoveryEvents = [];
     monitorData.inferredRecoveryEvents.splice(0, monitorData.inferredRecoveryEvents.length);
     if (!monitorData.ledgerRepairRequired || typeof monitorData.ledgerRepairRequired !== "object") {
@@ -211,12 +212,14 @@ describe("_applySharedFilamentState — フィラメント補助ドメイン（�
 
   it("#418: recovery / repair 診断を親から全置換ミラーする", () => {
     monitorData.inferredDecisionRecoveryRequired = { candidateHash: "stale", reason: "old" };
+    monitorData.inferredRecoveryOperationRecoveryRequired = { operation: "stale", reason: "old" };
     monitorData.inferredRecoveryEvents.push({ eventId: "ir-old", type: "old" });
     monitorData.ledgerRepairRequired.stale = { status: "old" };
     monitorData.mountHistoryRejectedEvents.push({ reason: "old", event: { evId: "old" } });
 
     _applySharedFilamentState({
       inferredDecisionRecoveryRequired: { candidateHash: "ic-a", action: "confirm", reason: "rollback_durable_save_failed" },
+      inferredRecoveryOperationRecoveryRequired: { operation: "clearLedgerRepairRequired", reason: "rollback_durable_save_failed" },
       inferredRecoveryEvents: [{ eventId: "ir-a", type: "recovery-durable-save-retried", createdAt: 123 }],
       ledgerRepairRequired: { k1: { spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 123 } },
       mountHistoryRejectedEvents: [{ reason: "reanchor-invalid-reference", event: { evId: "ev-a", host: "k1" } }],
@@ -225,6 +228,10 @@ describe("_applySharedFilamentState — フィラメント補助ドメイン（�
     expect(monitorData.inferredDecisionRecoveryRequired).toEqual({
       candidateHash: "ic-a",
       action: "confirm",
+      reason: "rollback_durable_save_failed",
+    });
+    expect(monitorData.inferredRecoveryOperationRecoveryRequired).toEqual({
+      operation: "clearLedgerRepairRequired",
       reason: "rollback_durable_save_failed",
     });
     expect(monitorData.inferredRecoveryEvents).toEqual([
@@ -239,18 +246,21 @@ describe("_applySharedFilamentState — フィラメント補助ドメイン（�
 
   it("#418: 親で解消済みの recovery / repair 診断を Satellite 側から消す", () => {
     monitorData.inferredDecisionRecoveryRequired = { candidateHash: "ic-a", reason: "old" };
+    monitorData.inferredRecoveryOperationRecoveryRequired = { operation: "old", reason: "old" };
     monitorData.inferredRecoveryEvents.push({ eventId: "ir-a", type: "old" });
     monitorData.ledgerRepairRequired.k1 = { status: "ambiguous" };
     monitorData.mountHistoryRejectedEvents.push({ reason: "old" });
 
     _applySharedFilamentState({
       inferredDecisionRecoveryRequired: null,
+      inferredRecoveryOperationRecoveryRequired: null,
       inferredRecoveryEvents: [],
       ledgerRepairRequired: {},
       mountHistoryRejectedEvents: [],
     });
 
     expect(monitorData.inferredDecisionRecoveryRequired).toBeNull();
+    expect(monitorData.inferredRecoveryOperationRecoveryRequired).toBeNull();
     expect(monitorData.inferredRecoveryEvents).toEqual([]);
     expect(monitorData.ledgerRepairRequired).toEqual({});
     expect(monitorData.mountHistoryRejectedEvents).toEqual([]);
@@ -260,12 +270,14 @@ describe("_applySharedFilamentState — フィラメント補助ドメイン（�
     globalThis.window._refreshFilamentManagerIfOpen = vi.fn();
     _applySharedFilamentState({
       inferredDecisionRecoveryRequired: { candidateHash: "ic-a", reason: "rollback_failed" },
+      inferredRecoveryOperationRecoveryRequired: null,
       inferredRecoveryEvents: [{ eventId: "ir-a", type: "retry" }],
     });
     const firstCount = globalThis.window._refreshFilamentManagerIfOpen.mock.calls.length;
 
     _applySharedFilamentState({
       inferredDecisionRecoveryRequired: { candidateHash: "ic-b", reason: "rollback_failed" },
+      inferredRecoveryOperationRecoveryRequired: { operation: "clearLedgerRepairRequired", reason: "rollback_failed" },
       inferredRecoveryEvents: [{ eventId: "ir-b", type: "retry" }],
     });
 

--- a/tests/unit/dashboard_inferred_candidate_decision.test.js
+++ b/tests/unit/dashboard_inferred_candidate_decision.test.js
@@ -8,7 +8,9 @@ const mocks = vi.hoisted(() => ({
   monitorData: {
     machines: {},
     filamentSpools: [],
-    inferredCandidateStore: {}
+    inferredCandidateStore: {},
+    inferredDecisionRecoveryRequired: null,
+    inferredRecoveryOperationRecoveryRequired: null
   },
   saveUnifiedStorageDurably: vi.fn(async () => ({ ok: true, backend: "test", reason: "saved" })),
   sendRelayFilament: vi.fn(() => true),
@@ -165,7 +167,8 @@ beforeEach(() => {
   };
   mocks.monitorData.filamentSpools = [spool("S1", 10000), spool("S2", 8000)];
   mocks.monitorData.inferredCandidateStore = { "ic-a": candidate() };
-  delete mocks.monitorData.inferredDecisionRecoveryRequired;
+  mocks.monitorData.inferredDecisionRecoveryRequired = null;
+  mocks.monitorData.inferredRecoveryOperationRecoveryRequired = null;
 });
 
 describe("canExecuteLedgerDecision", () => {
@@ -207,6 +210,26 @@ describe("canExecuteLedgerDecision", () => {
     });
     expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(10000);
     expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.PENDING);
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+
+  it("#424/O6D: recovery operation blocker がある間は O5 decision を停止する", async () => {
+    mocks.monitorData.inferredRecoveryOperationRecoveryRequired = {
+      operation: "clearLedgerRepairRequired",
+      reason: "rollback_durable_save_failed",
+      createdAt: 900
+    };
+
+    const result = await confirmInferredCandidate("ic-a", { nowMs: 11000 });
+
+    expect(canSubmitLedgerDecision()).toBe(false);
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "recovery_required",
+      candidateHash: "ic-a",
+      recoveryField: "inferredRecoveryOperationRecoveryRequired"
+    });
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(10000);
     expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/dashboard_inferred_candidate_ui.test.js
+++ b/tests/unit/dashboard_inferred_candidate_ui.test.js
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   canExecuteRecoveryOperation: vi.fn(() => true),
   retryInferredRecoveryDurableSave: vi.fn(async () => ({ ok: true, reason: "recovery_durable_save_retried" })),
   clearInferredDecisionRecoveryRequired: vi.fn(async () => ({ ok: true, reason: "decision_recovery_cleared" })),
+  clearInferredRecoveryOperationRecoveryRequired: vi.fn(async () => ({ ok: true, reason: "recovery_operation_recovery_cleared" })),
   clearLedgerRepairRequired: vi.fn(async () => ({ ok: true, reason: "ledger_repair_cleared" })),
   repairLedgerMountIntervals: vi.fn(async () => ({ ok: true, reason: "ledger_repair_intervals_repaired" })),
   archiveMountHistoryRejectedEvents: vi.fn(async () => ({ ok: true, reason: "mount_history_rejected_events_archived" })),
@@ -37,6 +38,7 @@ vi.mock("../../3dp_lib/dashboard_inferred_recovery_ops.js", () => ({
   canExecuteRecoveryOperation: mocks.canExecuteRecoveryOperation,
   retryInferredRecoveryDurableSave: mocks.retryInferredRecoveryDurableSave,
   clearInferredDecisionRecoveryRequired: mocks.clearInferredDecisionRecoveryRequired,
+  clearInferredRecoveryOperationRecoveryRequired: mocks.clearInferredRecoveryOperationRecoveryRequired,
   clearLedgerRepairRequired: mocks.clearLedgerRepairRequired,
   repairLedgerMountIntervals: mocks.repairLedgerMountIntervals,
   archiveMountHistoryRejectedEvents: mocks.archiveMountHistoryRejectedEvents
@@ -155,6 +157,8 @@ beforeEach(() => {
   mocks.retryInferredRecoveryDurableSave.mockResolvedValue({ ok: true, reason: "recovery_durable_save_retried" });
   mocks.clearInferredDecisionRecoveryRequired.mockClear();
   mocks.clearInferredDecisionRecoveryRequired.mockResolvedValue({ ok: true, reason: "decision_recovery_cleared" });
+  mocks.clearInferredRecoveryOperationRecoveryRequired.mockClear();
+  mocks.clearInferredRecoveryOperationRecoveryRequired.mockResolvedValue({ ok: true, reason: "recovery_operation_recovery_cleared" });
   mocks.clearLedgerRepairRequired.mockClear();
   mocks.clearLedgerRepairRequired.mockResolvedValue({ ok: true, reason: "ledger_repair_cleared" });
   mocks.repairLedgerMountIntervals.mockClear();
@@ -258,6 +262,35 @@ describe("createInferredCandidateCenterContent", () => {
     expect(document.querySelector(".ic-recovery-severity").textContent).toBe("INFO");
     expect(document.querySelector(".ic-recovery-title").textContent).toBe("Recovery operation audit");
     expect(document.querySelector(".ic-recovery-actions")).toBeNull();
+  });
+
+  it("#424/O6D: recovery operation blocker card の Clear recovery は専用解除APIを呼ぶ", async () => {
+    mocks.recoveryVm = {
+      hasIssues: true,
+      totalCount: 1,
+      blockerCount: 1,
+      warningCount: 0,
+      infoCount: 0,
+      cards: [{
+        type: "recovery-operation-recovery",
+        severity: "blocker",
+        title: "O6 recovery operation recovery required",
+        summary: "状態確認が必要です",
+        details: [{ label: "Operation", value: "clearLedgerRepairRequired" }]
+      }]
+    };
+
+    const center = createInferredCandidateCenterContent();
+    document.body.appendChild(center.el);
+    [...document.querySelectorAll(".ic-recovery-actions button")]
+      .find(button => button.textContent === "Clear operation recovery")
+      .click();
+
+    await waitForAssertion(() => {
+      expect(mocks.clearInferredRecoveryOperationRecoveryRequired).toHaveBeenCalledWith({ actor: "local-user" });
+      expect(mocks.clearInferredDecisionRecoveryRequired).not.toHaveBeenCalled();
+      expect(mocks.showAlert).toHaveBeenCalledWith("復旧操作の整合性確認フラグを解除しました", "success");
+    });
   });
 
   it("Satellite では recovery 操作を disabled にする", () => {

--- a/tests/unit/dashboard_inferred_candidate_view.test.js
+++ b/tests/unit/dashboard_inferred_candidate_view.test.js
@@ -86,6 +86,7 @@ beforeEach(() => {
     "ic-old": record("ic-old", { createdAt: 1000, status: "confirmed" })
   };
   delete mocks.monitorData.inferredDecisionRecoveryRequired;
+  delete mocks.monitorData.inferredRecoveryOperationRecoveryRequired;
   mocks.monitorData.inferredRecoveryEvents = [];
   mocks.monitorData.ledgerRepairRequired = {};
   mocks.monitorData.mountHistoryRejectedEvents = [];
@@ -150,6 +151,22 @@ describe("buildInferredCandidateViewModel", () => {
     const vm = buildInferredCandidateViewModel(mocks.monitorData.inferredCandidateStore["ic-new"]);
 
     expect(vm.warningCodes).toContain("history-already-attributed");
+  });
+
+  it("#424/O6D: recovery operation blocker がある場合は candidate decision を無効化する", () => {
+    mocks.monitorData.inferredRecoveryOperationRecoveryRequired = {
+      operation: "clearLedgerRepairRequired",
+      reason: "rollback_durable_save_failed",
+      createdAt: 900
+    };
+
+    const vm = buildInferredCandidateViewModel(mocks.monitorData.inferredCandidateStore["ic-new"]);
+
+    expect(vm.canConfirm).toBe(false);
+    expect(vm.canReject).toBe(false);
+    expect(vm.canReassign).toBe(false);
+    expect(vm.readOnlyReason).toBe("recovery-required");
+    expect(vm.warningCodes).toContain("decision-recovery-required");
   });
 });
 
@@ -248,6 +265,30 @@ describe("buildInferredRecoverySurfaceViewModel", () => {
     expect(vm.cards[0].details).toHaveLength(1);
     expect(vm.cards[0].details[0].value).toContain("decision-recovery-cleared");
     expect(vm.cards[0].details[0].value).toContain("ic-new");
+  });
+
+  it("#424/O6D: recovery operation blocker を blocker card に変換する", () => {
+    mocks.monitorData.inferredRecoveryOperationRecoveryRequired = {
+      operation: "clearLedgerRepairRequired",
+      reason: "rollback_durable_save_failed",
+      failureReason: "ledger_repair_clear_not_durably_saved",
+      createdAt: 900,
+      target: { host: "k1", spoolId: "S1" },
+      save: { reason: "idb_flush_failed" },
+      rollbackSave: { reason: "rollback_flush_failed" }
+    };
+
+    const vm = buildInferredRecoverySurfaceViewModel();
+
+    expect(vm.hasIssues).toBe(true);
+    expect(vm.blockerCount).toBe(1);
+    expect(vm.cards[0]).toMatchObject({
+      type: "recovery-operation-recovery",
+      severity: "blocker",
+      title: "O6 recovery operation recovery required"
+    });
+    expect(vm.cards[0].details).toContainEqual({ label: "Operation", value: "clearLedgerRepairRequired" });
+    expect(vm.cards[0].details).toContainEqual({ label: "Failure", value: "ledger_repair_clear_not_durably_saved" });
   });
 
   it("recovery item がない場合は空の診断モデルを返す", () => {

--- a/tests/unit/dashboard_inferred_recovery_ops.test.js
+++ b/tests/unit/dashboard_inferred_recovery_ops.test.js
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   monitorData: {
     inferredDecisionRecoveryRequired: null,
+    inferredRecoveryOperationRecoveryRequired: null,
     inferredRecoveryEvents: [],
     ledgerRepairRequired: {},
     mountHistoryRejectedEvents: [],
@@ -49,6 +50,7 @@ const {
   archiveMountHistoryRejectedEvents,
   canExecuteRecoveryOperation,
   clearInferredDecisionRecoveryRequired,
+  clearInferredRecoveryOperationRecoveryRequired,
   clearLedgerRepairRequired,
   repairLedgerMountIntervals,
   retryInferredRecoveryDurableSave
@@ -62,6 +64,7 @@ const {
  */
 function resetRecoveryState() {
   mocks.monitorData.inferredDecisionRecoveryRequired = null;
+  mocks.monitorData.inferredRecoveryOperationRecoveryRequired = null;
   mocks.monitorData.inferredRecoveryEvents = [];
   mocks.monitorData.ledgerRepairRequired = {};
   mocks.monitorData.mountHistoryRejectedEvents = [];
@@ -218,6 +221,29 @@ describe("clearLedgerRepairRequired", () => {
     expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
   });
 
+  it("#424/O6D: ok/none 以外の未知状態では ledger repair flag を解除しない", async () => {
+    mocks.monitorData.ledgerRepairRequired = {
+      k1: { spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 100 }
+    };
+    mocks.getMountIntervalStatus.mockReturnValueOnce({
+      status: "error",
+      openInterval: null,
+      intervals: [],
+      diagnostics: [{ code: "status-read-failed" }]
+    });
+
+    const result = await clearLedgerRepairRequired("k1");
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "ledger_repair_still_unresolved",
+      host: "k1",
+      status: { status: "error" }
+    });
+    expect(mocks.monitorData.ledgerRepairRequired.k1.status).toBe("ambiguous");
+    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+  });
+
   it("spoolId がない ledger repair flag は解除しない", async () => {
     mocks.monitorData.ledgerRepairRequired = {
       k1: { status: "ambiguous", detectedAtEpochMs: 100 }
@@ -242,6 +268,55 @@ describe("clearLedgerRepairRequired", () => {
     expect(result).toMatchObject({ ok: false, reason: "ledger_repair_clear_not_durably_saved" });
     expect(mocks.monitorData.ledgerRepairRequired).toEqual(repair);
     expect(mocks.monitorData.inferredRecoveryEvents).toHaveLength(0);
+  });
+
+  it("#424/O6D: rollback 保存にも失敗した場合は recovery operation blocker を残し後続通常操作を止める", async () => {
+    const repair = { k1: { spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 100 } };
+    mocks.monitorData.ledgerRepairRequired = { k1: { ...repair.k1 } };
+    mocks.saveUnifiedStorageDurably
+      .mockResolvedValueOnce({ ok: false, backend: "indexedDB", reason: "idb_flush_failed" })
+      .mockResolvedValueOnce({ ok: false, backend: "indexedDB", reason: "rollback_flush_failed" })
+      .mockResolvedValueOnce({ ok: true, backend: "indexedDB", reason: "blocker_saved" });
+
+    const result = await clearLedgerRepairRequired("k1", { nowMs: 900 });
+
+    expect(result).toMatchObject({ ok: false, reason: "recovery_operation_rollback_save_failed" });
+    expect(result.recovery).toMatchObject({
+      operation: "clearLedgerRepairRequired",
+      reason: "rollback_durable_save_failed",
+      failureReason: "ledger_repair_clear_not_durably_saved",
+      target: { host: "k1", spoolId: "S1" },
+      createdAt: 900
+    });
+    expect(result.recoverySave).toEqual({ ok: true, backend: "indexedDB", reason: "blocker_saved" });
+    expect(mocks.monitorData.ledgerRepairRequired).toEqual(repair);
+    expect(mocks.monitorData.inferredRecoveryOperationRecoveryRequired).toEqual(result.recovery);
+    expect(mocks.saveUnifiedStorageDurably).toHaveBeenCalledTimes(3);
+
+    const blocked = await archiveMountHistoryRejectedEvents();
+    expect(blocked).toMatchObject({ ok: false, reason: "recovery_required" });
+    expect(mocks.saveUnifiedStorageDurably).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("clearInferredRecoveryOperationRecoveryRequired", () => {
+  it("確認済みの recovery operation blocker を解除し audit event を保存する", async () => {
+    mocks.monitorData.inferredRecoveryOperationRecoveryRequired = {
+      operation: "clearLedgerRepairRequired",
+      reason: "rollback_durable_save_failed",
+      createdAt: 900
+    };
+
+    const result = await clearInferredRecoveryOperationRecoveryRequired({ actor: "operator", note: "checked", nowMs: 950 });
+
+    expect(result).toMatchObject({ ok: true, reason: "recovery_operation_recovery_cleared" });
+    expect(mocks.monitorData.inferredRecoveryOperationRecoveryRequired).toBeNull();
+    expect(mocks.monitorData.inferredRecoveryEvents[0]).toMatchObject({
+      type: "recovery-operation-recovery-cleared",
+      actor: "operator",
+      note: "checked",
+      createdAt: 950
+    });
   });
 });
 

--- a/tests/unit/dashboard_relay_bridge_filament_ops.test.js
+++ b/tests/unit/dashboard_relay_bridge_filament_ops.test.js
@@ -17,6 +17,7 @@ vi.mock("../../3dp_lib/dashboard_data.js", () => ({
     hostSpoolMap: {},
     mountHistory: [],
     inferredDecisionRecoveryRequired: null,
+    inferredRecoveryOperationRecoveryRequired: null,
     inferredRecoveryEvents: [],
     ledgerRepairRequired: {},
     mountHistoryRejectedEvents: [],
@@ -119,6 +120,10 @@ describe("relayBroadcastIfNeeded — #418 recovery 診断同期", () => {
       action: "confirm",
       reason: "rollback_durable_save_failed",
     };
+    monitorData.inferredRecoveryOperationRecoveryRequired = {
+      operation: "clearLedgerRepairRequired",
+      reason: "rollback_durable_save_failed",
+    };
     monitorData.ledgerRepairRequired = {
       k1: { spoolId: "S1", status: "ambiguous", detectedAtEpochMs: 123 },
     };
@@ -134,6 +139,7 @@ describe("relayBroadcastIfNeeded — #418 recovery 診断同期", () => {
 
     const snapshot = globalThis.window.electronAPI.relaySendSnapshot.mock.calls[0][1];
     expect(snapshot.inferredDecisionRecoveryRequired).toEqual(monitorData.inferredDecisionRecoveryRequired);
+    expect(snapshot.inferredRecoveryOperationRecoveryRequired).toEqual(monitorData.inferredRecoveryOperationRecoveryRequired);
     expect(snapshot.inferredRecoveryEvents).toEqual(monitorData.inferredRecoveryEvents);
     expect(snapshot.ledgerRepairRequired).toEqual(monitorData.ledgerRepairRequired);
     expect(snapshot.mountHistoryRejectedEvents).toEqual(monitorData.mountHistoryRejectedEvents);
@@ -142,6 +148,7 @@ describe("relayBroadcastIfNeeded — #418 recovery 診断同期", () => {
 
     const delta = globalThis.window.electronAPI.relayBroadcast.mock.calls[0][0];
     expect(delta.shared.inferredDecisionRecoveryRequired).toEqual(monitorData.inferredDecisionRecoveryRequired);
+    expect(delta.shared.inferredRecoveryOperationRecoveryRequired).toEqual(monitorData.inferredRecoveryOperationRecoveryRequired);
     expect(delta.shared.inferredRecoveryEvents).toEqual(monitorData.inferredRecoveryEvents);
     expect(delta.shared.ledgerRepairRequired).toEqual(monitorData.ledgerRepairRequired);
     expect(delta.shared.mountHistoryRejectedEvents).toEqual(monitorData.mountHistoryRejectedEvents);

--- a/tests/unit/dashboard_storage_durable.test.js
+++ b/tests/unit/dashboard_storage_durable.test.js
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => ({
     hostObservationCurrent: {},
     inferredCandidateStore: {},
     inferredDecisionRecoveryRequired: null,
+    inferredRecoveryOperationRecoveryRequired: null,
     inferredRecoveryEvents: [],
     pendingUnattributedUsage: [],
     pendingUnattributedUsageArchive: {},
@@ -79,6 +80,7 @@ beforeEach(async () => {
   mocks.monitorData.machines = { k1: { storedData: {}, printStore: { history: [] }, runtimeData: { transient: true } } };
   mocks.monitorData.inferredCandidateStore = { "ic-a": { candidateHash: "ic-a", usedMm: 1200 } };
   mocks.monitorData.inferredDecisionRecoveryRequired = { candidateHash: "ic-a", reason: "rollback_durable_save_failed" };
+  mocks.monitorData.inferredRecoveryOperationRecoveryRequired = { operation: "clearLedgerRepairRequired", reason: "rollback_durable_save_failed" };
   mocks.monitorData.inferredRecoveryEvents = [{ eventId: "ir-a", type: "recovery-durable-save-retried" }];
   mocks.monitorData.hostObservationWatermark = { k1: { observationSequence: 1 } };
   mocks.queueSharedWrite.mockClear();
@@ -95,6 +97,7 @@ describe("saveUnifiedStorageDurably", () => {
     expect(result).toEqual({ ok: true, backend: "indexedDB", reason: "flushed" });
     expect(mocks.queueSharedWrite).toHaveBeenCalledWith("inferredCandidateStore", mocks.monitorData.inferredCandidateStore);
     expect(mocks.queueSharedWrite).toHaveBeenCalledWith("inferredDecisionRecoveryRequired", mocks.monitorData.inferredDecisionRecoveryRequired);
+    expect(mocks.queueSharedWrite).toHaveBeenCalledWith("inferredRecoveryOperationRecoveryRequired", mocks.monitorData.inferredRecoveryOperationRecoveryRequired);
     expect(mocks.queueSharedWrite).toHaveBeenCalledWith("inferredRecoveryEvents", mocks.monitorData.inferredRecoveryEvents);
     expect(mocks.queueSharedWrite).toHaveBeenCalledWith("hostObservationWatermark", mocks.monitorData.hostObservationWatermark);
     expect(mocks.events.indexOf("queue:inferredCandidateStore")).toBeGreaterThanOrEqual(0);

--- a/tests/unit/dashboard_storage_migration.test.js
+++ b/tests/unit/dashboard_storage_migration.test.js
@@ -43,6 +43,7 @@ const monitorData = {
   pendingUnattributedUsageArchive: {},
   inferredCandidateStore: {},
   inferredDecisionRecoveryRequired: null,
+  inferredRecoveryOperationRecoveryRequired: null,
   inferredRecoveryEvents: [],
   ledgerRepairRequired: {},
   filamentEventContext: {},
@@ -69,6 +70,7 @@ function resetMonitorData() {
   monitorData.pendingUnattributedUsageArchive = {};
   monitorData.inferredCandidateStore = {};
   monitorData.inferredDecisionRecoveryRequired = null;
+  monitorData.inferredRecoveryOperationRecoveryRequired = null;
   monitorData.inferredRecoveryEvents = [];
   monitorData.ledgerRepairRequired = {};
   monitorData.hostSpoolMap = {};
@@ -177,6 +179,11 @@ describe('v2.2.1027 追加フィールドの round-trip', () => {
       reason: "rollback_durable_save_failed",
       createdAt: 120,
     };
+    monitorData.inferredRecoveryOperationRecoveryRequired = {
+      operation: "clearLedgerRepairRequired",
+      reason: "rollback_durable_save_failed",
+      createdAt: 125,
+    };
     monitorData.inferredRecoveryEvents = [
       { eventId: "ir-a", type: "decision-recovery-cleared", createdAt: 130, actor: "operator" },
     ];
@@ -200,6 +207,7 @@ describe('v2.2.1027 追加フィールドの round-trip', () => {
     expect(monitorData.inferredCandidateStore["ic-a"].usedMm).toBe(1234);
     // #420/O6A: recovery flag と audit event も往復で保持
     expect(monitorData.inferredDecisionRecoveryRequired.reason).toBe("rollback_durable_save_failed");
+    expect(monitorData.inferredRecoveryOperationRecoveryRequired.operation).toBe("clearLedgerRepairRequired");
     expect(monitorData.inferredRecoveryEvents).toEqual([
       { eventId: "ir-a", type: "decision-recovery-cleared", createdAt: 130, actor: "operator" },
     ]);
@@ -228,6 +236,11 @@ describe('v2.2.1027 追加フィールドの round-trip', () => {
       reason: "old",
       createdAt: 10,
     };
+    monitorData.inferredRecoveryOperationRecoveryRequired = {
+      operation: "old-operation",
+      reason: "old",
+      createdAt: 10,
+    };
     monitorData.inferredRecoveryEvents = [
       { eventId: "ir-a", type: "recovery-durable-save-retried", createdAt: 20 },
     ];
@@ -238,6 +251,11 @@ describe('v2.2.1027 追加フィールドの round-trip', () => {
         reason: "rollback_durable_save_failed",
         createdAt: 30,
       },
+      inferredRecoveryOperationRecoveryRequired: {
+        operation: "clearLedgerRepairRequired",
+        reason: "rollback_durable_save_failed",
+        createdAt: 35,
+      },
       inferredRecoveryEvents: [
         { eventId: "ir-a", type: "recovery-durable-save-retried", createdAt: 20 },
         { eventId: "ir-b", type: "decision-recovery-cleared", createdAt: 40 },
@@ -245,6 +263,7 @@ describe('v2.2.1027 追加フィールドの round-trip', () => {
     });
 
     expect(monitorData.inferredDecisionRecoveryRequired.candidateHash).toBe("ic-new");
+    expect(monitorData.inferredRecoveryOperationRecoveryRequired.operation).toBe("clearLedgerRepairRequired");
     expect(monitorData.inferredRecoveryEvents.map(event => event.eventId)).toEqual(["ir-a", "ir-b"]);
   });
 


### PR DESCRIPTION
## Summary
- Add a persistent O6 recovery-operation blocker when a recovery mutation save fails and the rollback save also fails.
- Block normal O5/O6 ledger-changing operations while either O5 decision recovery or O6 recovery-operation recovery is active, while keeping retry/clear recovery paths available.
- Persist, import/export, relay-sync, and render the new recovery blocker in the Candidate Center recovery surface.
- Make ledger repair clearance fail-closed by allowing only current mount statuses `ok` and `none`.

## Root Cause
The O6 rollback path restored memory state after a failed save, but if the rollback state could not be durably saved, it returned an error without leaving a persistent blocker. That allowed later recovery or decision operations to proceed while the authoritative storage state was uncertain. The ledger repair clear path also rejected only known bad statuses, which made unknown future statuses clearable by default.

## Validation
- `npx vitest run tests/unit/dashboard_inferred_recovery_ops.test.js tests/unit/dashboard_inferred_candidate_decision.test.js tests/unit/dashboard_inferred_candidate_view.test.js tests/unit/dashboard_inferred_candidate_ui.test.js tests/unit/dashboard_storage_durable.test.js tests/unit/dashboard_storage_migration.test.js tests/unit/dashboard_relay_bridge_filament_ops.test.js tests/unit/dashboard_client_sync_filament_sync.test.js --silent`
- `npx eslint 3dp_lib/dashboard_data.js 3dp_lib/dashboard_storage.js 3dp_lib/dashboard_storage_idb.js 3dp_lib/dashboard_relay_bridge.js 3dp_lib/dashboard_client_sync.js 3dp_lib/dashboard_inferred_candidate_decision.js 3dp_lib/dashboard_inferred_recovery_ops.js 3dp_lib/dashboard_inferred_candidate_view.js 3dp_lib/dashboard_inferred_candidate_ui.js --quiet`
- `npx vitest run --silent`

## Notes
- Full `npm run lint -- --quiet` still reports pre-existing issues outside this PR scope in `dashboard_storage_ui.js` and `dashboard_ui_mapping.js`.
- `npm run test:e2e` timed out locally while existing/manual `3dpmon.exe` processes were present; no running production process was terminated.
