### PR TITLE
Reconcile inferred ledger remaining balances

### DIFF
--- a/3dp_lib/dashboard_client_sync.js
+++ b/3dp_lib/dashboard_client_sync.js
@@ -22,9 +22,9 @@
  * - {@link sendRelayCommand}：親経由でプリンタにコマンド送信
  * - {@link sendRelayFilament}：親経由でフィラメント操作
  *
- * @version 1.390.1274 (PR #424)
+ * @version 1.390.1279 (PR #426)
  * @since   1.390.820 (PR #367)
- * @lastModified 2026-08-02 18:33:44
+ * @lastModified 2026-08-04 11:50:46
  * -----------------------------------------------------------
  */
 
@@ -44,6 +44,19 @@ let _updateStoredDataToDOM = null;
 import("./dashboard_ui.js")
   .then((m) => { _updateStoredDataToDOM = m.updateStoredDataToDOM; })
   .catch(() => { /* 非ブラウザ環境では未解決のまま（描画不要） */ });
+
+/**
+ * 親から受信した負残量表示モードを正規化する。
+ *
+ * @private
+ * @param {*} value - relay snapshot/delta の表示モード。
+ * @returns {?string} `"show-negative"` / `"clamp-zero"`。不明値は null。
+ */
+function _normalizeNegativeRemainingDisplayMode(value) {
+  if (value === "clamp-zero") return "clamp-zero";
+  if (value === "show-negative" || value === "show" || value === "signed") return "show-negative";
+  return null;
+}
 
 /** リレーモード: null=未検出, "parent"=親, "readonly"=子閲覧, "satellite"=子操作 */
 let _relayMode = null;
@@ -582,6 +595,12 @@ function _applySnapshot(state) {
     if (btz) monitorData.appSettings.businessTimeZone = btz;
     const ltz = normalizeTimeZone(state.appSettings.legacyHistoryTimeZone);
     if (ltz) monitorData.appSettings.legacyHistoryTimeZone = ltz;
+    const negativeMode = _normalizeNegativeRemainingDisplayMode(
+      state.appSettings.negativeRemainingDisplayMode
+        ?? state.appSettings.negativeRemainingDisplay
+        ?? state.appSettings.filamentRemainingDisplayMode
+    );
+    if (negativeMode) monitorData.appSettings.negativeRemainingDisplayMode = negativeMode;
   }
 
   // ★ フィラメントデータ: 親が唯一の権威 — 受信内容で全置換する。
@@ -699,6 +718,10 @@ function _applyDelta(msg) {
     if ("appSettingsBusinessTimeZone" in msg.shared) {
       const btz = normalizeTimeZone(msg.shared.appSettingsBusinessTimeZone);
       if (btz) monitorData.appSettings.businessTimeZone = btz;
+    }
+    if ("appSettingsNegativeRemainingDisplayMode" in msg.shared) {
+      const negativeMode = _normalizeNegativeRemainingDisplayMode(msg.shared.appSettingsNegativeRemainingDisplayMode);
+      if (negativeMode) monitorData.appSettings.negativeRemainingDisplayMode = negativeMode;
     }
   }
 

--- a/3dp_lib/dashboard_data.js
+++ b/3dp_lib/dashboard_data.js
@@ -19,9 +19,9 @@
  * - {@link getDisplayValue}：表示用値取得
  * - {@link markAllKeysDirty}：全キーを変更済みにマーク
  *
-* @version 1.390.1278 (PR #426)
+* @version 1.390.1279 (PR #426)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-08-04 09:22:41
+* @lastModified 2026-08-04 11:50:46
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -214,7 +214,7 @@ export const monitorData = {
     httpPort: 80,         // HTTP ポート（デフォルト。印刷履歴・ファイル取得用）
     relayPromotePin: "",  // リレー操作モード昇格PIN（空=確認のみ）。親でのみ設定・参照可
     filamentUnit: "m",    // 使用量表示単位 "m" | "mm"（印刷履歴・ファイル一覧共通トグル）
-    negativeRemainingDisplayMode: "show", // 負残量の表示方針 "show" | "clamp-zero"。台帳内部値は常に負値を保持する
+    negativeRemainingDisplayMode: "show-negative", // 負残量の表示方針 "show-negative" | "clamp-zero"。旧値 "show"/"signed" は読取互換
     // ★ レビュー(時計衛生 P1): 日次/月次集計の業務タイムゾーン（IANA）。親権威の永続設定で、
     //   リレーで子へミラーする。親起動時に未設定なら解決済みローカルへ確定・保存する。
     businessTimeZone: null,

--- a/3dp_lib/dashboard_data.js
+++ b/3dp_lib/dashboard_data.js
@@ -19,9 +19,9 @@
  * - {@link getDisplayValue}：表示用値取得
  * - {@link markAllKeysDirty}：全キーを変更済みにマーク
  *
-* @version 1.390.1274 (PR #424)
+* @version 1.390.1278 (PR #426)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-08-02 18:33:44
+* @lastModified 2026-08-04 09:22:41
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -182,7 +182,8 @@ export function ensureMachineData(host) {
  *     autoConnect: boolean,
  *     wsDest: string,
  *     cameraToggle: boolean,
- *     notificationSettings: Record<string, any>
+ *     notificationSettings: Record<string, any>,
+ *     negativeRemainingDisplayMode: string
  *   },
  *   machines: Record<string, MachineData>,
  *   filamentSpools: Array<Object>,
@@ -213,6 +214,7 @@ export const monitorData = {
     httpPort: 80,         // HTTP ポート（デフォルト。印刷履歴・ファイル取得用）
     relayPromotePin: "",  // リレー操作モード昇格PIN（空=確認のみ）。親でのみ設定・参照可
     filamentUnit: "m",    // 使用量表示単位 "m" | "mm"（印刷履歴・ファイル一覧共通トグル）
+    negativeRemainingDisplayMode: "show", // 負残量の表示方針 "show" | "clamp-zero"。台帳内部値は常に負値を保持する
     // ★ レビュー(時計衛生 P1): 日次/月次集計の業務タイムゾーン（IANA）。親権威の永続設定で、
     //   リレーで子へミラーする。親起動時に未設定なら解決済みローカルへ確定・保存する。
     businessTimeZone: null,

--- a/3dp_lib/dashboard_filament_ledger.js
+++ b/3dp_lib/dashboard_filament_ledger.js
@@ -26,9 +26,9 @@
  * - {@link getOpenFilamentEvent}：未解決のイベント文脈を取得（ADR-0005）
  * - {@link resolveFilamentEvent}：イベント文脈を解決済みにする（ADR-0005）
  *
- * @version 2.2.1027
+ * @version 1.390.1278 (PR #426)
  * @since   2.2.1012
- * @lastModified 2026-06-17
+ * @lastModified 2026-08-04 09:22:41
  * -----------------------------------------------------------
  */
 
@@ -49,6 +49,26 @@ import { wallNowMs, randomEventId } from "./dashboard_time.js";
 function _clamp(min, v, max) {
   if (!Number.isFinite(v)) return min;
   return Math.max(min, Math.min(v, max));
+}
+
+/**
+ * 残量台帳値を上限だけで制限する。
+ *
+ * 【詳細説明】
+ * - `remainingLengthMm` は監査上、0 未満の値を保持できる必要がある。
+ * - 総量を超える残量は従来どおり上限へ丸めるが、下限 0 のクランプは行わない。
+ *
+ * @private
+ * @function _capLedgerRemaining
+ * @param {number} value - 残量候補 mm。
+ * @param {number} cap - 許容上限 mm。
+ * @returns {number} 上限だけを適用した残量 mm。
+ */
+function _capLedgerRemaining(value, cap) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return 0;
+  const max = Number(cap);
+  return Number.isFinite(max) && max > 0 ? Math.min(n, max) : n;
 }
 
 /**
@@ -662,7 +682,7 @@ export function deriveSpoolRemaining(spoolId, { liveUsedMm = 0, excludeJobId = n
 
   if (activeIvs.length === 0) {
     // 装着履歴が無い → 現在値をそのまま維持（total へリセットしない）
-    const remaining = _clamp(0, _base - (Number(liveUsedMm) || 0), _cap);
+    const remaining = _capLedgerRemaining(_base - (Number(liveUsedMm) || 0), _cap);
     return { remainingMm: remaining, verified: false, mode: "none", usedMm: 0 };
   }
 
@@ -670,7 +690,7 @@ export function deriveSpoolRemaining(spoolId, { liveUsedMm = 0, excludeJobId = n
   //   誤った区間を選んで減算するより、現在値を維持して未検証にする方が安全（台帳が曖昧な状態）。
   const openIvs = activeIvs.filter(iv => iv.untilJobId == null);
   if (hardDiag.length > 0 || openIvs.length >= 2) {
-    const remaining = _clamp(0, _base - (Number(liveUsedMm) || 0), _cap);
+    const remaining = _capLedgerRemaining(_base - (Number(liveUsedMm) || 0), _cap);
     return {
       remainingMm: remaining, verified: false,
       mode: hardDiag.length > 0 ? "halt-corrupt" : "halt-ambiguous", usedMm: 0
@@ -727,11 +747,11 @@ export function deriveSpoolRemaining(spoolId, { liveUsedMm = 0, excludeJobId = n
   const anchor = Number(anchorIv.anchorRemainingMm) || 0;
   let remaining = anchor - used;
 
-  // clamp(0, remaining, total>0?total:anchor)。liveUsedMm はオーバーレイで追加減算。
+  // 上限だけを total に制限する。負残量は監査対象の台帳値として保持する。
   const cap = total > 0 ? total : Math.max(anchor, 0);
-  remaining = _clamp(0, remaining, cap);
+  remaining = _capLedgerRemaining(remaining, cap);
   if (liveUsedMm > 0) {
-    remaining = _clamp(0, remaining - liveUsedMm, cap);
+    remaining = _capLedgerRemaining(remaining - liveUsedMm, cap);
   }
 
   return { remainingMm: remaining, verified, mode: "anchor", usedMm: used };
@@ -883,7 +903,7 @@ export function recomputeSpoolFromManualEdit(spoolId, { ts } = {}) {
       used += attributedUsed(j, spoolId);
     }
   }
-  const after = _clamp(0, total - used, total);
+  const after = _capLedgerRemaining(total - used, total);
   spool.remainingLengthMm = after;
   spool._remainingVerified = true; // 手動編集＝権威
   if (ts != null) spool.updatedAt = ts;

--- a/3dp_lib/dashboard_filament_ledger.js
+++ b/3dp_lib/dashboard_filament_ledger.js
@@ -26,9 +26,9 @@
  * - {@link getOpenFilamentEvent}：未解決のイベント文脈を取得（ADR-0005）
  * - {@link resolveFilamentEvent}：イベント文脈を解決済みにする（ADR-0005）
  *
- * @version 1.390.1278 (PR #426)
+ * @version 1.390.1279 (PR #426)
  * @since   2.2.1012
- * @lastModified 2026-08-04 09:22:41
+ * @lastModified 2026-08-04 11:50:46
  * -----------------------------------------------------------
  */
 
@@ -850,6 +850,54 @@ function _reanchorOpenMount(host, spoolId, anchorRemainingMm, sinceJobId, ts) {
 }
 
 /**
+ * 手動再計算による残量補正を監査履歴へ追記し、O7 用 baseline を更新する。
+ *
+ * 【詳細説明】
+ * - 負残量は台帳上の正常な signed value として保存する。
+ * - 手動履歴帰属を権威として残量を再計算した時点を baseline にし、O7 が古い
+ *   `usedLengthLog` を二重に差し引かないようにする。
+ * - 監査eventは append-only で `usageHistory` へ残す。
+ *
+ * @private
+ * @param {Object} spool - 補正対象スプール。
+ * @param {number} beforeMm - 補正前の台帳残量。
+ * @param {number} afterMm - 補正後の台帳残量。
+ * @param {{ts?:number,reason?:string,actor?:string,source?:string}} [options] - 監査メタデータ。
+ * @returns {?Object} 追加した監査event。変更が無い場合は null。
+ */
+function _recordManualRemainingAdjustment(spool, beforeMm, afterMm, options = {}) {
+  if (!spool) return null;
+  if (!Number.isFinite(beforeMm) || !Number.isFinite(afterMm)) return null;
+  if (Math.abs(beforeMm - afterMm) <= 0.001) return null;
+  if (!Array.isArray(monitorData.usageHistory)) monitorData.usageHistory = [];
+  const now = Number.isFinite(Number(options.ts)) ? Number(options.ts) : wallNowMs();
+  const event = {
+    usageId: randomEventId("manual-remaining"),
+    type: "manual-remaining-adjustment",
+    spoolId: spool.id,
+    spoolSerial: spool.serialNo,
+    hostname: spool.hostname || null,
+    beforeMm,
+    afterMm,
+    deltaMm: afterMm - beforeMm,
+    reason: options.reason || "manual-history-recompute",
+    actor: options.actor || "user",
+    source: options.source || "recomputeSpoolFromManualEdit",
+    createdAt: now
+  };
+  monitorData.usageHistory.push(event);
+  monitorData.usageHistoryRev = (monitorData.usageHistoryRev || 0) + 1;
+  spool.remainingLedgerBaseline = {
+    remainingLengthMm: afterMm,
+    usedLengthLogIndex: Array.isArray(spool.usedLengthLog) ? spool.usedLengthLog.length : 0,
+    createdAt: now,
+    source: event.type,
+    eventId: event.usageId
+  };
+  return event;
+}
+
+/**
  * 手動の履歴フィラメント編集を「権威」として、スプール残量を総量基準で再計算する。
  *
  * 【ユーザー選択（Option 1）】手動で履歴の帰属(filamentInfo)を変更/指定したとき、
@@ -907,6 +955,11 @@ export function recomputeSpoolFromManualEdit(spoolId, { ts } = {}) {
   spool.remainingLengthMm = after;
   spool._remainingVerified = true; // 手動編集＝権威
   if (ts != null) spool.updatedAt = ts;
+  _recordManualRemainingAdjustment(spool, before, after, {
+    ts,
+    reason: "manual-history-recompute",
+    source: "recomputeSpoolFromManualEdit"
+  });
 
   // ★ 再アンカー: 装着中スプールは開区間 mount を貼り直して権威値を保持
   const hostSpoolMap = monitorData.hostSpoolMap || {};

--- a/3dp_lib/dashboard_filament_manager.js
+++ b/3dp_lib/dashboard_filament_manager.js
@@ -19,9 +19,9 @@
  * 【公開関数一覧】
  * - {@link showFilamentManager}：管理モーダルを開く
  *
-* @version 1.390.1278 (PR #426)
+* @version 1.390.1279 (PR #426)
 * @since   1.390.228 (PR #102)
-* @lastModified 2026-08-04 09:22:41
+* @lastModified 2026-08-04 11:50:46
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -2603,12 +2603,13 @@ function createEditorContent(onDone) {
       note: noteIn.value,
       isFavorite: favIn.checked
     };
-    // ★ D1: 残量バリデーション（0未満やtotal超過を防止）
+    // ★ D1: 残量バリデーション（total超過のみ防止）
+    // 台帳内部では負残量を監査可能な真値として保存するため、0未満への丸めは表示層だけで行う。
     if (data.filamentCurrentLength != null) {
       const curVal = Number(data.filamentCurrentLength);
       const totVal = Number(data.filamentTotalLength || 0);
       if (!isNaN(curVal) && !isNaN(totVal)) {
-        data.filamentCurrentLength = Math.max(0, Math.min(curVal, totVal));
+        data.filamentCurrentLength = Math.min(curVal, totVal);
       }
     }
     // ★ D2: フィールド名マッピング（remainingLengthMm が未設定の場合のみ）

--- a/3dp_lib/dashboard_filament_manager.js
+++ b/3dp_lib/dashboard_filament_manager.js
@@ -19,9 +19,9 @@
  * 【公開関数一覧】
  * - {@link showFilamentManager}：管理モーダルを開く
  *
-* @version 1.390.1262 (PR #415)
+* @version 1.390.1278 (PR #426)
 * @since   1.390.228 (PR #102)
-* @lastModified 2026-07-25 14:25:00
+* @lastModified 2026-08-04 09:22:41
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -45,6 +45,8 @@ import {
   getSpoolStateLabel,
   formatSpoolDisplayId,
   formatFilamentAmount,
+  formatRemainingFilamentAmount,
+  displayRemainingLengthMm,
   buildSpoolAnalytics,
   buildWasteReport,
   getSpoolById,
@@ -215,7 +217,7 @@ function spoolToPreviewOverrides(sp) {
  * @returns {string} HTML 文字列
  */
 function renderRemainBar(remaining, total, color) {
-  const pct = total > 0 ? Math.min(100, (remaining / total) * 100) : 0;
+  const pct = total > 0 ? Math.max(0, Math.min(100, (remaining / total) * 100)) : 0;
   const barColor = color || "#22C55E";
   return `<span class="remain-bar"><span class="remain-bar-fill" style="width:${pct.toFixed(1)}%;background:${barColor}"></span></span>${pct.toFixed(0)}%`;
 }
@@ -341,12 +343,13 @@ function createDashboardContent(hostname, switchTab) {
 
         const infoBox = document.createElement("div");
         infoBox.className = "fm-mounted-info";
-        const pct = spool.totalLengthMm > 0
-          ? ((spool.remainingLengthMm / spool.totalLengthMm) * 100).toFixed(0)
+        const displayRemainingMm = displayRemainingLengthMm(spool.remainingLengthMm);
+        const pct = spool.totalLengthMm > 0 && displayRemainingMm != null
+          ? ((displayRemainingMm / spool.totalLengthMm) * 100).toFixed(0)
           : 0;
         const colorSwatch = `<span class="color-swatch color-swatch-md" style="background:${spool.filamentColor || spool.color || "#ccc"}"></span>`;
         // 残量を人間可読フォーマットで表示
-        const remainFmt = formatFilamentAmount(spool.remainingLengthMm, spool);
+        const remainFmt = formatRemainingFilamentAmount(spool.remainingLengthMm, spool);
         // 枯渇予測
         const analytics = buildSpoolAnalytics(spool.id);
         let predLine = "";
@@ -361,7 +364,7 @@ function createDashboardContent(hostname, switchTab) {
           `<div><strong>${formatSpoolDisplayId(spool)}</strong> ${spool.name || ""}</div>` +
           `<div>${colorSwatch}${spool.colorName || ""} / ${spool.materialName || spool.material || ""}</div>` +
           `<div style="margin:2px 0">${remainFmt.display} (${pct}%)</div>` +
-          `<div>${renderRemainBar(spool.remainingLengthMm, spool.totalLengthMm, spool.filamentColor || spool.color)}</div>` +
+          `<div>${renderRemainBar(displayRemainingMm ?? spool.remainingLengthMm, spool.totalLengthMm, spool.filamentColor || spool.color)}</div>` +
           predLine;
 
         const btnWrap = document.createElement("div");
@@ -447,8 +450,9 @@ function createDashboardContent(hostname, switchTab) {
           enableDrag: false
         });
 
-        const pct = sp.totalLengthMm > 0
-          ? ((sp.remainingLengthMm / sp.totalLengthMm) * 100).toFixed(0)
+        const displayRemainingMm = displayRemainingLengthMm(sp.remainingLengthMm);
+        const pct = sp.totalLengthMm > 0 && displayRemainingMm != null
+          ? ((displayRemainingMm / sp.totalLengthMm) * 100).toFixed(0)
           : 0;
         const label = document.createElement("div");
         label.innerHTML = `${formatSpoolDisplayId(sp)}<br>${pct}%`;
@@ -1359,8 +1363,9 @@ function createRegisteredContent(openEditor, hostname) {
 
       // 残量バー
       const remainTd = document.createElement("td");
+      const displayRemainingMm = displayRemainingLengthMm(sp.remainingLengthMm);
       remainTd.innerHTML = renderRemainBar(
-        sp.remainingLengthMm || 0,
+        displayRemainingMm ?? sp.remainingLengthMm ?? 0,
         sp.totalLengthMm || 0,
         sp.filamentColor || sp.color
       );
@@ -1627,7 +1632,7 @@ function createRegisteredContent(openEditor, hostname) {
     drilldown.appendChild(hdr);
 
     // サマリカード
-    const remainFmt = formatFilamentAmount(analytics.remainMm, sp);
+    const remainFmt = formatRemainingFilamentAmount(analytics.remainMm, sp);
     const consumedFmt = formatFilamentAmount(analytics.consumedMm, sp);
     const cards = document.createElement("div");
     cards.className = "stat-cards";
@@ -1668,7 +1673,8 @@ function createRegisteredContent(openEditor, hostname) {
         const cumulativeData = [];
         for (let i = 0; i < log.length; i++) {
           remaining -= (log[i].used || 0);
-          cumulativeData.push(Math.max(0, remaining) / 1000); // m 単位
+          const displayRemainingMm = displayRemainingLengthMm(remaining);
+          cumulativeData.push((displayRemainingMm ?? remaining) / 1000); // m 単位
         }
         new Chart(canvas.getContext("2d"), {
           type: "line",
@@ -1854,7 +1860,7 @@ function createHistoryContent() {
       const remainTd = document.createElement("td");
       remainTd.style.textAlign = "right";
       const remVal = u.currentLength ?? u.startLength ?? null;
-      remainTd.textContent = remVal != null ? formatFilamentAmount(remVal, sp).display : "--";
+      remainTd.textContent = remVal != null ? formatRemainingFilamentAmount(remVal, sp).display : "--";
       tr.appendChild(remainTd);
 
       // 種別
@@ -2087,8 +2093,9 @@ function createReportContent() {
     for (const sp of activeSpools) {
       const a = buildSpoolAnalytics(sp.id);
       if (!a) continue;
-      const remainFmt = formatFilamentAmount(a.remainMm, sp);
-      const remainPct = a.totalMm > 0 ? ((a.remainMm / a.totalMm) * 100).toFixed(0) : "?";
+      const remainFmt = formatRemainingFilamentAmount(a.remainMm, sp);
+      const displayRemainingMm = displayRemainingLengthMm(a.remainMm);
+      const remainPct = a.totalMm > 0 && displayRemainingMm != null ? ((displayRemainingMm / a.totalMm) * 100).toFixed(0) : "?";
       const tr = document.createElement("tr");
       tr.innerHTML = `<td>${formatSpoolDisplayId(sp)} ${sp.name || ""}</td>` +
         `<td>${a.material}</td>` +

--- a/3dp_lib/dashboard_filament_manager.js
+++ b/3dp_lib/dashboard_filament_manager.js
@@ -19,9 +19,9 @@
  * 【公開関数一覧】
  * - {@link showFilamentManager}：管理モーダルを開く
  *
-* @version 1.390.1279 (PR #426)
+* @version 1.390.1280 (PR #426)
 * @since   1.390.228 (PR #102)
-* @lastModified 2026-08-04 11:50:46
+* @lastModified 2026-08-04 12:15:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -43,6 +43,8 @@ import {
   restoreSpool,
   getSpoolState,
   getSpoolStateLabel,
+  getSpoolBalanceState,
+  getSpoolBalanceStateLabel,
   formatSpoolDisplayId,
   formatFilamentAmount,
   formatRemainingFilamentAmount,
@@ -53,7 +55,8 @@ import {
   confirmInferredSpool,
   revertInferredSpool,
   mountNewSpoolFromPreset,
-  SPOOL_STATE
+  SPOOL_STATE,
+  SPOOL_BALANCE_STATE
 } from "./dashboard_spool.js";
 import {
   getInventory,
@@ -232,6 +235,19 @@ function renderRemainBar(remaining, total, color) {
 function renderStateBadge(state) {
   const label = getSpoolStateLabel(state);
   return `<span class="spool-state-badge spool-state-${state}">${label}</span>`;
+}
+
+/**
+ * signed 残量状態バッジ HTML を生成する。
+ *
+ * @private
+ * @param {string} balanceState - SPOOL_BALANCE_STATE の値
+ * @returns {string} HTML 文字列
+ */
+function renderBalanceBadge(balanceState) {
+  if (balanceState !== SPOOL_BALANCE_STATE.OVERDRAWN) return "";
+  const label = getSpoolBalanceStateLabel(balanceState);
+  return ` <span class="spool-state-badge spool-balance-${balanceState}">${label}</span>`;
 }
 
 /**
@@ -1329,7 +1345,8 @@ function createRegisteredContent(openEditor, hostname) {
 
       // 状態バッジ + 装着先統合
       const stateTd = document.createElement("td");
-      let stateHtml = renderStateBadge(state);
+      const balanceState = getSpoolBalanceState(sp);
+      let stateHtml = renderStateBadge(state) + renderBalanceBadge(balanceState);
       // ★ ADR-0005 P6: 暫定推定スプールは「推定」バッジを前置（確認/訂正待ち）
       if (sp.inferred) {
         stateHtml = `<span class="spool-state-badge" style="background:#f59e0b;color:#fff" title="推定で自動投入。確認/訂正してください">推定</span> ` + stateHtml;

--- a/3dp_lib/dashboard_inferred_candidate_ledger.js
+++ b/3dp_lib/dashboard_inferred_candidate_ledger.js
@@ -19,9 +19,9 @@
  * - {@link undoInferredCandidateLedger}：確定済み candidate の台帳反映を取り消す
  * - {@link rollbackInferredCandidateLedger}：確定反映前 snapshot へメモリ状態を戻す
  *
- * @version 1.390.1269 (PR #419)
+ * @version 1.390.1278 (PR #426)
  * @since   1.390.1261 (PR #414)
- * @lastModified 2026-08-01 19:47:47
+ * @lastModified 2026-08-04 09:22:41
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -112,17 +112,18 @@ function _positiveMm(value) {
  *
  * 【詳細説明】
  * - O5 の Confirm/Reassign は確定台帳を書き換えるため、残量不明の spool には適用しない。
- * - null/undefined/空文字/NaN/負値は不明扱いで null を返す。
+ * - null/undefined/空文字/NaN は不明扱いで null を返す。
+ * - 負値は「使い切り後も実際に印刷できた量」を保持する監査値として有効に扱う。
  *
  * @private
  * @function _remainingOrNull
  * @param {*} value - spool.remainingLengthMm 相当の値。
- * @returns {?number} 0 以上の有限値。不明値は null。
+ * @returns {?number} 有限値。不明値は null。
  */
 function _remainingOrNull(value) {
   if (value == null || value === "") return null;
   const n = Number(value);
-  return Number.isFinite(n) && n >= 0 ? n : null;
+  return Number.isFinite(n) ? n : null;
 }
 
 /**
@@ -614,10 +615,6 @@ export function applyInferredCandidateLedger(candidateRecord, targetSpoolId, opt
   const debits = _candidateDebits(candidateRecord);
   const total = _validateDebitTotal(candidateRecord, debits);
   if (!total.ok) return { ok: false, reason: total.reason, snapshot: null, spool };
-  if (remaining < total.usedMm) {
-    return { ok: false, reason: "confirmed_remaining_insufficient", snapshot: null, spool };
-  }
-
   const byKey = _historyIndexByObservationKey(history);
   const updates = [];
   const seenIndexes = new Set();
@@ -666,7 +663,8 @@ export function applyInferredCandidateLedger(candidateRecord, targetSpoolId, opt
   }
   const historyAfter = updates.map(item => _captureHistoryAfter(item.entry, item.debit.observationKey));
 
-  spool.remainingLengthMm = Math.max(0, remaining - total.usedMm);
+  // 台帳内部値は負残量を保持する。見た目だけの 0 クロップは表示層で行う。
+  spool.remainingLengthMm = remaining - total.usedMm;
   if (!Array.isArray(spool.usedLengthLog)) spool.usedLengthLog = [];
   const event = {
     eventId: options.eventId || randomEventId("icd"),

--- a/3dp_lib/dashboard_inferred_candidate_ledger.js
+++ b/3dp_lib/dashboard_inferred_candidate_ledger.js
@@ -19,9 +19,9 @@
  * - {@link undoInferredCandidateLedger}：確定済み candidate の台帳反映を取り消す
  * - {@link rollbackInferredCandidateLedger}：確定反映前 snapshot へメモリ状態を戻す
  *
- * @version 1.390.1278 (PR #426)
+ * @version 1.390.1279 (PR #426)
  * @since   1.390.1261 (PR #414)
- * @lastModified 2026-08-04 09:22:41
+ * @lastModified 2026-08-04 11:50:46
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -664,7 +664,8 @@ export function applyInferredCandidateLedger(candidateRecord, targetSpoolId, opt
   const historyAfter = updates.map(item => _captureHistoryAfter(item.entry, item.debit.observationKey));
 
   // 台帳内部値は負残量を保持する。見た目だけの 0 クロップは表示層で行う。
-  spool.remainingLengthMm = remaining - total.usedMm;
+  const remainingAfterMm = remaining - total.usedMm;
+  spool.remainingLengthMm = remainingAfterMm;
   if (!Array.isArray(spool.usedLengthLog)) spool.usedLengthLog = [];
   const event = {
     eventId: options.eventId || randomEventId("icd"),
@@ -676,6 +677,11 @@ export function applyInferredCandidateLedger(candidateRecord, targetSpoolId, opt
     decisionType,
     actor,
     usedMm: total.usedMm,
+    remainingBeforeMm: remaining,
+    appliedDebitMm: total.usedMm,
+    remainingAfterMm,
+    overdrawnMm: remainingAfterMm < 0 ? Math.abs(remainingAfterMm) : 0,
+    crossedZero: remaining >= 0 && remainingAfterMm < 0,
     observationKeys: Array.isArray(candidateRecord.observationKeys) ? candidateRecord.observationKeys.map(String).sort() : [],
     historyBefore,
     historyAfter,
@@ -798,12 +804,15 @@ export function undoInferredCandidateLedger(candidateRecord, options = {}) {
     spoolId: spool.id,
     actor,
     usedMm: eventUsedMm,
+    remainingBeforeMm: remaining,
+    reversedUsedMm: eventUsedMm,
+    remainingAfterMm: remaining + eventUsedMm,
     observationKeys: Array.isArray(events[0].event.observationKeys) ? events[0].event.observationKeys.slice() : [],
     createdAt: now
   };
   if (!Array.isArray(spool.usedLengthLog)) spool.usedLengthLog = [];
   spool.usedLengthLog.push(undoEvent);
-  spool.remainingLengthMm = remaining + eventUsedMm;
+  spool.remainingLengthMm = undoEvent.remainingAfterMm;
 
   return {
     ok: true,

--- a/3dp_lib/dashboard_inferred_candidate_ui.js
+++ b/3dp_lib/dashboard_inferred_candidate_ui.js
@@ -16,9 +16,9 @@
  * 【公開関数一覧】
  * - {@link createInferredCandidateCenterContent}：フィラメント管理モーダル用 Candidate Center を生成する
  *
- * @version 1.390.1274 (PR #424)
+ * @version 1.390.1278 (PR #426)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-08-02 18:33:44
+ * @lastModified 2026-08-04 09:22:41
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -51,6 +51,7 @@ import {
   retryInferredRecoveryDurableSave
 } from "./dashboard_inferred_recovery_ops.js";
 import { showAlert } from "./dashboard_notification_manager.js";
+import { formatRemainingFilamentAmount } from "./dashboard_spool.js";
 import { showConfirmDialog } from "./dashboard_ui_confirm.js";
 import { createEmptyState } from "./dashboard_ui_components.js";
 
@@ -82,7 +83,7 @@ const REASON_LABELS = Object.freeze({
   target_spool_same_as_candidate: "候補スプールと同じため再割当てできません",
   target_spool_not_found: "対象スプールが見つかりません",
   confirmed_remaining_unknown: "確定残量が不明なため処理できません",
-  confirmed_remaining_insufficient: "確定残量が候補消費量を下回るため処理できません",
+  confirmed_remaining_insufficient: "確定残量が候補消費量を下回っています",
   history_entry_missing: "対象履歴が不足しています",
   history_observation_ambiguous: "対象履歴が曖昧です",
   history_already_attributed: "履歴がすでに別スプールへ確定されています",
@@ -141,7 +142,8 @@ const WARNING_LABELS = Object.freeze({
   "history-already-attributed": "対象履歴が既に帰属済みです",
   "spool-missing": "候補スプールが見つかりません",
   "remaining-unknown": "確定残量が不明です",
-  "remaining-insufficient": "確定残量が推定消費量より少ない状態です",
+  "remaining-insufficient": "確定後に負残量になります",
+  "remaining-negative-after-decision": "確定後に負残量になります",
   "low-confidence": "信頼度が低い候補です",
   "decision-recovery-required": "整合性確認が必要です",
   "relay-readonly": "この端末は閲覧専用です"
@@ -650,7 +652,7 @@ async function _reassignAction(vm) {
   const formId = `ic-reassign-${++_dialogSeq}`;
   const options = spools.map(spool => {
     const remaining = Number.isFinite(Number(spool.remainingLengthMm))
-      ? `${Math.round(Number(spool.remainingLengthMm)).toLocaleString()} mm`
+      ? formatRemainingFilamentAmount(spool.remainingLengthMm, spool).display
       : "残量不明";
     const label = `${spool.name || spool.id} / ${spool.materialName || spool.material || ""} / ${remaining}`;
     return `<option value="${_escapeHtml(spool.id)}">${_escapeHtml(label)}</option>`;

--- a/3dp_lib/dashboard_inferred_candidate_ui.js
+++ b/3dp_lib/dashboard_inferred_candidate_ui.js
@@ -16,9 +16,9 @@
  * 【公開関数一覧】
  * - {@link createInferredCandidateCenterContent}：フィラメント管理モーダル用 Candidate Center を生成する
  *
- * @version 1.390.1278 (PR #426)
+ * @version 1.390.1279 (PR #426)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-08-04 09:22:41
+ * @lastModified 2026-08-04 11:50:46
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -83,7 +83,7 @@ const REASON_LABELS = Object.freeze({
   target_spool_same_as_candidate: "候補スプールと同じため再割当てできません",
   target_spool_not_found: "対象スプールが見つかりません",
   confirmed_remaining_unknown: "確定残量が不明なため処理できません",
-  confirmed_remaining_insufficient: "確定残量が候補消費量を下回っています",
+  confirmed_remaining_insufficient: "確定後に負残量になります",
   history_entry_missing: "対象履歴が不足しています",
   history_observation_ambiguous: "対象履歴が曖昧です",
   history_already_attributed: "履歴がすでに別スプールへ確定されています",

--- a/3dp_lib/dashboard_inferred_candidate_view.js
+++ b/3dp_lib/dashboard_inferred_candidate_view.js
@@ -20,9 +20,9 @@
  * - {@link countPendingInferredCandidates}：pending candidate 件数を返す
  * - {@link buildInferredRecoverySurfaceViewModel}：recovery / repair 状態を診断表示モデルへ変換する
  *
- * @version 1.390.1276 (PR #426)
+ * @version 1.390.1278 (PR #426)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-08-03 09:22:00
+ * @lastModified 2026-08-04 09:22:41
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -36,7 +36,7 @@ import { jobObservationIdentity } from "./dashboard_history_identity.js";
 import { canSubmitLedgerDecision } from "./dashboard_inferred_candidate_decision.js";
 import { buildInferredLedgerReconciliationReport } from "./dashboard_inferred_reconciliation.js";
 import { INFERRED_CANDIDATE_STATUS } from "./dashboard_offline_candidate_store.js";
-import { formatFilamentAmount, formatSpoolDisplayId } from "./dashboard_spool.js";
+import { formatFilamentAmount, formatRemainingFilamentAmount, formatSpoolDisplayId } from "./dashboard_spool.js";
 
 /**
  * Candidate Center の status filter。
@@ -164,6 +164,29 @@ function _formatMm(mm, spool = null) {
   if (!Number.isFinite(n)) return "--";
   try {
     return formatFilamentAmount(n, spool).display;
+  } catch {
+    return `${Math.round(n).toLocaleString()} mm`;
+  }
+}
+
+/**
+ * 残量 mm 値を UI 表示用文字列へ変換する。
+ *
+ * 【詳細説明】
+ * - 台帳内部は負残量を保持できるため、残量表示には appSettings の表示モードを適用する。
+ * - 汎用使用量表示とは分け、表示だけ 0 クロップする設定でも元の台帳値は変更しない。
+ *
+ * @private
+ * @function _formatRemainingMm
+ * @param {*} mm - 残量 mm 値。
+ * @param {?Object} [spool=null] - spool context。
+ * @returns {string} 表示文字列。
+ */
+function _formatRemainingMm(mm, spool = null) {
+  const n = Number(mm);
+  if (!Number.isFinite(n)) return "--";
+  try {
+    return formatRemainingFilamentAmount(n, spool).display;
   } catch {
     return `${Math.round(n).toLocaleString()} mm`;
   }
@@ -452,14 +475,14 @@ export function buildInferredCandidateViewModel(record, options = {}) {
     : null;
   const projectedRemainingMm = confirmedRemainingMm == null || !Number.isFinite(usedMm)
     ? null
-    : Math.max(0, confirmedRemainingMm - usedMm);
+    : confirmedRemainingMm - usedMm;
   const confidenceLevel = record?.confidence?.level || "unknown";
   const jobData = _jobViewModels(record || {}, spool);
   const warnings = new Set(jobData.warningCodes);
   if (!spool) warnings.add("spool-missing");
   if (confirmedRemainingMm == null) warnings.add("remaining-unknown");
   if (confirmedRemainingMm != null && Number.isFinite(usedMm) && confirmedRemainingMm < usedMm) {
-    warnings.add("remaining-insufficient");
+    warnings.add("remaining-negative-after-decision");
   }
   if (confidenceLevel === "low") warnings.add("low-confidence");
   const hasRecoveryBlocker = !!monitorData.inferredDecisionRecoveryRequired
@@ -483,9 +506,9 @@ export function buildInferredCandidateViewModel(record, options = {}) {
     usedMm: Number.isFinite(usedMm) ? usedMm : 0,
     usedDisplay: Number.isFinite(usedMm) ? _formatMm(usedMm, spool) : "--",
     confirmedRemainingMm,
-    confirmedRemainingDisplay: confirmedRemainingMm == null ? "--" : _formatMm(confirmedRemainingMm, spool),
+    confirmedRemainingDisplay: confirmedRemainingMm == null ? "--" : _formatRemainingMm(confirmedRemainingMm, spool),
     projectedRemainingMm,
-    projectedRemainingDisplay: projectedRemainingMm == null ? "--" : _formatMm(projectedRemainingMm, spool),
+    projectedRemainingDisplay: projectedRemainingMm == null ? "--" : _formatRemainingMm(projectedRemainingMm, spool),
     confidenceLevel,
     confidenceLabel: CONFIDENCE_LABELS[confidenceLevel] || confidenceLevel,
     confidenceRank: CONFIDENCE_RANK[confidenceLevel] || 0,
@@ -699,6 +722,7 @@ export function buildInferredRecoverySurfaceViewModel(options = {}) {
       createdAtDisplay: _formatTime(reconciliation.checkedAt),
       reconciliation,
       details: [
+        { label: "Remaining negative", value: _formatValue(reconciliation.remainingBalanceNegativeCount || 0) },
         { label: "Remaining mismatch", value: _formatValue(reconciliation.remainingBalanceMismatchCount || 0) },
         { label: "Remaining unverifiable", value: _formatValue(reconciliation.remainingBalanceUnverifiableCount || 0) },
         ...reconciliation.issues.map((issue, index) => ({

--- a/3dp_lib/dashboard_inferred_candidate_view.js
+++ b/3dp_lib/dashboard_inferred_candidate_view.js
@@ -20,9 +20,9 @@
  * - {@link countPendingInferredCandidates}：pending candidate 件数を返す
  * - {@link buildInferredRecoverySurfaceViewModel}：recovery / repair 状態を診断表示モデルへ変換する
  *
- * @version 1.390.1275 (PR #425)
+ * @version 1.390.1276 (PR #426)
  * @since   1.390.1262 (PR #415)
- * @lastModified 2026-08-02 19:10:00
+ * @lastModified 2026-08-03 09:22:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -698,18 +698,23 @@ export function buildInferredRecoverySurfaceViewModel(options = {}) {
       createdAt: Number(reconciliation.checkedAt) || 0,
       createdAtDisplay: _formatTime(reconciliation.checkedAt),
       reconciliation,
-      details: reconciliation.issues.map((issue, index) => ({
-        label: `Issue ${index + 1}`,
-        value: _formatValue({
-          severity: issue.severity,
-          reason: issue.reason,
-          candidateHash: issue.candidateHash,
-          host: issue.host,
-          spoolId: issue.spoolId,
-          eventId: issue.eventId,
-          observationKey: issue.observationKey
-        })
-      }))
+      details: [
+        { label: "Remaining mismatch", value: _formatValue(reconciliation.remainingBalanceMismatchCount || 0) },
+        { label: "Remaining unverifiable", value: _formatValue(reconciliation.remainingBalanceUnverifiableCount || 0) },
+        ...reconciliation.issues.map((issue, index) => ({
+          label: `Issue ${index + 1}`,
+          value: _formatValue({
+            severity: issue.severity,
+            reason: issue.reason,
+            repairHint: issue.repairHint,
+            candidateHash: issue.candidateHash,
+            host: issue.host,
+            spoolId: issue.spoolId,
+            eventId: issue.eventId,
+            observationKey: issue.observationKey
+          })
+        }))
+      ]
     });
   }
 

--- a/3dp_lib/dashboard_inferred_reconciliation.js
+++ b/3dp_lib/dashboard_inferred_reconciliation.js
@@ -10,18 +10,20 @@
  * 【機能内容サマリ】
  * - O7 Ledger Reconciliation の read-only 入口として、O5 が作成した candidate decision と
  *   確定台帳 event、Undo 逆仕訳 event、履歴 attribution の構造的一致を検査する。
+ * - 再計算可能な spool では `startLength` と `usedLengthLog` から期待残量を計算し、保存残量との
+ *   差分を検出する。
  * - monitorData を読み取るだけで、spool 残量・履歴・candidate store・recovery flag は変更しない。
  * - 自動修復は行わず、O6/O7 の Recovery surface へ表示できる issue report を返す。
  *
  * 【公開関数一覧】
  * - {@link buildInferredLedgerReconciliationReport}：推定 candidate 台帳の read-only 照合結果を生成する
  *
- * @version 1.390.1275 (PR #425)
+ * @version 1.390.1276 (PR #426)
  * @since   1.390.1275 (PR #425)
- * @lastModified 2026-08-02 19:10:00
+ * @lastModified 2026-08-03 09:22:00
  * -----------------------------------------------------------
  * @todo
- * - O7B で通常 print finalize 由来の usedLengthLog と残量再計算 baseline を統合する。
+ * - none
  */
 
 "use strict";
@@ -52,6 +54,13 @@ export const INFERRED_RECONCILIATION_SEVERITY = Object.freeze({
  * @constant {string}
  */
 const INFERRED_DEBIT_STATUS = "inferred-debit";
+
+/**
+ * 残量再計算で許容する丸め誤差 [mm]。
+ *
+ * @constant {number}
+ */
+const REMAINING_TOLERANCE_MM = 0.1;
 
 /**
  * JSON 互換値を deep clone する。
@@ -91,6 +100,20 @@ function _nowMs(options = {}) {
 function _positiveMm(value) {
   const n = Number(value);
   return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/**
+ * 0以上の有限 mm 値へ正規化する。
+ *
+ * @private
+ * @function _nonNegativeMmOrNull
+ * @param {*} value - mm 値候補。
+ * @returns {?number} 0以上の有限値。不正値は null。
+ */
+function _nonNegativeMmOrNull(value) {
+  if (value == null || value === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? n : null;
 }
 
 /**
@@ -288,6 +311,69 @@ function _usedLengthLog(spool) {
 }
 
 /**
+ * usedLengthLog の1行を残量再計算用 delta へ変換する。
+ *
+ * 【詳細説明】
+ * - 通常 print finalize の `{jobId, used}` は残量を減らす正の delta として扱う。
+ * - O5 Confirm/Reassign の confirmed event は `usedMm` を正の delta として扱う。
+ * - O5 Undo の undone event は `usedMm` を負の delta として扱い、逆仕訳として残量を戻す。
+ * - 未知 typed event や不正値は再計算を壊さないよう `ok:false` で返し、呼び出し側が
+ *   unverifiable issue に変換する。
+ *
+ * @private
+ * @function _usedLengthDelta
+ * @param {Object} entry - usedLengthLog entry。
+ * @returns {{ok:boolean,deltaMm:number,kind:string,reason:?string}} 残量計算 delta。
+ */
+function _usedLengthDelta(entry) {
+  if (!entry || typeof entry !== "object") {
+    return { ok: false, deltaMm: 0, kind: "invalid", reason: "used_length_log_entry_invalid" };
+  }
+  if (entry.type === INFERRED_DECISION_LEDGER_EVENT_TYPE) {
+    const usedMm = _positiveMm(entry.usedMm);
+    if (usedMm <= 0) return { ok: false, deltaMm: 0, kind: "inferred-confirmed", reason: "inferred_event_used_mm_invalid" };
+    return { ok: true, deltaMm: usedMm, kind: "inferred-confirmed", reason: null };
+  }
+  if (entry.type === INFERRED_DECISION_UNDO_LEDGER_EVENT_TYPE) {
+    const usedMm = _positiveMm(entry.usedMm);
+    if (usedMm <= 0) return { ok: false, deltaMm: 0, kind: "inferred-undone", reason: "inferred_undo_used_mm_invalid" };
+    return { ok: true, deltaMm: -usedMm, kind: "inferred-undone", reason: null };
+  }
+  if (entry.type) {
+    return { ok: false, deltaMm: 0, kind: "unknown-typed", reason: "used_length_log_type_unknown" };
+  }
+  const used = _nonNegativeMmOrNull(entry.used);
+  if (used == null) return { ok: false, deltaMm: 0, kind: "print-finalize", reason: "used_length_log_used_invalid" };
+  return { ok: true, deltaMm: used, kind: "print-finalize", reason: null };
+}
+
+/**
+ * issue reason から read-only 修復方針を返す。
+ *
+ * 【詳細説明】
+ * - O7 は自動修復を行わないため、issue には次に確認すべき運用操作や調査対象を添える。
+ * - ここで返す値は UI/レビュー用の提案であり、実際の台帳変更は O6/O7 の明示操作だけが行う。
+ *
+ * @private
+ * @function _repairHintForReason
+ * @param {string} reason - issue reason。
+ * @returns {string} 推奨される確認・修復方針。
+ */
+function _repairHintForReason(reason) {
+  if (reason === "spool_remaining_recalculation_mismatch") return "verify-spool-balance-and-repair-ledger";
+  if (reason === "spool_balance_unverifiable") return "inspect-used-length-log-entry";
+  if (reason === "orphan_inferred_ledger_event") return "restore-candidate-or-append-reversal";
+  if (reason === "unresolved_candidate_has_ledger_event") return "resolve-candidate-status-or-reverse-ledger-event";
+  if (reason === "candidate_ledger_event_missing") return "restore-ledger-event-or-reopen-candidate";
+  if (reason === "candidate_undo_event_missing_or_ambiguous") return "inspect-undo-ledger-events";
+  if (reason === "history_attribution_mismatch") return "inspect-history-attribution-before-undo";
+  if (reason.includes("history")) return "inspect-print-history-snapshots";
+  if (reason.includes("undo")) return "inspect-undo-ledger-events";
+  if (reason.includes("ledger")) return "inspect-candidate-ledger-events";
+  return "manual-reconciliation-required";
+}
+
+/**
  * spool.usedLengthLog から O5 confirmed event を抽出する。
  *
  * @private
@@ -335,6 +421,7 @@ function _issue(severity, reason, data = {}) {
   return {
     severity,
     reason,
+    repairHint: data.repairHint || _repairHintForReason(reason),
     candidateHash: data.candidateHash || null,
     host: data.host || null,
     spoolId: data.spoolId || null,
@@ -654,6 +741,122 @@ function _checkOrphanLedgerEvents(knownCandidateHashes) {
 }
 
 /**
+ * spool の startLength と usedLengthLog から期待残量を再計算する。
+ *
+ * 【詳細説明】
+ * - `startLength` はこの spool の台帳開始点であり、通常 print finalize と O5 inferred decision の
+ *   delta をすべて差し引くことで期待残量を求める。
+ * - `startLength` や `remainingLengthMm` が不明な spool は、古い import や手動編集の可能性があるため
+ *   issue にはせず `status:"unverifiable"` として集計だけ行う。
+ * - usedLengthLog 内の不正 entry は再計算結果を信用できないため warning issue を返す。
+ *
+ * @private
+ * @function _checkSpoolRemainingBalance
+ * @param {Object} spool - spool object。
+ * @returns {{balance:Object,issues:Array<Object>}} balance と issue 配列。
+ */
+function _checkSpoolRemainingBalance(spool) {
+  const spoolId = spool?.id == null ? null : String(spool.id);
+  const startLengthMm = _nonNegativeMmOrNull(spool?.startLength);
+  const remainingLengthMm = _nonNegativeMmOrNull(spool?.remainingLengthMm);
+  const log = _usedLengthLog(spool);
+  const base = {
+    spoolId,
+    startLengthMm,
+    remainingLengthMm,
+    expectedRemainingMm: null,
+    netUsedMm: null,
+    deltaMm: null,
+    status: "unverifiable",
+    reason: null,
+    logCount: log.length
+  };
+  if (!spoolId) {
+    return {
+      balance: { ...base, reason: "spool_id_missing" },
+      issues: [_issue(INFERRED_RECONCILIATION_SEVERITY.WARNING, "spool_balance_unverifiable", {
+        spoolId,
+        details: { reason: "spool_id_missing" }
+      })]
+    };
+  }
+  if (startLengthMm == null || remainingLengthMm == null) {
+    return {
+      balance: {
+        ...base,
+        reason: startLengthMm == null ? "start_length_unknown" : "remaining_length_unknown"
+      },
+      issues: []
+    };
+  }
+
+  let netUsedMm = 0;
+  const issues = [];
+  for (let index = 0; index < log.length; index++) {
+    const delta = _usedLengthDelta(log[index]);
+    if (!delta.ok) {
+      issues.push(_issue(INFERRED_RECONCILIATION_SEVERITY.WARNING, "spool_balance_unverifiable", {
+        spoolId,
+        eventId: log[index]?.eventId || null,
+        details: {
+          reason: delta.reason,
+          index,
+          kind: delta.kind
+        }
+      }));
+      return {
+        balance: { ...base, status: "unverifiable", reason: delta.reason },
+        issues
+      };
+    }
+    netUsedMm += delta.deltaMm;
+  }
+
+  const expectedRemainingMm = Math.max(0, startLengthMm - netUsedMm);
+  const deltaMm = remainingLengthMm - expectedRemainingMm;
+  const ok = Math.abs(deltaMm) <= REMAINING_TOLERANCE_MM;
+  const balance = {
+    ...base,
+    expectedRemainingMm,
+    netUsedMm,
+    deltaMm,
+    status: ok ? "ok" : "mismatch",
+    reason: ok ? null : "remaining_length_mismatch"
+  };
+  if (!ok) {
+    issues.push(_issue(INFERRED_RECONCILIATION_SEVERITY.BLOCKER, "spool_remaining_recalculation_mismatch", {
+      spoolId,
+      details: {
+        startLengthMm,
+        netUsedMm,
+        expectedRemainingMm,
+        remainingLengthMm,
+        deltaMm
+      }
+    }));
+  }
+  return { balance, issues };
+}
+
+/**
+ * 全 active spool の残量再計算結果を作る。
+ *
+ * @private
+ * @function _checkSpoolRemainingBalances
+ * @returns {{balances:Array<Object>,issues:Array<Object>}} balance report。
+ */
+function _checkSpoolRemainingBalances() {
+  const balances = [];
+  const issues = [];
+  for (const spool of _spools()) {
+    const result = _checkSpoolRemainingBalance(spool);
+    balances.push(result.balance);
+    issues.push(...result.issues);
+  }
+  return { balances, issues };
+}
+
+/**
  * 推定 candidate 台帳の read-only 照合結果を生成する。
  *
  * 【詳細説明】
@@ -685,6 +888,8 @@ export function buildInferredLedgerReconciliationReport(options = {}) {
     }
   }
   issues.push(..._checkOrphanLedgerEvents(known));
+  const remainingBalances = _checkSpoolRemainingBalances();
+  issues.push(...remainingBalances.issues);
 
   const maxIssues = Math.max(1, Math.min(100, Number(options.maxIssues) || 20));
   const limitedIssues = issues.slice(0, maxIssues);
@@ -695,6 +900,9 @@ export function buildInferredLedgerReconciliationReport(options = {}) {
     sum + _usedLengthLog(spool).filter(event => event?.type === INFERRED_DECISION_LEDGER_EVENT_TYPE).length, 0);
   const undoEventCount = _spools().reduce((sum, spool) =>
     sum + _usedLengthLog(spool).filter(event => event?.type === INFERRED_DECISION_UNDO_LEDGER_EVENT_TYPE).length, 0);
+  const remainingBalanceOkCount = remainingBalances.balances.filter(item => item.status === "ok").length;
+  const remainingBalanceMismatchCount = remainingBalances.balances.filter(item => item.status === "mismatch").length;
+  const remainingBalanceUnverifiableCount = remainingBalances.balances.filter(item => item.status === "unverifiable").length;
 
   return {
     ok: issues.length === 0,
@@ -704,6 +912,10 @@ export function buildInferredLedgerReconciliationReport(options = {}) {
     spoolCount: _spools().length,
     decisionEventCount,
     undoEventCount,
+    remainingBalanceOkCount,
+    remainingBalanceMismatchCount,
+    remainingBalanceUnverifiableCount,
+    remainingBalances: remainingBalances.balances,
     issueCount: issues.length,
     visibleIssueCount: limitedIssues.length,
     truncated: limitedIssues.length < issues.length,

--- a/3dp_lib/dashboard_inferred_reconciliation.js
+++ b/3dp_lib/dashboard_inferred_reconciliation.js
@@ -18,9 +18,9 @@
  * 【公開関数一覧】
  * - {@link buildInferredLedgerReconciliationReport}：推定 candidate 台帳の read-only 照合結果を生成する
  *
- * @version 1.390.1278 (PR #426)
+ * @version 1.390.1279 (PR #426)
  * @since   1.390.1275 (PR #425)
- * @lastModified 2026-08-04 09:22:41
+ * @lastModified 2026-08-04 11:50:46
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -949,8 +949,8 @@ function _checkSpoolRemainingBalance(spool) {
     rawExpectedRemainingMm: expectedRemainingMm,
     netUsedMm,
     deltaMm,
-    status: ok ? (expectedRemainingMm < 0 ? "negative" : "ok") : "mismatch",
-    reason: ok ? (expectedRemainingMm < 0 ? "negative_remaining" : null) : "remaining_length_mismatch"
+    status: ok ? (expectedRemainingMm < 0 ? "negative-but-accounted" : "ok") : "mismatch",
+    reason: ok ? (expectedRemainingMm < 0 ? "negative_remaining_accounted" : null) : "remaining_length_mismatch"
   };
   if (ok && expectedRemainingMm < 0) {
     issues.push(_issue(INFERRED_RECONCILIATION_SEVERITY.WARNING, "spool_negative_remaining", {
@@ -1044,7 +1044,7 @@ export function buildInferredLedgerReconciliationReport(options = {}) {
   const undoEventCount = _spools().reduce((sum, spool) =>
     sum + _usedLengthLog(spool).filter(event => event?.type === INFERRED_DECISION_UNDO_LEDGER_EVENT_TYPE).length, 0);
   const remainingBalanceOkCount = remainingBalances.balances.filter(item => item.status === "ok").length;
-  const remainingBalanceNegativeCount = remainingBalances.balances.filter(item => item.status === "negative").length;
+  const remainingBalanceNegativeCount = remainingBalances.balances.filter(item => item.status === "negative-but-accounted").length;
   const remainingBalanceMismatchCount = remainingBalances.balances.filter(item => item.status === "mismatch").length;
   const remainingBalanceUnverifiableCount = remainingBalances.balances.filter(item => item.status === "unverifiable").length;
 

--- a/3dp_lib/dashboard_inferred_reconciliation.js
+++ b/3dp_lib/dashboard_inferred_reconciliation.js
@@ -18,9 +18,9 @@
  * 【公開関数一覧】
  * - {@link buildInferredLedgerReconciliationReport}：推定 candidate 台帳の read-only 照合結果を生成する
  *
- * @version 1.390.1276 (PR #426)
+ * @version 1.390.1278 (PR #426)
  * @since   1.390.1275 (PR #425)
- * @lastModified 2026-08-03 09:22:00
+ * @lastModified 2026-08-04 09:22:41
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -103,6 +103,20 @@ function _positiveMm(value) {
 }
 
 /**
+ * 有限 mm 値へ正規化する。
+ *
+ * @private
+ * @function _finiteMmOrNull
+ * @param {*} value - mm 値候補。
+ * @returns {?number} 有限値。不正値は null。
+ */
+function _finiteMmOrNull(value) {
+  if (value == null || value === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
  * 0以上の有限 mm 値へ正規化する。
  *
  * @private
@@ -111,9 +125,8 @@ function _positiveMm(value) {
  * @returns {?number} 0以上の有限値。不正値は null。
  */
 function _nonNegativeMmOrNull(value) {
-  if (value == null || value === "") return null;
-  const n = Number(value);
-  return Number.isFinite(n) && n >= 0 ? n : null;
+  const n = _finiteMmOrNull(value);
+  return n != null && n >= 0 ? n : null;
 }
 
 /**
@@ -157,25 +170,48 @@ function _store() {
 }
 
 /**
- * active spool 配列を安全に取得する。
+ * 全 spool 配列を安全に取得する。
  *
  * @private
  * @function _spools
- * @returns {Array<Object>} active spool 配列。
+ * @returns {Array<Object>} 削除済みを含む spool 配列。
  */
 function _spools() {
   return Array.isArray(monitorData.filamentSpools)
-    ? monitorData.filamentSpools.filter(spool => spool && !spool.deleted && !spool.isDeleted)
+    ? monitorData.filamentSpools.filter(spool => spool)
     : [];
 }
 
 /**
- * spool ID から active spool を取得する。
+ * spool が archive / deleted 相当か判定する。
+ *
+ * @private
+ * @function _isArchivedSpool
+ * @param {?Object} spool - spool object。
+ * @returns {boolean} 廃棄・削除済みなら true。
+ */
+function _isArchivedSpool(spool) {
+  return !!(spool?.deleted || spool?.isDeleted);
+}
+
+/**
+ * 残量再計算対象の active spool 配列を返す。
+ *
+ * @private
+ * @function _activeSpools
+ * @returns {Array<Object>} active spool 配列。
+ */
+function _activeSpools() {
+  return _spools().filter(spool => !_isArchivedSpool(spool));
+}
+
+/**
+ * spool ID から spool を取得する。
  *
  * @private
  * @function _spoolById
  * @param {?string} spoolId - spool ID。
- * @returns {?Object} spool。存在しない場合は null。
+ * @returns {?Object} 削除済みを含む spool。存在しない場合は null。
  */
 function _spoolById(spoolId) {
   if (spoolId == null) return null;
@@ -348,6 +384,64 @@ function _usedLengthDelta(entry) {
 }
 
 /**
+ * spool から残量再計算用 baseline を取得する。
+ *
+ * 【詳細説明】
+ * - `startLength` は再装着時に現在残量へ更新されるため、usedLengthLog 全件の基点とは限らない。
+ * - `remainingLedgerBaseline` などの明示 boundary がある場合だけ、そこから後続 log を再計算する。
+ * - baseline が無く log が存在する場合は、旧データ・再装着・手動補正の境界を証明できないため
+ *   `remaining_baseline_boundary_unknown` として fail-safe に unverifiable へ落とす。
+ *
+ * @private
+ * @function _remainingLedgerBaseline
+ * @param {Object} spool - spool object。
+ * @param {Array<Object>} log - usedLengthLog。
+ * @returns {{ok:boolean,reason:?string,remainingLengthMm:?number,usedLengthLogIndex:number,source:string}}
+ *   baseline 情報。
+ */
+function _remainingLedgerBaseline(spool, log) {
+  const candidates = [
+    { source: "remainingLedgerBaseline", value: spool?.remainingLedgerBaseline },
+    { source: "ledgerBaseline", value: spool?.ledgerBaseline },
+    { source: "remainingBalanceBaseline", value: spool?.remainingBalanceBaseline }
+  ];
+  for (const candidate of candidates) {
+    const value = candidate.value;
+    if (!value || typeof value !== "object") continue;
+    const remainingLengthMm = _finiteMmOrNull(
+      value.remainingLengthMm ?? value.remainingMm ?? value.startLengthMm ?? value.startLength
+    );
+    const rawIndex = Number(value.usedLengthLogIndex ?? value.logIndex ?? 0);
+    if (remainingLengthMm == null) {
+      return { ok: false, reason: "remaining_baseline_length_unknown", remainingLengthMm: null, usedLengthLogIndex: 0, source: candidate.source };
+    }
+    if (!Number.isInteger(rawIndex) || rawIndex < 0 || rawIndex > log.length) {
+      return { ok: false, reason: "remaining_baseline_log_index_invalid", remainingLengthMm: null, usedLengthLogIndex: 0, source: candidate.source };
+    }
+    return {
+      ok: true,
+      reason: null,
+      remainingLengthMm,
+      usedLengthLogIndex: rawIndex,
+      source: candidate.source
+    };
+  }
+  if (log.length === 0) {
+    const startLengthMm = _nonNegativeMmOrNull(spool?.startLength);
+    if (startLengthMm != null) {
+      return { ok: true, reason: null, remainingLengthMm: startLengthMm, usedLengthLogIndex: 0, source: "startLength-empty-log" };
+    }
+  }
+  return {
+    ok: false,
+    reason: log.length > 0 ? "remaining_baseline_boundary_unknown" : "remaining_baseline_missing",
+    remainingLengthMm: null,
+    usedLengthLogIndex: 0,
+    source: "none"
+  };
+}
+
+/**
  * issue reason から read-only 修復方針を返す。
  *
  * 【詳細説明】
@@ -361,7 +455,8 @@ function _usedLengthDelta(entry) {
  */
 function _repairHintForReason(reason) {
   if (reason === "spool_remaining_recalculation_mismatch") return "verify-spool-balance-and-repair-ledger";
-  if (reason === "spool_balance_unverifiable") return "inspect-used-length-log-entry";
+  if (reason === "spool_balance_unverifiable") return "inspect-used-length-log-baseline";
+  if (reason === "spool_negative_remaining") return "review-negative-remaining-ledger";
   if (reason === "orphan_inferred_ledger_event") return "restore-candidate-or-append-reversal";
   if (reason === "unresolved_candidate_has_ledger_event") return "resolve-candidate-status-or-reverse-ledger-event";
   if (reason === "candidate_ledger_event_missing") return "restore-ledger-event-or-reopen-candidate";
@@ -758,13 +853,17 @@ function _checkOrphanLedgerEvents(knownCandidateHashes) {
 function _checkSpoolRemainingBalance(spool) {
   const spoolId = spool?.id == null ? null : String(spool.id);
   const startLengthMm = _nonNegativeMmOrNull(spool?.startLength);
-  const remainingLengthMm = _nonNegativeMmOrNull(spool?.remainingLengthMm);
+  const remainingLengthMm = _finiteMmOrNull(spool?.remainingLengthMm);
   const log = _usedLengthLog(spool);
   const base = {
     spoolId,
     startLengthMm,
     remainingLengthMm,
+    baselineRemainingMm: null,
+    usedLengthLogStartIndex: null,
+    baselineSource: null,
     expectedRemainingMm: null,
+    rawExpectedRemainingMm: null,
     netUsedMm: null,
     deltaMm: null,
     status: "unverifiable",
@@ -780,24 +879,43 @@ function _checkSpoolRemainingBalance(spool) {
       })]
     };
   }
-  if (startLengthMm == null || remainingLengthMm == null) {
+  if (remainingLengthMm == null) {
     return {
       balance: {
         ...base,
-        reason: startLengthMm == null ? "start_length_unknown" : "remaining_length_unknown"
+        reason: "remaining_length_unknown"
       },
       issues: []
     };
   }
 
+  const baseline = _remainingLedgerBaseline(spool, log);
+  if (!baseline.ok) {
+    const baselineIssues = log.length > 0
+      ? [_issue(INFERRED_RECONCILIATION_SEVERITY.WARNING, "spool_balance_unverifiable", {
+        spoolId,
+        details: { reason: baseline.reason, baselineSource: baseline.source, logCount: log.length }
+      })]
+      : [];
+    return {
+      balance: {
+        ...base,
+        reason: baseline.reason,
+        baselineSource: baseline.source
+      },
+      issues: baselineIssues
+    };
+  }
+
   let netUsedMm = 0;
   const issues = [];
-  for (let index = 0; index < log.length; index++) {
+  for (let index = baseline.usedLengthLogIndex; index < log.length; index++) {
     const delta = _usedLengthDelta(log[index]);
     if (!delta.ok) {
       issues.push(_issue(INFERRED_RECONCILIATION_SEVERITY.WARNING, "spool_balance_unverifiable", {
         spoolId,
         eventId: log[index]?.eventId || null,
+        repairHint: "inspect-used-length-log-entry",
         details: {
           reason: delta.reason,
           index,
@@ -805,29 +923,54 @@ function _checkSpoolRemainingBalance(spool) {
         }
       }));
       return {
-        balance: { ...base, status: "unverifiable", reason: delta.reason },
+        balance: {
+          ...base,
+          baselineRemainingMm: baseline.remainingLengthMm,
+          usedLengthLogStartIndex: baseline.usedLengthLogIndex,
+          baselineSource: baseline.source,
+          status: "unverifiable",
+          reason: delta.reason
+        },
         issues
       };
     }
     netUsedMm += delta.deltaMm;
   }
 
-  const expectedRemainingMm = Math.max(0, startLengthMm - netUsedMm);
+  const expectedRemainingMm = baseline.remainingLengthMm - netUsedMm;
   const deltaMm = remainingLengthMm - expectedRemainingMm;
   const ok = Math.abs(deltaMm) <= REMAINING_TOLERANCE_MM;
   const balance = {
     ...base,
+    baselineRemainingMm: baseline.remainingLengthMm,
+    usedLengthLogStartIndex: baseline.usedLengthLogIndex,
+    baselineSource: baseline.source,
     expectedRemainingMm,
+    rawExpectedRemainingMm: expectedRemainingMm,
     netUsedMm,
     deltaMm,
-    status: ok ? "ok" : "mismatch",
-    reason: ok ? null : "remaining_length_mismatch"
+    status: ok ? (expectedRemainingMm < 0 ? "negative" : "ok") : "mismatch",
+    reason: ok ? (expectedRemainingMm < 0 ? "negative_remaining" : null) : "remaining_length_mismatch"
   };
+  if (ok && expectedRemainingMm < 0) {
+    issues.push(_issue(INFERRED_RECONCILIATION_SEVERITY.WARNING, "spool_negative_remaining", {
+      spoolId,
+      details: {
+        baselineRemainingMm: baseline.remainingLengthMm,
+        usedLengthLogStartIndex: baseline.usedLengthLogIndex,
+        netUsedMm,
+        expectedRemainingMm,
+        remainingLengthMm
+      }
+    }));
+  }
   if (!ok) {
     issues.push(_issue(INFERRED_RECONCILIATION_SEVERITY.BLOCKER, "spool_remaining_recalculation_mismatch", {
       spoolId,
       details: {
         startLengthMm,
+        baselineRemainingMm: baseline.remainingLengthMm,
+        usedLengthLogStartIndex: baseline.usedLengthLogIndex,
         netUsedMm,
         expectedRemainingMm,
         remainingLengthMm,
@@ -848,7 +991,7 @@ function _checkSpoolRemainingBalance(spool) {
 function _checkSpoolRemainingBalances() {
   const balances = [];
   const issues = [];
-  for (const spool of _spools()) {
+  for (const spool of _activeSpools()) {
     const result = _checkSpoolRemainingBalance(spool);
     balances.push(result.balance);
     issues.push(...result.issues);
@@ -901,6 +1044,7 @@ export function buildInferredLedgerReconciliationReport(options = {}) {
   const undoEventCount = _spools().reduce((sum, spool) =>
     sum + _usedLengthLog(spool).filter(event => event?.type === INFERRED_DECISION_UNDO_LEDGER_EVENT_TYPE).length, 0);
   const remainingBalanceOkCount = remainingBalances.balances.filter(item => item.status === "ok").length;
+  const remainingBalanceNegativeCount = remainingBalances.balances.filter(item => item.status === "negative").length;
   const remainingBalanceMismatchCount = remainingBalances.balances.filter(item => item.status === "mismatch").length;
   const remainingBalanceUnverifiableCount = remainingBalances.balances.filter(item => item.status === "unverifiable").length;
 
@@ -913,6 +1057,7 @@ export function buildInferredLedgerReconciliationReport(options = {}) {
     decisionEventCount,
     undoEventCount,
     remainingBalanceOkCount,
+    remainingBalanceNegativeCount,
     remainingBalanceMismatchCount,
     remainingBalanceUnverifiableCount,
     remainingBalances: remainingBalances.balances,

--- a/3dp_lib/dashboard_offline_projection.js
+++ b/3dp_lib/dashboard_offline_projection.js
@@ -21,9 +21,9 @@
  * - {@link evaluateCandidateObservationKey}：candidate の observation key 1件を履歴へ照合する。
  * - {@link buildInferredContinuityProjection}：candidate 全体から推定残量 projection を作る。
  *
- * @version 1.390.1246 (PR #413)
+ * @version 1.390.1278 (PR #426)
  * @since   1.390.1244 (PR #411)
- * @lastModified  2026-07-22 12:00:00
+ * @lastModified 2026-08-04 09:22:41
  * -----------------------------------------------------------
  * @todo
  * - O4 で candidate 永続化・状態遷移・親子同期へ接続する。
@@ -94,18 +94,19 @@ function _nonNegativeMm(value) {
  * 確定残量として使える値を正規化する。
  *
  * 【詳細説明】
- * - `remainingLengthMm` の `0` は実残量ゼロとして有効だが、null/undefined/NaN/負値は「不明」として扱う。
+ * - `remainingLengthMm` の負値は「使い切り後も印刷できた監査値」として有効に扱う。
+ * - null/undefined/NaN は「不明」として扱う。
  * - O5 の UI や不可逆操作 gate が「空」と「不明」を混同しないよう、不明値は null のまま返す。
  *
  * @private
  * @function _remainingOrNull
  * @param {*} value - spool.remainingLengthMm 相当の値。
- * @returns {?number} 有効な 0 以上の数値。不明な場合は null。
+ * @returns {?number} 有効な有限数値。不明な場合は null。
  */
 function _remainingOrNull(value) {
   if (value == null || value === "") return null;
   const n = Number(value);
-  return Number.isFinite(n) && n >= 0 ? n : null;
+  return Number.isFinite(n) ? n : null;
 }
 
 /**
@@ -327,8 +328,7 @@ export function evaluateCandidateObservationKey(observationKey, entry, candidate
  *
  * 【詳細説明】
  * - `classificationResult.classification` が `continuity-candidate` でない場合は推定 debit しない。
- * - `spool.remainingLengthMm` が 0 以上の有限値の場合だけ `confirmedRemainingMm` として読み、
- *   不明値は null として返す。
+ * - `spool.remainingLengthMm` が有限値の場合だけ `confirmedRemainingMm` として読み、不明値は null として返す。
  * - `projectedRemainingMm` は表示・計画用の推定値であり、spool オブジェクトへは書き戻さない。
  * - 入力履歴に同一 observation key が既に候補スプールへ確定帰属している場合は対象外にし、
  *   別スプール確定済みなら contradictions に分離する。
@@ -405,7 +405,7 @@ export function buildInferredContinuityProjection(classificationResult, spool, h
     status,
     eligibleForPersistence,
     inferredContinuityUsedMm,
-    projectedRemainingMm: confirmedRemainingMm == null ? null : Math.max(0, confirmedRemainingMm - inferredContinuityUsedMm),
+    projectedRemainingMm: confirmedRemainingMm == null ? null : confirmedRemainingMm - inferredContinuityUsedMm,
     candidateDebits,
     contradictions,
     unresolved

--- a/3dp_lib/dashboard_printmanager.js
+++ b/3dp_lib/dashboard_printmanager.js
@@ -22,9 +22,9 @@
  * - {@link saveVideos}：動画一覧保存
  * - {@link jobsToRaw}：内部モデル→生データ変換
  *
-* @version 1.390.1121 (PR #385)
+* @version 1.390.1278 (PR #426)
 * @since   1.390.197 (PR #88)
-* @lastModified 2026-06-23 00:00:00
+* @lastModified 2026-08-04 09:22:41
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -54,6 +54,7 @@ import {
   useFilament,
   getSpoolById,
   formatFilamentAmount,
+  formatRemainingFilamentAmount,
   formatUsageHtml,
   usageHeaderLabel,
   formatSpoolDisplayId,
@@ -902,7 +903,7 @@ export const renderTemplates = {
       const spName = spool.name || spool.colorName || "";
       const mat = spool.materialName || spool.material || "";
       const color = spool.filamentColor || "#000";
-      const remainFmt = formatFilamentAmount(spool.remainingLengthMm, spool);
+      const remainFmt = formatRemainingFilamentAmount(spool.remainingLengthMm, spool);
       const remainPct = spool.totalLengthMm > 0
         ? ((spool.remainingLengthMm / spool.totalLengthMm) * 100).toFixed(0) : "?";
       spoolHtml = `
@@ -1659,7 +1660,7 @@ export function renderHistoryTable(rawArray, baseUrl, hostname) {
         }
         const cnt = info.spoolCount ?? sp?.printCount ?? 0;
         const remMm = info.expectedRemain ?? sp?.remainingLengthMm ?? 0;
-        const remFmt = formatFilamentAmount(remMm, sp);
+        const remFmt = formatRemainingFilamentAmount(remMm, sp);
         parts.push(`<div class="spool-line">${text}</div>`);
         parts.push(`<div class="spool-meta">残:${remFmt.display} 回:${cnt}</div>`);
       });
@@ -2098,13 +2099,13 @@ async function handlePrintClick(raw, thumbUrl, hostname) {
     }
   }
 
-  const afterRemaining = Math.max(0, remaining - materialNeeded);
+  const afterRemaining = remaining - materialNeeded;
   const isShort        = remaining > 0 && materialNeeded > remaining;
 
   // フィラメント量を人間可読にフォーマット
   const fmtNeed  = formatFilamentAmount(materialNeeded, spool);
-  const fmtRemain = formatFilamentAmount(remaining, spool);
-  const fmtAfter = formatFilamentAmount(afterRemaining, spool);
+  const fmtRemain = formatRemainingFilamentAmount(remaining, spool);
+  const fmtAfter = formatRemainingFilamentAmount(afterRemaining, spool);
 
   // 所要時間（実績 > GCode見積 > 機器報告値）
   let estSec, durLabel;

--- a/3dp_lib/dashboard_relay_bridge.js
+++ b/3dp_lib/dashboard_relay_bridge.js
@@ -22,9 +22,9 @@
  * - {@link buildCameraEndpoints}：カメラパススルー用エンドポイントを構築する
  * - {@link relayBroadcastIfNeeded}：変更があれば子へデルタ配信する
  *
- * @version 1.390.1274 (PR #424)
+ * @version 1.390.1279 (PR #426)
  * @since   1.390.820 (PR #367)
- * @lastModified 2026-08-02 18:33:44
+ * @lastModified 2026-08-04 11:50:46
  * -----------------------------------------------------------
  */
 
@@ -61,6 +61,20 @@ let _prevIkHash = "";
 
 /** 前回ブロードキャストした業務タイムゾーン（変更検出）。undefined=未送信 */
 let _prevBizTz;
+
+/** 前回ブロードキャストした負残量表示モード（変更検出）。undefined=未送信 */
+let _prevNegativeRemainingDisplayMode;
+
+/**
+ * 負残量表示モードを親子同期用の正規値へ変換する。
+ *
+ * @private
+ * @param {*} value - appSettings に保存された表示モード。
+ * @returns {string} `"show-negative"` または `"clamp-zero"`。
+ */
+function _normalizeNegativeRemainingDisplayMode(value) {
+  return value === "clamp-zero" ? "clamp-zero" : "show-negative";
+}
 
 /**
  * 前回ブロードキャストしたフィラメント補助ドメイン（在庫・プリセット・
@@ -769,6 +783,19 @@ function _buildDelta() {
     hasChanges = true;
   }
 
+  // ★ Signed remaining: 負残量表示設定は Parent が権威を持ち、Satellite へミラーする。
+  const negativeMode = _normalizeNegativeRemainingDisplayMode(
+    monitorData.appSettings.negativeRemainingDisplayMode
+      ?? monitorData.appSettings.negativeRemainingDisplay
+      ?? monitorData.appSettings.filamentRemainingDisplayMode
+  );
+  if (negativeMode !== _prevNegativeRemainingDisplayMode) {
+    _prevNegativeRemainingDisplayMode = negativeMode;
+    sharedDelta = sharedDelta || {};
+    sharedDelta.appSettingsNegativeRemainingDisplayMode = negativeMode;
+    hasChanges = true;
+  }
+
   if (!hasChanges) return null;
 
   const delta = { machines: machinesDelta, shared: sharedDelta };
@@ -846,7 +873,13 @@ function _buildFullSnapshot() {
       // ★ レビュー(時計衛生): 業務タイムゾーン(親権威)を子へミラー（日次/月次集計の既定ゾーン）。
       businessTimeZone: monitorData.appSettings.businessTimeZone ?? null,
       // 旧履歴移行の固定基準ゾーンも子へミラー（親の tz-less 旧履歴を子が同一解釈するため）。
-      legacyHistoryTimeZone: monitorData.appSettings.legacyHistoryTimeZone ?? null
+      legacyHistoryTimeZone: monitorData.appSettings.legacyHistoryTimeZone ?? null,
+      // 負残量表示は Parent 権威でミラーする。台帳値は filamentSpools の signed 値をそのまま使う。
+      negativeRemainingDisplayMode: _normalizeNegativeRemainingDisplayMode(
+        monitorData.appSettings.negativeRemainingDisplayMode
+          ?? monitorData.appSettings.negativeRemainingDisplay
+          ?? monitorData.appSettings.filamentRemainingDisplayMode
+      )
     }
   };
 }

--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -18,6 +18,7 @@
  * - {@link getSpoolById}：ID指定取得
  * - {@link getCurrentSpoolId}：現在ID取得
  * - {@link getCurrentSpool}：現在スプール取得
+ * - {@link getSpoolBalanceState}：signed 残量状態取得
  * - {@link setCurrentSpoolId}：現在ID設定
  * - {@link addSpool}：スプール追加
  * - {@link updateSpool}：スプール更新
@@ -29,9 +30,9 @@
  * - {@link autoCorrectCurrentSpool}：履歴から残量補正
  * - {@link mountNewSpoolFromPreset}：新品開封＋装着（リレー子対応の複合操作）
  *
-* @version 1.390.1279 (PR #426)
+* @version 1.390.1280 (PR #426)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-08-04 11:50:46
+* @lastModified 2026-08-04 12:15:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -134,11 +135,29 @@ export const SPOOL_STATE = {
   STORED:     "stored",
   /** 残量ゼロ近く（使い切り） */
   EXHAUSTED:  "exhausted",
-  /** 登録基準量を超過して使用済み（台帳残量が負数） */
-  OVERDRAWN:  "overdrawn",
   /** 廃棄済み（ソフトデリート） */
   DISCARDED:  "discarded"
 };
+
+/**
+ * スプール残量状態定数。
+ *
+ * 【詳細説明】
+ * - `SPOOL_STATE` は装着・保管・廃棄などのライフサイクルだけを表す。
+ * - 本定数は signed `remainingLengthMm` の残量軸を分離して表す。
+ *
+ * @enum {string}
+ */
+export const SPOOL_BALANCE_STATE = Object.freeze({
+  /** 残量を数値として確認できない */
+  UNKNOWN: "unknown",
+  /** 正の残量がある */
+  POSITIVE: "positive",
+  /** 残量がちょうど 0 */
+  ZERO: "zero",
+  /** 台帳上の残量が負数 */
+  OVERDRAWN: "overdrawn"
+});
 
 /** 使い切り判定の閾値 [mm]（約 0.3g PLA 相当） */
 const EXHAUSTED_THRESHOLD_MM = 100;
@@ -153,7 +172,6 @@ const EXHAUSTED_THRESHOLD_MM = 100;
 export function getSpoolState(spool) {
   if (!spool) return SPOOL_STATE.INVENTORY;
   if (spool.deleted || spool.isDeleted) return SPOOL_STATE.DISCARDED;
-  if (Number(spool.remainingLengthMm) < 0) return SPOOL_STATE.OVERDRAWN;
   if (spool.isActive) return SPOOL_STATE.MOUNTED;
   if (spool.removedAt) {
     return (spool.remainingLengthMm ?? 0) <= EXHAUSTED_THRESHOLD_MM
@@ -161,6 +179,45 @@ export function getSpoolState(spool) {
       : SPOOL_STATE.STORED;
   }
   return SPOOL_STATE.INVENTORY;
+}
+
+/**
+ * スプールの signed 残量状態を返す。
+ *
+ * 【詳細説明】
+ * - 装着中かどうか、廃棄済みかどうかは `getSpoolState()` で扱う。
+ * - 本関数は `remainingLengthMm` の数値だけを見て、負残量を overdrawn として監査可能にする。
+ *
+ * @function getSpoolBalanceState
+ * @param {Object} spool - スプールオブジェクト。
+ * @returns {string} `SPOOL_BALANCE_STATE` の値。
+ */
+export function getSpoolBalanceState(spool) {
+  if (!spool || spool.remainingLengthMm == null || spool.remainingLengthMm === "") {
+    return SPOOL_BALANCE_STATE.UNKNOWN;
+  }
+  const remaining = Number(spool?.remainingLengthMm);
+  if (!Number.isFinite(remaining)) return SPOOL_BALANCE_STATE.UNKNOWN;
+  if (remaining < 0) return SPOOL_BALANCE_STATE.OVERDRAWN;
+  if (remaining === 0) return SPOOL_BALANCE_STATE.ZERO;
+  return SPOOL_BALANCE_STATE.POSITIVE;
+}
+
+/**
+ * スプール残量状態に対応する日本語ラベルを返す。
+ *
+ * @function getSpoolBalanceStateLabel
+ * @param {string} state - `SPOOL_BALANCE_STATE` の値。
+ * @returns {string} 日本語ラベル。
+ */
+export function getSpoolBalanceStateLabel(state) {
+  switch (state) {
+    case SPOOL_BALANCE_STATE.POSITIVE:  return "残量あり";
+    case SPOOL_BALANCE_STATE.ZERO:      return "残量0";
+    case SPOOL_BALANCE_STATE.OVERDRAWN: return "超過使用";
+    case SPOOL_BALANCE_STATE.UNKNOWN:   return "残量不明";
+    default: return "不明";
+  }
 }
 
 /**
@@ -175,7 +232,6 @@ export function getSpoolStateLabel(state) {
     case SPOOL_STATE.MOUNTED:    return "装着中";
     case SPOOL_STATE.STORED:     return "保管中";
     case SPOOL_STATE.EXHAUSTED:  return "使い切り";
-    case SPOOL_STATE.OVERDRAWN:  return "超過使用";
     case SPOOL_STATE.DISCARDED:  return "廃棄済";
     default: return "不明";
   }
@@ -311,7 +367,7 @@ export const FILAMENT_REMAINING_DISPLAY_MODE = NEGATIVE_REMAINING_DISPLAY_MODE;
  * appSettings から負残量表示モードを取得する。
  *
  * 【詳細説明】
- * - 保存済み設定が未知値の場合は既定の `show` に戻す。
+ * - 保存済み設定が未知値の場合は既定の `show-negative` に戻す。
  * - 親子同期や import の古い設定でも表示が壊れないよう、純粋な正規化だけを行う。
  *
  * @function getNegativeRemainingDisplayMode
@@ -1079,6 +1135,16 @@ export function addSpool(data, { inferred = false } = {}) {
   // ★ ADR-0005 P6/R1: inferred(暫定推定)スプールは serialNo を採番しない
   //   （不可逆な spoolSerialCounter を消費しない。確定時に confirmInferredSpool で採番）。
   const serialNo = inferred ? null : ++monitorData.spoolSerialCounter;
+  const initialRemainingLengthMm = Number(data.remainingLengthMm) || 0;
+  const initialUsedLengthLog = Array.isArray(data.usedLengthLog) ? data.usedLengthLog : [];
+  const initialRemainingLedgerBaseline = data.remainingLedgerBaseline && typeof data.remainingLedgerBaseline === "object"
+    ? { ...data.remainingLedgerBaseline }
+    : {
+      remainingLengthMm: initialRemainingLengthMm,
+      usedLengthLogIndex: 0,
+      createdAt: wallNowMs(),
+      source: inferred ? "inferred-spool-created" : "spool-created"
+    };
   const spool = {
     id,
     spoolId: id,
@@ -1116,7 +1182,7 @@ export function addSpool(data, { inferred = false } = {}) {
     purchaseLink: data.purchaseLink || "",
     priceCheckDate: data.priceCheckDate || "",
     totalLengthMm: Number(data.totalLengthMm) || 0,
-    remainingLengthMm: Number(data.remainingLengthMm) || 0,
+    remainingLengthMm: initialRemainingLengthMm,
     weightGram: Number(data.weightGram) || 0,
     printCount: Number(data.printCount) || 0,
     startDate: data.startDate || new Date().toISOString(),
@@ -1136,7 +1202,12 @@ export function addSpool(data, { inferred = false } = {}) {
     currentJobExpectedLength: data.currentJobExpectedLength ?? null,
     removedAt: data.removedAt || null,
     note: data.note || "",
-    usedLengthLog: data.usedLengthLog || [],
+    usedLengthLog: initialUsedLengthLog,
+    /**
+     * O7 残量再計算の基準点。
+     * @type {{remainingLengthMm:number,usedLengthLogIndex:number,createdAt:number,source:string}}
+     */
+    remainingLedgerBaseline: initialRemainingLedgerBaseline,
     /**
      * スプールを装着してから取り外すまでの印刷ID範囲配列
      * @type {Array<{startPrintID:string,endPrintID:?string}>}

--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -29,9 +29,9 @@
  * - {@link autoCorrectCurrentSpool}：履歴から残量補正
  * - {@link mountNewSpoolFromPreset}：新品開封＋装着（リレー子対応の複合操作）
  *
-* @version 1.390.1278 (PR #426)
+* @version 1.390.1279 (PR #426)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-08-04 09:22:41
+* @lastModified 2026-08-04 11:50:46
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -134,6 +134,8 @@ export const SPOOL_STATE = {
   STORED:     "stored",
   /** 残量ゼロ近く（使い切り） */
   EXHAUSTED:  "exhausted",
+  /** 登録基準量を超過して使用済み（台帳残量が負数） */
+  OVERDRAWN:  "overdrawn",
   /** 廃棄済み（ソフトデリート） */
   DISCARDED:  "discarded"
 };
@@ -151,6 +153,7 @@ const EXHAUSTED_THRESHOLD_MM = 100;
 export function getSpoolState(spool) {
   if (!spool) return SPOOL_STATE.INVENTORY;
   if (spool.deleted || spool.isDeleted) return SPOOL_STATE.DISCARDED;
+  if (Number(spool.remainingLengthMm) < 0) return SPOOL_STATE.OVERDRAWN;
   if (spool.isActive) return SPOOL_STATE.MOUNTED;
   if (spool.removedAt) {
     return (spool.remainingLengthMm ?? 0) <= EXHAUSTED_THRESHOLD_MM
@@ -172,6 +175,7 @@ export function getSpoolStateLabel(state) {
     case SPOOL_STATE.MOUNTED:    return "装着中";
     case SPOOL_STATE.STORED:     return "保管中";
     case SPOOL_STATE.EXHAUSTED:  return "使い切り";
+    case SPOOL_STATE.OVERDRAWN:  return "超過使用";
     case SPOOL_STATE.DISCARDED:  return "廃棄済";
     default: return "不明";
   }
@@ -295,9 +299,13 @@ export function formatFilamentAmount(mm, spool = null) {
  * @enum {string}
  */
 export const NEGATIVE_REMAINING_DISPLAY_MODE = Object.freeze({
-  SHOW: "show",
+  SHOW: "show-negative",
+  SIGNED: "show-negative",
   CLAMP_ZERO: "clamp-zero"
 });
+
+/** 負残量表示モード定数の提案仕様名互換エイリアス。 */
+export const FILAMENT_REMAINING_DISPLAY_MODE = NEGATIVE_REMAINING_DISPLAY_MODE;
 
 /**
  * appSettings から負残量表示モードを取得する。
@@ -311,7 +319,9 @@ export const NEGATIVE_REMAINING_DISPLAY_MODE = Object.freeze({
  * @returns {string} `NEGATIVE_REMAINING_DISPLAY_MODE` の値。
  */
 export function getNegativeRemainingDisplayMode(settings = monitorData.appSettings) {
-  const value = settings?.negativeRemainingDisplayMode;
+  const value = settings?.negativeRemainingDisplayMode
+    ?? settings?.negativeRemainingDisplay
+    ?? settings?.filamentRemainingDisplayMode;
   return value === NEGATIVE_REMAINING_DISPLAY_MODE.CLAMP_ZERO
     ? NEGATIVE_REMAINING_DISPLAY_MODE.CLAMP_ZERO
     : NEGATIVE_REMAINING_DISPLAY_MODE.SHOW;
@@ -1340,7 +1350,19 @@ export function updateSpool(id, patch) {
       }
     }
   }
+  const remainingAdjustmentReason = applied.remainingAdjustmentReason;
+  const remainingAdjustmentActor = applied.remainingAdjustmentActor;
+  delete applied.remainingAdjustmentReason;
+  delete applied.remainingAdjustmentActor;
+  const beforeRemaining = Number(s.remainingLengthMm);
   Object.assign(s, applied);
+  if ("remainingLengthMm" in applied) {
+    _recordManualRemainingAdjustment(s, beforeRemaining, Number(s.remainingLengthMm), {
+      reason: remainingAdjustmentReason || "manual-spool-update",
+      actor: remainingAdjustmentActor || "user",
+      source: "updateSpool"
+    });
+  }
   // purchasePrice or totalLengthMm が変わった場合に costPerMm を再算出
   if ("purchasePrice" in applied || "totalLengthMm" in applied) {
     s.costPerMm = _calcCostPerMm(s);
@@ -1447,6 +1469,55 @@ function logUsage(spool, lengthMm, jobId, type = "complete") {
   });
   trimUsageHistory();
   saveUnifiedStorage(true);
+}
+
+/**
+ * 手動残量補正を監査履歴へ追記し、O7 再計算 baseline を現在位置へ更新する。
+ *
+ * 【詳細説明】
+ * - 台帳値 `remainingLengthMm` は負数を含む真値として保持する。
+ * - ユーザーが実測や手動編集で残量を補正した場合、古い `usedLengthLog` 全件を
+ *   O7 が再度差し引かないよう、補正時点を `remainingLedgerBaseline` として保存する。
+ * - 監査eventは `usageHistory` に append-only で残し、補正前後と差分を追跡できるようにする。
+ *
+ * @private
+ * @param {Object} spool - 補正対象スプール。
+ * @param {number} beforeMm - 補正前の台帳残量。
+ * @param {number} afterMm - 補正後の台帳残量。
+ * @param {{reason?:string,actor?:string,source?:string,ts?:number}} [options] - 監査メタデータ。
+ * @returns {?Object} 追加した監査event。変更が無い場合は null。
+ */
+function _recordManualRemainingAdjustment(spool, beforeMm, afterMm, options = {}) {
+  if (!spool) return null;
+  if (!Number.isFinite(beforeMm) || !Number.isFinite(afterMm)) return null;
+  if (Math.abs(beforeMm - afterMm) <= 0.001) return null;
+  const now = Number.isFinite(Number(options.ts)) ? Number(options.ts) : wallNowMs();
+  if (!Array.isArray(monitorData.usageHistory)) monitorData.usageHistory = [];
+  const event = {
+    usageId: randomEventId("manual-remaining"),
+    type: "manual-remaining-adjustment",
+    spoolId: spool.id,
+    spoolSerial: spool.serialNo,
+    hostname: spool.hostname || null,
+    beforeMm,
+    afterMm,
+    deltaMm: afterMm - beforeMm,
+    reason: options.reason || "manual-remaining-adjustment",
+    actor: options.actor || "user",
+    source: options.source || "manual",
+    createdAt: now
+  };
+  monitorData.usageHistory.push(event);
+  monitorData.usageHistoryRev = (monitorData.usageHistoryRev || 0) + 1;
+  spool.remainingLedgerBaseline = {
+    remainingLengthMm: afterMm,
+    usedLengthLogIndex: Array.isArray(spool.usedLengthLog) ? spool.usedLengthLog.length : 0,
+    createdAt: now,
+    source: event.type,
+    eventId: event.usageId
+  };
+  trimUsageHistory();
+  return event;
 }
 
 /**

--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -29,9 +29,9 @@
  * - {@link autoCorrectCurrentSpool}：履歴から残量補正
  * - {@link mountNewSpoolFromPreset}：新品開封＋装着（リレー子対応の複合操作）
  *
-* @version 1.390.1110 (PR #380)
+* @version 1.390.1278 (PR #426)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-06-12 12:00:00
+* @lastModified 2026-08-04 09:22:41
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -283,6 +283,85 @@ export function formatFilamentAmount(mm, spool = null) {
   }
 
   return { mm: val, m, g, cost, currency, display };
+}
+
+/**
+ * 負残量表示モードの定数。
+ *
+ * 【詳細説明】
+ * - 台帳内部の `remainingLengthMm` は負値を保持できる。ここで切り替えるのは表示値だけ。
+ * - `SHOW` は負値をそのまま表示し、`CLAMP_ZERO` は画面表示だけ 0mm に丸める。
+ *
+ * @enum {string}
+ */
+export const NEGATIVE_REMAINING_DISPLAY_MODE = Object.freeze({
+  SHOW: "show",
+  CLAMP_ZERO: "clamp-zero"
+});
+
+/**
+ * appSettings から負残量表示モードを取得する。
+ *
+ * 【詳細説明】
+ * - 保存済み設定が未知値の場合は既定の `show` に戻す。
+ * - 親子同期や import の古い設定でも表示が壊れないよう、純粋な正規化だけを行う。
+ *
+ * @function getNegativeRemainingDisplayMode
+ * @param {Object} [settings=monitorData.appSettings] - appSettings 相当のオブジェクト。
+ * @returns {string} `NEGATIVE_REMAINING_DISPLAY_MODE` の値。
+ */
+export function getNegativeRemainingDisplayMode(settings = monitorData.appSettings) {
+  const value = settings?.negativeRemainingDisplayMode;
+  return value === NEGATIVE_REMAINING_DISPLAY_MODE.CLAMP_ZERO
+    ? NEGATIVE_REMAINING_DISPLAY_MODE.CLAMP_ZERO
+    : NEGATIVE_REMAINING_DISPLAY_MODE.SHOW;
+}
+
+/**
+ * 残量表示用の mm 値を返す。
+ *
+ * 【詳細説明】
+ * - 台帳値は引数の `mm` をそのまま保持し、表示用だけ `clamp-zero` 設定時に 0 へ丸める。
+ * - 非有限値は `null` を返し、呼び出し側が `"---"` などの不明表示へ変換する。
+ *
+ * @function displayRemainingLengthMm
+ * @param {*} mm - 台帳上の残量 mm。
+ * @param {{mode?:string,settings?:Object}} [options] - 表示モード指定。
+ * @returns {?number} 表示用 mm。判定不能なら null。
+ */
+export function displayRemainingLengthMm(mm, options = {}) {
+  const n = Number(mm);
+  if (!Number.isFinite(n)) return null;
+  const mode = options.mode || getNegativeRemainingDisplayMode(options.settings || monitorData.appSettings);
+  return mode === NEGATIVE_REMAINING_DISPLAY_MODE.CLAMP_ZERO && n < 0 ? 0 : n;
+}
+
+/**
+ * 残量を表示設定に従ってフォーマットする。
+ *
+ * 【詳細説明】
+ * - `formatFilamentAmount()` は汎用の量表示であり、負値もそのまま表示できる。
+ * - 本関数は残量専用に「表示だけ 0 クロップ」設定を適用し、同時に元台帳値とクロップ有無を返す。
+ *
+ * @function formatRemainingFilamentAmount
+ * @param {*} mm - 台帳上の残量 mm。
+ * @param {?Object} [spool=null] - spool context。
+ * @param {{mode?:string,settings?:Object}} [options] - 表示モード指定。
+ * @returns {{mm:?number,rawMm:?number,m:string,g:?string,cost:?string,currency:string,display:string,isDisplayClamped:boolean}}
+ *   表示用フォーマットと元台帳値。
+ */
+export function formatRemainingFilamentAmount(mm, spool = null, options = {}) {
+  const raw = Number(mm);
+  if (!Number.isFinite(raw)) {
+    return { mm: null, rawMm: null, m: "---", g: null, cost: null, currency: "", display: "---", isDisplayClamped: false };
+  }
+  const displayMm = displayRemainingLengthMm(raw, options);
+  const formatted = formatFilamentAmount(displayMm, spool);
+  return {
+    ...formatted,
+    rawMm: raw,
+    isDisplayClamped: displayMm !== raw
+  };
 }
 
 /**
@@ -811,8 +890,12 @@ export function setCurrentSpoolId(id, hostname, { operationId } = {}) {
       }
     }
     // ★ ADR-0004/0005: 取外しイベントを mountHistory に追記。
-    //   分割(一時停止交換)では旧区間に進行中ジョブ J を含める（until=J）。
-    //   稼働中=全体/通常取り外しでは最新完了 Lc（J を除外）。
+    //   分割(一時停止交換)で旧リール消費がある場合だけ旧区間に進行中ジョブ J を含める。
+    //   残量0で開始した空OLDなど旧リール消費が0の分割では、J を旧区間へ含めると
+    //   filamentInfo 未設定の単一スプール履歴が OLD/NEW の両方に帰属し、0クロップ解除後に
+    //   OLD が負残量へ落ちる。J を除外し、NEW 側だけが実測 materialUsedMm を受け取る。
+    //   稼働中=全体/通常取り外しでも最新完了 Lc（J を除外）。
+    const _prevUntilJobId = (_midPrintSwap && _mode === "split" && _Uold > 0) ? _J : _Lc;
     if (host) {
       // ★ P0-4(レビュー): 閉じる区間を明示指定する（projection の「同host最新open」旧
       //   フォールバック依存を廃し、複数open時に別区間を誤クローズしない）。
@@ -826,7 +909,7 @@ export function setCurrentSpoolId(id, hostname, { operationId } = {}) {
       appendUnmountEvent({
         host,
         spoolId: prevSpool.id,
-        untilJobId: (_midPrintSwap && _mode === "split") ? _J : _Lc,
+        untilJobId: _prevUntilJobId,
         targetIntervalId: _prevOpen ? _prevOpen.intervalId : null,
         opId: `${_opBase}:unmount:${prevSpool.id}`,
         ts: nowTs
@@ -1797,7 +1880,8 @@ export function finalizeFilamentUsage(lengthMm, jobId = "", hostname, isSuccess 
   }
   // ★ B2: 0消費は残量を変更しない（二重finalize等による偽値での破壊を防止）
   if (!isNaN(resolvedUsed) && resolvedUsed > 0) {
-    s.remainingLengthMm = Math.max(0, startLen - resolvedUsed);
+    // 台帳内部値は負残量を保持する。表示だけを設定で 0 クロップできるよう、ここでは丸めない。
+    s.remainingLengthMm = startLen - resolvedUsed;
     s.updatedAt = Date.now();  // ★ C1: 時系列判定用タイムスタンプ更新
   } else if (resolvedUsed === 0 || isNaN(resolvedUsed)) {
     console.warn(`[finalizeFilamentUsage] resolvedUsed=${resolvedUsed} → 残量変更なし (${hostname})`);

--- a/3dp_lib/dashboard_storage.js
+++ b/3dp_lib/dashboard_storage.js
@@ -27,9 +27,9 @@
  * - {@link loadPrintCurrent}：現ジョブ読込
  * - {@link savePrintCurrent}：現ジョブ保存
  *
-* @version 1.390.1274 (PR #424)
+* @version 1.390.1279 (PR #426)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-08-02 18:33:44
+* @lastModified 2026-08-04 11:50:46
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -164,8 +164,8 @@ export async function importAllData(data) {
           // ★ remainingLengthMm は updatedAt で判定（新しい方が勝つ）
           const importRemain = existing.remainingLengthMm;
           const importTime = existing.updatedAt ?? 0;
-          const prevValid = Number.isFinite(prevRemain) && prevRemain > 0;
-          const importValid = Number.isFinite(importRemain) && importRemain > 0;
+          const prevValid = Number.isFinite(prevRemain);
+          const importValid = Number.isFinite(importRemain);
           if (prevValid && importValid) {
             if (prevUpdatedAt >= importTime) {
               existing.remainingLengthMm = prevRemain;
@@ -429,6 +429,20 @@ export async function importAllData(data) {
       monitorData.appSettings.connectionTargets.push(t);
       existingDests.add(t.dest);
       existingIps.add(ip);
+    }
+  }
+  if (data.appSettings && typeof data.appSettings === "object") {
+    const importedNegativeMode = data.appSettings.negativeRemainingDisplayMode
+      ?? data.appSettings.negativeRemainingDisplay
+      ?? data.appSettings.filamentRemainingDisplayMode;
+    if (importedNegativeMode === "clamp-zero") {
+      monitorData.appSettings.negativeRemainingDisplayMode = "clamp-zero";
+    } else if (
+      importedNegativeMode === "show-negative"
+      || importedNegativeMode === "show"
+      || importedNegativeMode === "signed"
+    ) {
+      monitorData.appSettings.negativeRemainingDisplayMode = "show-negative";
     }
   }
 
@@ -1215,8 +1229,8 @@ function _restoreFromData(shared, machines) {
           // ★ C2: remainingLengthMm — updatedAt 時系列判定（Math.min 廃止）
           const existRemain = existing.remainingLengthMm;
           const restoredRemain = restored.remainingLengthMm;
-          const existValid = Number.isFinite(existRemain) && existRemain > 0;
-          const restoredValid = Number.isFinite(restoredRemain) && restoredRemain > 0;
+          const existValid = Number.isFinite(existRemain);
+          const restoredValid = Number.isFinite(restoredRemain);
 
           let mergedRemain;
           if (existValid && restoredValid) {

--- a/3dp_lib/dashboard_storage_ui.js
+++ b/3dp_lib/dashboard_storage_ui.js
@@ -15,9 +15,9 @@
  * 【公開関数一覧】
  * - なし（DOMイベント経由で動作）
  *
- * @version 1.390.1278 (PR #426)
+ * @version 1.390.1279 (PR #426)
  * @since   1.390.198 (PR #89)
- * @lastModified 2026-08-04 09:22:41
+ * @lastModified 2026-08-04 11:50:46
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -142,7 +142,7 @@ export function initStorageUI() {
     if (elNegativeRemaining) {
       elNegativeRemaining.value = monitorData.appSettings.negativeRemainingDisplayMode === "clamp-zero"
         ? "clamp-zero"
-        : "show";
+        : "show-negative";
     }
   };
 
@@ -158,7 +158,7 @@ export function initStorageUI() {
     elNegativeRemaining.addEventListener("change", () => {
       monitorData.appSettings.negativeRemainingDisplayMode = elNegativeRemaining.value === "clamp-zero"
         ? "clamp-zero"
-        : "show";
+        : "show-negative";
       saveUnifiedStorage(true);
       panelToast(
         monitorData.appSettings.negativeRemainingDisplayMode === "clamp-zero"

--- a/3dp_lib/dashboard_storage_ui.js
+++ b/3dp_lib/dashboard_storage_ui.js
@@ -15,9 +15,9 @@
  * 【公開関数一覧】
  * - なし（DOMイベント経由で動作）
  *
- * @version 1.390.317 (PR #143)
+ * @version 1.390.1278 (PR #426)
  * @since   1.390.198 (PR #89)
- * @lastModified 2025-06-19 22:38:18
+ * @lastModified 2026-08-04 09:22:41
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -132,12 +132,18 @@ export function initStorageUI() {
   const elLogMax = document.getElementById("setting-log-max-lines");
   const elChartWin = document.getElementById("setting-chart-window-min");
   const elLogRaw = document.getElementById("setting-log-received-raw");
+  const elNegativeRemaining = document.getElementById("setting-negative-remaining-display");
 
   /** 入力値を保存値で初期化する（モーダル展開時に呼ぶ） */
   const _syncRetentionInputs = () => {
     if (elLogMax) elLogMax.value = String(monitorData.appSettings.logMaxLines ?? 1000);
     if (elChartWin) elChartWin.value = String(monitorData.appSettings.chartWindowMin ?? 15);
     if (elLogRaw) elLogRaw.checked = monitorData.appSettings.logReceivedRaw === true;
+    if (elNegativeRemaining) {
+      elNegativeRemaining.value = monitorData.appSettings.negativeRemainingDisplayMode === "clamp-zero"
+        ? "clamp-zero"
+        : "show";
+    }
   };
 
   if (elLogRaw) {
@@ -145,6 +151,20 @@ export function initStorageUI() {
       monitorData.appSettings.logReceivedRaw = elLogRaw.checked === true;
       saveUnifiedStorage(true);
       panelToast(`受信生ログ: ${elLogRaw.checked ? "ON（K1系）" : "OFF"}`);
+    });
+  }
+
+  if (elNegativeRemaining) {
+    elNegativeRemaining.addEventListener("change", () => {
+      monitorData.appSettings.negativeRemainingDisplayMode = elNegativeRemaining.value === "clamp-zero"
+        ? "clamp-zero"
+        : "show";
+      saveUnifiedStorage(true);
+      panelToast(
+        monitorData.appSettings.negativeRemainingDisplayMode === "clamp-zero"
+          ? "負残量表示: 表示だけ0に丸めます"
+          : "負残量表示: マイナス表示を許容します"
+      );
     });
   }
 
@@ -236,7 +256,7 @@ function updateSyncTime(ts) {
   elSync.textContent = new Date(ts).toLocaleString();
 }
 
-/** 使用量ライブ更新開始（2 秒ごと） */
+/** 使用量ライブ更新開始（2秒ごと） */
 function startLiveUsage() {
   if (liveTimer) return;
   liveTimer = setInterval(updateUsage, 2000);
@@ -415,9 +435,9 @@ function doImportHistoryOnly(toast) {
   input.click();
 }
 
-/** バイト数を “X.XX MiB” に変換 */
+/** バイト数を "X.XX MiB" に変換 */
 function formatBytes(b) {
-  return (b / 1024 / 1024).toFixed(2) + " MiB";
+  return (b / 1024 / 1024).toFixed(2) + " MiB";
 }
 
 /**

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -150,6 +150,14 @@
           <label><input type="checkbox" id="setting-log-received-raw" /> <strong>受信生ログを表示（K1系のみ）</strong></label>
           <div style="font-size:11px;color:#64748b;margin-top:2px;">K1系の受信パケットをログに流します（大量・CPU増。既定OFF）。Moonraker は Gcode タブを使用。</div>
         </div>
+        <div style="margin-top:6px;">
+          <label for="setting-negative-remaining-display"><strong>負残量表示:</strong></label>
+          <select id="setting-negative-remaining-display" style="font-size:12px;padding:3px;border:1px solid #ccc;border-radius:3px;margin-left:6px;">
+            <option value="show">マイナス表示を許容</option>
+            <option value="clamp-zero">表示だけ0に丸める</option>
+          </select>
+          <div style="font-size:11px;color:#64748b;margin-top:2px;">内部台帳の負残量は保持します。0丸めは画面表示だけに適用されます。</div>
+        </div>
         <div id="confirm-delete-modal" class="confirm-modal" style="display:none;">
           <div class="confirm-modal-box">
             <p>全ストレージを本当に削除しますか？</p>
@@ -993,4 +1001,3 @@
 
 </body>
 </html>
-

--- a/3dp_monitor.html
+++ b/3dp_monitor.html
@@ -153,7 +153,7 @@
         <div style="margin-top:6px;">
           <label for="setting-negative-remaining-display"><strong>負残量表示:</strong></label>
           <select id="setting-negative-remaining-display" style="font-size:12px;padding:3px;border:1px solid #ccc;border-radius:3px;margin-left:6px;">
-            <option value="show">マイナス表示を許容</option>
+            <option value="show-negative">マイナス表示を許容</option>
             <option value="clamp-zero">表示だけ0に丸める</option>
           </select>
           <div style="font-size:11px;color:#64748b;margin-top:2px;">内部台帳の負残量は保持します。0丸めは画面表示だけに適用されます。</div>

--- a/3dp_panel.css
+++ b/3dp_panel.css
@@ -1,7 +1,7 @@
 /*
   3dp_panel.css
   GridStack パネルシステム用スタイル
-  Version 1.390.1271
+  Version 1.390.1280
 */
 
 /* ===============================================================
@@ -2266,6 +2266,7 @@ body.panel-mode .notification-container {
 .spool-state-exhausted { background: var(--color-badge-stored);    color: #92400e; }
 .spool-state-discarded { background: var(--color-badge-exhausted); color: #991b1b; text-decoration: line-through; }
 .spool-state-inventory { background: var(--color-badge-inventory); color: #1e40af; }
+.spool-balance-overdrawn { background: var(--color-danger-bg); color: var(--color-danger-text); }
 /* --- 残量バー --- */
 .remain-bar {
   display: inline-block; width: 60px; height: 10px;

--- a/docs/en/filament_manual.md
+++ b/docs/en/filament_manual.md
@@ -169,14 +169,23 @@ The O7 read-only reconciliation check compares `inferredCandidateStore`,
 O5 confirmed / undone events in `usedLengthLog`, and the history
 `filamentInfo` / `filamentId` snapshots. When it finds a mismatch, the
 surface shows **Ledger reconciliation issues**. This diagnostic does not
-repair data or change remaining length. For spools with a known
-`startLength`, it also combines normal print-finalize `{jobId, used}`
-entries, O5 confirmed events, and O5 undone events to compare the
-recalculated remaining length with saved `remainingLengthMm`. Spools with
-unknown `startLength` or `remainingLengthMm` are counted as unverifiable
-instead of being reported as mismatches. Each issue includes a `repairHint`
-that names the next manual inspection or repair direction, but the
-diagnostic itself remains read-only.
+repair data or change remaining length. For spools with an explicit
+remaining baseline such as `remainingLedgerBaseline`, it only combines
+normal print-finalize `{jobId, used}` entries, O5 confirmed events, and O5
+undone events after that baseline boundary, then compares the recalculated
+remaining length with saved `remainingLengthMm`. Spools whose baseline
+boundary cannot be proven after remounts, manual adjustments, or old imports
+are counted as unverifiable instead of being reported as mismatches. Negative
+remaining length is a valid audited ledger value; when the saved value and
+recalculated value match below zero, O7 reports a `spool_negative_remaining`
+warning rather than clamping the value away. Each issue includes a
+`repairHint` that names the next manual inspection or repair direction, but
+the diagnostic itself remains read-only.
+
+Negative remaining display is controlled by **Negative remaining display** in
+Storage settings. The default is to show negative values. Choosing display
+clamp only rounds the UI to zero; the internal `remainingLengthMm` remains
+negative and stays available for O5/O7 audit.
 
 ### Registered Filament Tab
 

--- a/docs/en/filament_manual.md
+++ b/docs/en/filament_manual.md
@@ -169,9 +169,14 @@ The O7 read-only reconciliation check compares `inferredCandidateStore`,
 O5 confirmed / undone events in `usedLengthLog`, and the history
 `filamentInfo` / `filamentId` snapshots. When it finds a mismatch, the
 surface shows **Ledger reconciliation issues**. This diagnostic does not
-repair data or change remaining length. Full recalculation that includes
-the normal print-finalize remaining baseline is reserved for a later O7B
-step.
+repair data or change remaining length. For spools with a known
+`startLength`, it also combines normal print-finalize `{jobId, used}`
+entries, O5 confirmed events, and O5 undone events to compare the
+recalculated remaining length with saved `remainingLengthMm`. Spools with
+unknown `startLength` or `remainingLengthMm` are counted as unverifiable
+instead of being reported as mismatches. Each issue includes a `repairHint`
+that names the next manual inspection or repair direction, but the
+diagnostic itself remains read-only.
 
 ### Registered Filament Tab
 

--- a/docs/ja/filament_manual.md
+++ b/docs/ja/filament_manual.md
@@ -111,7 +111,9 @@ Standalone / Parent では、Recovery / repair status から次の復旧操作�
 
 復旧操作後は、同じ Recovery / repair status に **Recovery operation audit** が表示されます。ここには最新の再保存、recovery flag 解除、ledger repair flag 解除、隔離 event 退避の履歴が残り、対象 candidate、host、件数、操作者、実行時刻を確認できます。未解決 blocker が無い場合でも、直近の復旧操作履歴は INFO として表示されます。
 
-O7 の read-only 照合では、`inferredCandidateStore`、O5 が `usedLengthLog` へ追加した confirmed / undone event、履歴 `filamentInfo` / `filamentId` snapshot を突き合わせます。不一致がある場合は **Ledger reconciliation issues** として表示されます。さらに、`startLength` が確認できるスプールでは、通常 print finalize の `{jobId, used}`、O5 confirmed event、O5 undone event を合算し、保存済み `remainingLengthMm` と再計算残量を比較します。各 issue には確認すべき修復方針 `repairHint` を添えますが、この表示は診断専用で、自動修復や残量変更は行いません。`startLength` または `remainingLengthMm` が不明なスプールは誤検出を避けるため再計算対象外として集計されます。
+O7 の read-only 照合では、`inferredCandidateStore`、O5 が `usedLengthLog` へ追加した confirmed / undone event、履歴 `filamentInfo` / `filamentId` snapshot を突き合わせます。不一致がある場合は **Ledger reconciliation issues** として表示されます。さらに、`remainingLedgerBaseline` などの明示された残量 baseline があるスプールでは、その baseline 以降の通常 print finalize `{jobId, used}`、O5 confirmed event、O5 undone event だけを合算し、保存済み `remainingLengthMm` と再計算残量を比較します。各 issue には確認すべき修復方針 `repairHint` を添えますが、この表示は診断専用で、自動修復や残量変更は行いません。再装着・手動補正・旧 import などで baseline 境界を証明できないスプールは誤検出を避けるため mismatch ではなく `unverifiable` として集計されます。負残量は台帳上の有効な監査値として保持され、再計算値と保存値が一致する場合は `spool_negative_remaining` warning として表示されます。
+
+負残量の表示はストレージ設定の **負残量表示** で切り替えできます。既定は「マイナス表示を許容」です。「表示だけ0に丸める」を選んだ場合も、内部台帳の `remainingLengthMm` は負値のまま保存され、O5/O7 の監査対象として残ります。
 
 ### 登録済みフィラメントタブ
 

--- a/docs/ja/filament_manual.md
+++ b/docs/ja/filament_manual.md
@@ -111,7 +111,7 @@ Standalone / Parent では、Recovery / repair status から次の復旧操作�
 
 復旧操作後は、同じ Recovery / repair status に **Recovery operation audit** が表示されます。ここには最新の再保存、recovery flag 解除、ledger repair flag 解除、隔離 event 退避の履歴が残り、対象 candidate、host、件数、操作者、実行時刻を確認できます。未解決 blocker が無い場合でも、直近の復旧操作履歴は INFO として表示されます。
 
-O7 の read-only 照合では、`inferredCandidateStore`、O5 が `usedLengthLog` へ追加した confirmed / undone event、履歴 `filamentInfo` / `filamentId` snapshot を突き合わせます。不一致がある場合は **Ledger reconciliation issues** として表示されます。この表示は診断専用で、自動修復や残量変更は行いません。通常 print finalize 由来の残量 baseline まで含む完全再計算は後続の O7B 対象です。
+O7 の read-only 照合では、`inferredCandidateStore`、O5 が `usedLengthLog` へ追加した confirmed / undone event、履歴 `filamentInfo` / `filamentId` snapshot を突き合わせます。不一致がある場合は **Ledger reconciliation issues** として表示されます。さらに、`startLength` が確認できるスプールでは、通常 print finalize の `{jobId, used}`、O5 confirmed event、O5 undone event を合算し、保存済み `remainingLengthMm` と再計算残量を比較します。各 issue には確認すべき修復方針 `repairHint` を添えますが、この表示は診断専用で、自動修復や残量変更は行いません。`startLength` または `remainingLengthMm` が不明なスプールは誤検出を避けるため再計算対象外として集計されます。
 
 ### 登録済みフィラメントタブ
 

--- a/tests/unit/dashboard_filament_ledger.test.js
+++ b/tests/unit/dashboard_filament_ledger.test.js
@@ -338,12 +338,12 @@ describe("ライブオーバーレイ", () => {
     expect(withLive.remainingMm).toBe(95000 - 1200);
   });
 
-  it("liveUsedMm は 0 未満にクランプ", () => {
+  it("liveUsedMm が残量を超えても負残量を保持する", () => {
     addSpool({ id: "sp1", totalLengthMm: 100000, remainingLengthMm: 0 });
     setHistory("h", [job(10, 99000)]);
     appendMountEvent({ host: "h", spoolId: "sp1", anchorRemainingMm: 100000, sinceJobId: 0, ts: 100 });
     const r = deriveSpoolRemaining("sp1", { liveUsedMm: 5000 });
-    expect(r.remainingMm).toBe(0);
+    expect(r.remainingMm).toBe(-4000);
   });
 });
 
@@ -853,14 +853,14 @@ describe("recomputeSpoolFromManualEdit（手動編集=権威）", () => {
     expect(getSpoolIntervals("sp1").filter(iv => iv.untilJobId == null)).toHaveLength(1);
   });
 
-  it("消費が総量を超える → 0 にクランプ", () => {
+  it("消費が総量を超える場合は負残量として保持する", () => {
     const sp = addSpool({ id: "sp1", totalLengthMm: 50000, remainingLengthMm: 50000 });
     setHistory("h", [job(100, 80000, { filamentId: "sp1" })]);
     mockMonitorData.hostSpoolMap = { h: "sp1" };
     appendMountEvent({ host: "h", spoolId: "sp1", anchorRemainingMm: 50000, sinceJobId: 100, ts: 10 });
     const r = recomputeSpoolFromManualEdit("sp1", { ts: 1 });
-    expect(r.after).toBe(0);
-    expect(sp.remainingLengthMm).toBe(0);
+    expect(r.after).toBe(-30000);
+    expect(sp.remainingLengthMm).toBe(-30000);
   });
 
   it("印刷中スプールは触らない（skip）", () => {

--- a/tests/unit/dashboard_inferred_candidate_decision.test.js
+++ b/tests/unit/dashboard_inferred_candidate_decision.test.js
@@ -288,7 +288,12 @@ describe("confirmInferredCandidate", () => {
       spoolId: "S1",
       usedMm: 3000,
       decisionType: "confirm",
-      actor: "operator"
+      actor: "operator",
+      remainingBeforeMm: 10000,
+      appliedDebitMm: 3000,
+      remainingAfterMm: 7000,
+      overdrawnMm: 0,
+      crossedZero: false
     });
     const history = mocks.monitorData.machines.k1.printStore.history;
     expect(history[0].filamentId).toBe("S1");
@@ -343,6 +348,13 @@ describe("confirmInferredCandidate", () => {
     expect(result.ok).toBe(true);
     expect(result.reason).toBe("confirmed");
     expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(-2900);
+    expect(mocks.monitorData.filamentSpools[0].usedLengthLog[0]).toMatchObject({
+      remainingBeforeMm: 100,
+      appliedDebitMm: 3000,
+      remainingAfterMm: -2900,
+      overdrawnMm: 2900,
+      crossedZero: true
+    });
     expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.CONFIRMED);
     expect(mocks.saveUnifiedStorageDurably).toHaveBeenCalledTimes(1);
   });
@@ -528,6 +540,13 @@ describe("reassignInferredCandidate", () => {
     expect(result.ok).toBe(true);
     expect(result.reason).toBe("reassigned");
     expect(mocks.monitorData.filamentSpools.find(s => s.id === "S2").remainingLengthMm).toBe(-2900);
+    expect(mocks.monitorData.filamentSpools.find(s => s.id === "S2").usedLengthLog[0]).toMatchObject({
+      remainingBeforeMm: 100,
+      appliedDebitMm: 3000,
+      remainingAfterMm: -2900,
+      overdrawnMm: 2900,
+      crossedZero: true
+    });
     expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.REASSIGNED);
     expect(mocks.saveUnifiedStorageDurably).toHaveBeenCalledTimes(1);
   });
@@ -551,7 +570,10 @@ describe("undoInferredCandidateDecision", () => {
       reversesEventId: mocks.monitorData.filamentSpools[0].usedLengthLog[0].eventId,
       candidateHash: "ic-a",
       usedMm: 3000,
-      actor: "operator"
+      actor: "operator",
+      remainingBeforeMm: 7000,
+      reversedUsedMm: 3000,
+      remainingAfterMm: 10000
     });
     const history = mocks.monitorData.machines.k1.printStore.history;
     expect(history[0].filamentId).toBeUndefined();

--- a/tests/unit/dashboard_inferred_candidate_decision.test.js
+++ b/tests/unit/dashboard_inferred_candidate_decision.test.js
@@ -335,16 +335,16 @@ describe("confirmInferredCandidate", () => {
     expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
   });
 
-  it("対象 spool の確定残量が candidate 使用量未満なら fail-closed する", async () => {
+  it("対象 spool の確定残量が candidate 使用量未満でも負残量として確定する", async () => {
     mocks.monitorData.filamentSpools[0].remainingLengthMm = 100;
 
     const result = await confirmInferredCandidate("ic-a", { nowMs: 11000 });
 
-    expect(result.ok).toBe(false);
-    expect(result.reason).toBe("confirmed_remaining_insufficient");
-    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(100);
-    expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.PENDING);
-    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe("confirmed");
+    expect(mocks.monitorData.filamentSpools[0].remainingLengthMm).toBe(-2900);
+    expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.CONFIRMED);
+    expect(mocks.saveUnifiedStorageDurably).toHaveBeenCalledTimes(1);
   });
 
   it("履歴が既に帰属済みなら二重反映しない", async () => {
@@ -520,16 +520,16 @@ describe("reassignInferredCandidate", () => {
     expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
   });
 
-  it("再割当て先 spool の確定残量が candidate 使用量未満なら fail-closed する", async () => {
+  it("再割当て先 spool の確定残量が candidate 使用量未満でも負残量として確定する", async () => {
     mocks.monitorData.filamentSpools.find(s => s.id === "S2").remainingLengthMm = 100;
 
     const result = await reassignInferredCandidate("ic-a", "S2", { actor: "operator", nowMs: 11000 });
 
-    expect(result.ok).toBe(false);
-    expect(result.reason).toBe("confirmed_remaining_insufficient");
-    expect(mocks.monitorData.filamentSpools.find(s => s.id === "S2").remainingLengthMm).toBe(100);
-    expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.PENDING);
-    expect(mocks.saveUnifiedStorageDurably).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe("reassigned");
+    expect(mocks.monitorData.filamentSpools.find(s => s.id === "S2").remainingLengthMm).toBe(-2900);
+    expect(mocks.monitorData.inferredCandidateStore["ic-a"].status).toBe(INFERRED_CANDIDATE_STATUS.REASSIGNED);
+    expect(mocks.saveUnifiedStorageDurably).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/unit/dashboard_inferred_candidate_view.test.js
+++ b/tests/unit/dashboard_inferred_candidate_view.test.js
@@ -20,6 +20,10 @@ const mocks = vi.hoisted(() => ({
     spoolCount: 0,
     decisionEventCount: 0,
     undoEventCount: 0,
+    remainingBalanceOkCount: 0,
+    remainingBalanceMismatchCount: 0,
+    remainingBalanceUnverifiableCount: 0,
+    remainingBalances: [],
     issueCount: 0,
     visibleIssueCount: 0,
     truncated: false,
@@ -117,6 +121,10 @@ beforeEach(() => {
     spoolCount: 0,
     decisionEventCount: 0,
     undoEventCount: 0,
+    remainingBalanceOkCount: 0,
+    remainingBalanceMismatchCount: 0,
+    remainingBalanceUnverifiableCount: 0,
+    remainingBalances: [],
     issueCount: 0,
     visibleIssueCount: 0,
     truncated: false,
@@ -335,6 +343,10 @@ describe("buildInferredRecoverySurfaceViewModel", () => {
       spoolCount: 1,
       decisionEventCount: 1,
       undoEventCount: 0,
+      remainingBalanceOkCount: 0,
+      remainingBalanceMismatchCount: 1,
+      remainingBalanceUnverifiableCount: 0,
+      remainingBalances: [{ spoolId: "S1", status: "mismatch" }],
       issueCount: 1,
       visibleIssueCount: 1,
       truncated: false,
@@ -344,6 +356,7 @@ describe("buildInferredRecoverySurfaceViewModel", () => {
       issues: [{
         severity: "blocker",
         reason: "candidate_ledger_event_missing",
+        repairHint: "restore-ledger-event-or-reopen-candidate",
         candidateHash: "ic-old",
         host: "k1",
         spoolId: "S1",
@@ -362,7 +375,9 @@ describe("buildInferredRecoverySurfaceViewModel", () => {
       severity: "blocker",
       title: "Ledger reconciliation issues"
     });
-    expect(vm.cards[0].details[0].value).toContain("candidate_ledger_event_missing");
+    expect(vm.cards[0].details).toContainEqual({ label: "Remaining mismatch", value: "1" });
+    expect(vm.cards[0].details[2].value).toContain("candidate_ledger_event_missing");
+    expect(vm.cards[0].details[2].value).toContain("restore-ledger-event-or-reopen-candidate");
     expect(vm.cards[0].reconciliation.issueCount).toBe(1);
   });
 

--- a/tests/unit/dashboard_inferred_candidate_view.test.js
+++ b/tests/unit/dashboard_inferred_candidate_view.test.js
@@ -376,8 +376,9 @@ describe("buildInferredRecoverySurfaceViewModel", () => {
       title: "Ledger reconciliation issues"
     });
     expect(vm.cards[0].details).toContainEqual({ label: "Remaining mismatch", value: "1" });
-    expect(vm.cards[0].details[2].value).toContain("candidate_ledger_event_missing");
-    expect(vm.cards[0].details[2].value).toContain("restore-ledger-event-or-reopen-candidate");
+    const issueDetail = vm.cards[0].details.find(item => item.label === "Issue 1");
+    expect(issueDetail?.value).toContain("candidate_ledger_event_missing");
+    expect(issueDetail?.value).toContain("restore-ledger-event-or-reopen-candidate");
     expect(vm.cards[0].reconciliation.issueCount).toBe(1);
   });
 

--- a/tests/unit/dashboard_inferred_reconciliation.test.js
+++ b/tests/unit/dashboard_inferred_reconciliation.test.js
@@ -134,7 +134,13 @@ beforeEach(() => {
     }
   };
   mocks.monitorData.filamentSpools = [
-    { id: "S1", startLength: 10000, remainingLengthMm: 7000, usedLengthLog: [decisionEvent()] }
+    {
+      id: "S1",
+      startLength: 10000,
+      remainingLengthMm: 7000,
+      remainingLedgerBaseline: { remainingLengthMm: 10000, usedLengthLogIndex: 0 },
+      usedLengthLog: [decisionEvent()]
+    }
   ];
   mocks.monitorData.inferredCandidateStore = {
     "ic-a": candidate("confirmed")
@@ -154,6 +160,7 @@ describe("buildInferredLedgerReconciliationReport", () => {
       decisionEventCount: 1,
       undoEventCount: 0,
       remainingBalanceOkCount: 1,
+      remainingBalanceNegativeCount: 0,
       remainingBalanceMismatchCount: 0,
       remainingBalanceUnverifiableCount: 0,
       issueCount: 0,
@@ -315,7 +322,13 @@ describe("buildInferredLedgerReconciliationReport", () => {
   it("#426/O7B: 0使用量の通常 usedLengthLog は no-op として残量再計算へ含める", () => {
     mocks.monitorData.inferredCandidateStore = {};
     mocks.monitorData.filamentSpools = [
-      { id: "S2", startLength: 1000, remainingLengthMm: 1000, usedLengthLog: [{ jobId: "zero", used: 0 }] }
+      {
+        id: "S2",
+        startLength: 1000,
+        remainingLengthMm: 1000,
+        remainingLedgerBaseline: { remainingLengthMm: 1000, usedLengthLogIndex: 0 },
+        usedLengthLog: [{ jobId: "zero", used: 0 }]
+      }
     ];
 
     const report = buildInferredLedgerReconciliationReport();
@@ -333,7 +346,13 @@ describe("buildInferredLedgerReconciliationReport", () => {
   it("#426/O7B: 非数値の usedLengthLog は残量再計算不能 warning として検出する", () => {
     mocks.monitorData.inferredCandidateStore = {};
     mocks.monitorData.filamentSpools = [
-      { id: "S2", startLength: 1000, remainingLengthMm: 900, usedLengthLog: [{ jobId: "bad", used: "abc" }] }
+      {
+        id: "S2",
+        startLength: 1000,
+        remainingLengthMm: 900,
+        remainingLedgerBaseline: { remainingLengthMm: 1000, usedLengthLogIndex: 0 },
+        usedLengthLog: [{ jobId: "bad", used: "abc" }]
+      }
     ];
 
     const report = buildInferredLedgerReconciliationReport();
@@ -347,5 +366,87 @@ describe("buildInferredLedgerReconciliationReport", () => {
       repairHint: "inspect-used-length-log-entry",
       spoolId: "S2"
     }));
+  });
+
+  it("#426/O7B: baseline 境界が無い usedLengthLog 付き spool は誤 mismatch にせず unverifiable にする", () => {
+    mocks.monitorData.inferredCandidateStore = {};
+    mocks.monitorData.filamentSpools = [
+      {
+        id: "S2",
+        startLength: 9000,
+        remainingLengthMm: 8500,
+        usedLengthLog: [
+          { jobId: "before-remount", used: 1000 },
+          { jobId: "after-remount", used: 500 }
+        ]
+      }
+    ];
+
+    const report = buildInferredLedgerReconciliationReport();
+
+    expect(report.ok).toBe(false);
+    expect(report.status).toBe("warning");
+    expect(report.remainingBalanceMismatchCount).toBe(0);
+    expect(report.remainingBalanceUnverifiableCount).toBe(1);
+    expect(report.remainingBalances[0]).toMatchObject({
+      spoolId: "S2",
+      status: "unverifiable",
+      reason: "remaining_baseline_boundary_unknown"
+    });
+    expect(report.issues).toContainEqual(expect.objectContaining({
+      severity: "warning",
+      reason: "spool_balance_unverifiable",
+      spoolId: "S2"
+    }));
+  });
+
+  it("#426/O7B: 明示 baseline 以降の使用量だけで負残量を監査 warning にする", () => {
+    mocks.monitorData.inferredCandidateStore = {};
+    mocks.monitorData.filamentSpools = [
+      {
+        id: "S2",
+        startLength: 1000,
+        remainingLengthMm: -250,
+        remainingLedgerBaseline: { remainingLengthMm: 1000, usedLengthLogIndex: 1 },
+        usedLengthLog: [
+          { jobId: "before-baseline", used: 5000 },
+          { jobId: "after-baseline", used: 1250 }
+        ]
+      }
+    ];
+
+    const report = buildInferredLedgerReconciliationReport();
+
+    expect(report.ok).toBe(false);
+    expect(report.status).toBe("warning");
+    expect(report.remainingBalanceNegativeCount).toBe(1);
+    expect(report.remainingBalanceMismatchCount).toBe(0);
+    expect(report.remainingBalances[0]).toMatchObject({
+      spoolId: "S2",
+      baselineRemainingMm: 1000,
+      usedLengthLogStartIndex: 1,
+      netUsedMm: 1250,
+      expectedRemainingMm: -250,
+      remainingLengthMm: -250,
+      status: "negative"
+    });
+    expect(report.issues).toContainEqual(expect.objectContaining({
+      severity: "warning",
+      reason: "spool_negative_remaining",
+      spoolId: "S2"
+    }));
+  });
+
+  it("#425/O7A: deleted spool 上の確定 candidate も ledger 照合対象に含める", () => {
+    mocks.monitorData.filamentSpools[0].deleted = true;
+
+    const report = buildInferredLedgerReconciliationReport();
+
+    expect(report.issues).not.toContainEqual(expect.objectContaining({
+      reason: "resolved_spool_missing",
+      spoolId: "S1"
+    }));
+    expect(report.decisionEventCount).toBe(1);
+    expect(report.remainingBalances).toHaveLength(0);
   });
 });

--- a/tests/unit/dashboard_inferred_reconciliation.test.js
+++ b/tests/unit/dashboard_inferred_reconciliation.test.js
@@ -134,7 +134,7 @@ beforeEach(() => {
     }
   };
   mocks.monitorData.filamentSpools = [
-    { id: "S1", remainingLengthMm: 7000, usedLengthLog: [decisionEvent()] }
+    { id: "S1", startLength: 10000, remainingLengthMm: 7000, usedLengthLog: [decisionEvent()] }
   ];
   mocks.monitorData.inferredCandidateStore = {
     "ic-a": candidate("confirmed")
@@ -153,6 +153,9 @@ describe("buildInferredLedgerReconciliationReport", () => {
       spoolCount: 1,
       decisionEventCount: 1,
       undoEventCount: 0,
+      remainingBalanceOkCount: 1,
+      remainingBalanceMismatchCount: 0,
+      remainingBalanceUnverifiableCount: 0,
       issueCount: 0,
       issues: []
     });
@@ -204,6 +207,7 @@ describe("buildInferredLedgerReconciliationReport", () => {
   it("#425/O7A: undone candidate の履歴が Confirm 前 snapshot に戻っていれば ok を返す", () => {
     mocks.monitorData.inferredCandidateStore["ic-a"] = candidate("undone");
     mocks.monitorData.filamentSpools[0].usedLengthLog = [decisionEvent(), undoEvent()];
+    mocks.monitorData.filamentSpools[0].remainingLengthMm = 10000;
     mocks.monitorData.machines.k1.printStore.history = [
       { observationKey: "kA" },
       { observationKey: "kB" }
@@ -213,6 +217,7 @@ describe("buildInferredLedgerReconciliationReport", () => {
 
     expect(report.ok).toBe(true);
     expect(report.undoEventCount).toBe(1);
+    expect(report.remainingBalanceOkCount).toBe(1);
   });
 
   it("#425/O7A: confirmed candidate の履歴 attribution 変更を blocker として検出する", () => {
@@ -256,6 +261,91 @@ describe("buildInferredLedgerReconciliationReport", () => {
       reason: "orphan_inferred_ledger_event",
       candidateHash: "ic-a",
       eventId: "ev-a"
+    }));
+  });
+
+  it("#426/O7B: startLength と usedLengthLog から保存残量の不一致を検出する", () => {
+    mocks.monitorData.filamentSpools[0].remainingLengthMm = 6500;
+
+    const report = buildInferredLedgerReconciliationReport();
+
+    expect(report.ok).toBe(false);
+    expect(report.remainingBalanceMismatchCount).toBe(1);
+    expect(report.remainingBalances[0]).toMatchObject({
+      spoolId: "S1",
+      startLengthMm: 10000,
+      expectedRemainingMm: 7000,
+      remainingLengthMm: 6500,
+      deltaMm: -500,
+      status: "mismatch"
+    });
+    expect(report.issues).toContainEqual(expect.objectContaining({
+      severity: "blocker",
+      reason: "spool_remaining_recalculation_mismatch",
+      repairHint: "verify-spool-balance-and-repair-ledger",
+      spoolId: "S1"
+    }));
+  });
+
+  it("#426/O7B: 通常 usedLengthLog と O5逆仕訳を同じ残量再計算へ含める", () => {
+    mocks.monitorData.inferredCandidateStore["ic-a"] = candidate("undone");
+    mocks.monitorData.filamentSpools[0].usedLengthLog = [
+      { jobId: "normal-a", used: 500 },
+      decisionEvent(),
+      undoEvent()
+    ];
+    mocks.monitorData.filamentSpools[0].remainingLengthMm = 9500;
+    mocks.monitorData.machines.k1.printStore.history = [
+      { observationKey: "kA" },
+      { observationKey: "kB" }
+    ];
+
+    const report = buildInferredLedgerReconciliationReport();
+
+    expect(report.ok).toBe(true);
+    expect(report.remainingBalances[0]).toMatchObject({
+      spoolId: "S1",
+      netUsedMm: 500,
+      expectedRemainingMm: 9500,
+      remainingLengthMm: 9500,
+      status: "ok"
+    });
+  });
+
+  it("#426/O7B: 0使用量の通常 usedLengthLog は no-op として残量再計算へ含める", () => {
+    mocks.monitorData.inferredCandidateStore = {};
+    mocks.monitorData.filamentSpools = [
+      { id: "S2", startLength: 1000, remainingLengthMm: 1000, usedLengthLog: [{ jobId: "zero", used: 0 }] }
+    ];
+
+    const report = buildInferredLedgerReconciliationReport();
+
+    expect(report.ok).toBe(true);
+    expect(report.remainingBalanceOkCount).toBe(1);
+    expect(report.remainingBalances[0]).toMatchObject({
+      spoolId: "S2",
+      netUsedMm: 0,
+      expectedRemainingMm: 1000,
+      status: "ok"
+    });
+  });
+
+  it("#426/O7B: 非数値の usedLengthLog は残量再計算不能 warning として検出する", () => {
+    mocks.monitorData.inferredCandidateStore = {};
+    mocks.monitorData.filamentSpools = [
+      { id: "S2", startLength: 1000, remainingLengthMm: 900, usedLengthLog: [{ jobId: "bad", used: "abc" }] }
+    ];
+
+    const report = buildInferredLedgerReconciliationReport();
+
+    expect(report.ok).toBe(false);
+    expect(report.status).toBe("warning");
+    expect(report.remainingBalanceUnverifiableCount).toBe(1);
+    expect(report.issues).toContainEqual(expect.objectContaining({
+      severity: "warning",
+      reason: "spool_balance_unverifiable",
+      repairHint: "inspect-used-length-log-entry",
+      spoolId: "S2"
     }));
   });
 });

--- a/tests/unit/dashboard_inferred_reconciliation.test.js
+++ b/tests/unit/dashboard_inferred_reconciliation.test.js
@@ -428,7 +428,7 @@ describe("buildInferredLedgerReconciliationReport", () => {
       netUsedMm: 1250,
       expectedRemainingMm: -250,
       remainingLengthMm: -250,
-      status: "negative"
+      status: "negative-but-accounted"
     });
     expect(report.issues).toContainEqual(expect.objectContaining({
       severity: "warning",

--- a/tests/unit/dashboard_offline_projection.test.js
+++ b/tests/unit/dashboard_offline_projection.test.js
@@ -278,7 +278,7 @@ describe("buildInferredContinuityProjection", () => {
     expect(result.projectedRemainingMm).toBe(7000);
   });
 
-  it("推定 debit が確定残量を超えても projectedRemainingMm は 0 未満にしない", () => {
+  it("推定 debit が確定残量を超える場合は projectedRemainingMm を負値で保持する", () => {
     const entry = job("801", 9000, 801);
     const result = buildInferredContinuityProjection(
       classification([keyOf(entry)]),
@@ -287,6 +287,20 @@ describe("buildInferredContinuityProjection", () => {
     );
 
     expect(result.inferredContinuityUsedMm).toBe(9000);
-    expect(result.projectedRemainingMm).toBe(0);
+    expect(result.projectedRemainingMm).toBe(-8000);
+  });
+
+  it("確定残量が負値でも不明扱いにせず projection へ反映する", () => {
+    const entry = job("802", 500, 802);
+    const result = buildInferredContinuityProjection(
+      classification([keyOf(entry)]),
+      { id: "S1", remainingLengthMm: -1200 },
+      [entry]
+    );
+
+    expect(result.confirmedRemainingMm).toBe(-1200);
+    expect(result.inferredContinuityUsedMm).toBe(500);
+    expect(result.projectedRemainingMm).toBe(-1700);
+    expect(result.eligibleForPersistence).toBe(true);
   });
 });

--- a/tests/unit/dashboard_printmanager_render_perf.test.js
+++ b/tests/unit/dashboard_printmanager_render_perf.test.js
@@ -53,6 +53,7 @@ vi.mock("../../3dp_lib/dashboard_spool.js", () => ({
   useFilament: vi.fn(),
   getSpoolById: vi.fn(() => null),
   formatFilamentAmount: vi.fn(() => ({ display: "—", g: null })),
+  formatRemainingFilamentAmount: vi.fn(() => ({ display: "—", g: null })),
   formatUsageHtml: vi.fn(() => "—"),
   usageHeaderLabel: vi.fn(() => "使用量"),
   formatSpoolDisplayId: vi.fn(() => ""),

--- a/tests/unit/dashboard_relay_bridge_filament_ops.test.js
+++ b/tests/unit/dashboard_relay_bridge_filament_ops.test.js
@@ -115,6 +115,7 @@ function setupRelayApi() {
 describe("relayBroadcastIfNeeded — #418 recovery 診断同期", () => {
   it("full snapshot と delta に Parent 権威の recovery / repair 診断を同梱する", () => {
     const relay = setupRelayApi();
+    monitorData.appSettings.negativeRemainingDisplayMode = "clamp-zero";
     monitorData.inferredDecisionRecoveryRequired = {
       candidateHash: "ic-a",
       action: "confirm",
@@ -143,6 +144,7 @@ describe("relayBroadcastIfNeeded — #418 recovery 診断同期", () => {
     expect(snapshot.inferredRecoveryEvents).toEqual(monitorData.inferredRecoveryEvents);
     expect(snapshot.ledgerRepairRequired).toEqual(monitorData.ledgerRepairRequired);
     expect(snapshot.mountHistoryRejectedEvents).toEqual(monitorData.mountHistoryRejectedEvents);
+    expect(snapshot.appSettings.negativeRemainingDisplayMode).toBe("clamp-zero");
 
     relayBroadcastIfNeeded();
 
@@ -152,6 +154,7 @@ describe("relayBroadcastIfNeeded — #418 recovery 診断同期", () => {
     expect(delta.shared.inferredRecoveryEvents).toEqual(monitorData.inferredRecoveryEvents);
     expect(delta.shared.ledgerRepairRequired).toEqual(monitorData.ledgerRepairRequired);
     expect(delta.shared.mountHistoryRejectedEvents).toEqual(monitorData.mountHistoryRejectedEvents);
+    expect(delta.shared.appSettingsNegativeRemainingDisplayMode).toBe("clamp-zero");
   });
 });
 

--- a/tests/unit/dashboard_spool.test.js
+++ b/tests/unit/dashboard_spool.test.js
@@ -46,6 +46,9 @@ import {
   getSpoolStateLabel,
   formatSpoolDisplayId,
   formatFilamentAmount,
+  formatRemainingFilamentAmount,
+  displayRemainingLengthMm,
+  getNegativeRemainingDisplayMode,
   formatUsageHtml,
   usageHeaderLabel,
   weightFromLength,
@@ -334,6 +337,30 @@ describe('formatFilamentAmount', () => {
     const result = formatFilamentAmount(12340);
     expect(typeof result.display).toBe('string');
     expect(result.display.length).toBeGreaterThan(0);
+  });
+
+  it('負残量は既定でマイナス表示を保持する', () => {
+    monitorData.appSettings = { negativeRemainingDisplayMode: 'show' };
+    const result = formatRemainingFilamentAmount(-2500);
+
+    expect(getNegativeRemainingDisplayMode()).toBe('show');
+    expect(displayRemainingLengthMm(-2500)).toBe(-2500);
+    expect(result.rawMm).toBe(-2500);
+    expect(result.mm).toBe(-2500);
+    expect(result.display).toContain('-2.5m');
+    expect(result.isDisplayClamped).toBe(false);
+  });
+
+  it('負残量の0クロップ設定は表示値だけを丸める', () => {
+    monitorData.appSettings = { negativeRemainingDisplayMode: 'clamp-zero' };
+    const result = formatRemainingFilamentAmount(-2500);
+
+    expect(getNegativeRemainingDisplayMode()).toBe('clamp-zero');
+    expect(displayRemainingLengthMm(-2500)).toBe(0);
+    expect(result.rawMm).toBe(-2500);
+    expect(result.mm).toBe(0);
+    expect(result.display).toContain('0.0m');
+    expect(result.isDisplayClamped).toBe(true);
   });
 });
 

--- a/tests/unit/dashboard_spool.test.js
+++ b/tests/unit/dashboard_spool.test.js
@@ -64,6 +64,7 @@ import {
   getAttributionPresentation,
   getAttributionIssueIdsForHost,
   countAttributionIssuesForHost,
+  updateSpool,
 } from '../../3dp_lib/dashboard_spool.js';
 import { monitorData } from '../../3dp_lib/dashboard_data.js';
 import { loadHistory, saveHistory } from '../../3dp_lib/dashboard_printmanager.js';
@@ -87,6 +88,11 @@ describe('getSpoolState', () => {
 
   it('isActive=true → MOUNTED', () => {
     expect(getSpoolState({ isActive: true })).toBe(SPOOL_STATE.MOUNTED);
+  });
+
+  it('負残量は台帳上の超過使用状態として分類する', () => {
+    expect(getSpoolState({ remainingLengthMm: -1 })).toBe(SPOOL_STATE.OVERDRAWN);
+    expect(getSpoolState({ isActive: true, remainingLengthMm: -1 })).toBe(SPOOL_STATE.OVERDRAWN);
   });
 
   it('deleted優先: deleted=true + isActive=true → DISCARDED', () => {
@@ -138,6 +144,7 @@ describe('getSpoolStateLabel', () => {
     expect(getSpoolStateLabel(SPOOL_STATE.MOUNTED)).toBe('装着中');
     expect(getSpoolStateLabel(SPOOL_STATE.STORED)).toBe('保管中');
     expect(getSpoolStateLabel(SPOOL_STATE.EXHAUSTED)).toBe('使い切り');
+    expect(getSpoolStateLabel(SPOOL_STATE.OVERDRAWN)).toBe('超過使用');
     expect(getSpoolStateLabel(SPOOL_STATE.DISCARDED)).toBe('廃棄済');
   });
 
@@ -343,7 +350,7 @@ describe('formatFilamentAmount', () => {
     monitorData.appSettings = { negativeRemainingDisplayMode: 'show' };
     const result = formatRemainingFilamentAmount(-2500);
 
-    expect(getNegativeRemainingDisplayMode()).toBe('show');
+    expect(getNegativeRemainingDisplayMode()).toBe('show-negative');
     expect(displayRemainingLengthMm(-2500)).toBe(-2500);
     expect(result.rawMm).toBe(-2500);
     expect(result.mm).toBe(-2500);
@@ -361,6 +368,59 @@ describe('formatFilamentAmount', () => {
     expect(result.mm).toBe(0);
     expect(result.display).toContain('0.0m');
     expect(result.isDisplayClamped).toBe(true);
+  });
+
+  it('負残量表示モードは提案仕様名と旧値を show-negative へ正規化する', () => {
+    expect(getNegativeRemainingDisplayMode({ negativeRemainingDisplay: 'show-negative' })).toBe('show-negative');
+    expect(getNegativeRemainingDisplayMode({ negativeRemainingDisplayMode: 'show' })).toBe('show-negative');
+    expect(getNegativeRemainingDisplayMode({ filamentRemainingDisplayMode: 'signed' })).toBe('show-negative');
+    expect(getNegativeRemainingDisplayMode({ filamentRemainingDisplayMode: 'clamp-zero' })).toBe('clamp-zero');
+  });
+});
+
+describe('updateSpool — signed remaining manual baseline', () => {
+  beforeEach(() => {
+    monitorData.filamentSpools = [];
+    monitorData.usageHistory = [];
+    monitorData.usageHistoryRev = 0;
+    monitorData.hostSpoolMap = {};
+  });
+
+  it('手動残量補正は負値からの復帰も監査し、O7 baseline を補正位置へ更新する', () => {
+    monitorData.filamentSpools.push({
+      id: 'S-manual',
+      serialNo: 'SER-1',
+      hostname: 'k1',
+      remainingLengthMm: -2350,
+      usedLengthLog: [{ jobId: 'before-remount', used: 1000 }],
+    });
+
+    updateSpool('S-manual', {
+      expectedRemainingLengthMm: -2350,
+      remainingLengthMm: 420,
+      remainingAdjustmentReason: 'weighed-spool',
+      remainingAdjustmentActor: 'operator',
+    });
+
+    const spool = monitorData.filamentSpools[0];
+    expect(spool.remainingLengthMm).toBe(420);
+    expect(monitorData.usageHistory).toHaveLength(1);
+    expect(monitorData.usageHistory[0]).toMatchObject({
+      type: 'manual-remaining-adjustment',
+      spoolId: 'S-manual',
+      beforeMm: -2350,
+      afterMm: 420,
+      deltaMm: 2770,
+      reason: 'weighed-spool',
+      actor: 'operator',
+    });
+    expect(monitorData.usageHistoryRev).toBe(1);
+    expect(spool.remainingLedgerBaseline).toMatchObject({
+      remainingLengthMm: 420,
+      usedLengthLogIndex: 1,
+      source: 'manual-remaining-adjustment',
+      eventId: monitorData.usageHistory[0].usageId,
+    });
   });
 });
 
@@ -824,13 +884,14 @@ describe('getAttributionPresentation / getAttributionIssueIdsForHost（Phase5 U1
 // SPOOL_STATE 定数の完全性
 // =============================================
 describe('SPOOL_STATE 定数', () => {
-  it('5状態が定義されている', () => {
+  it('6状態が定義されている', () => {
     const states = Object.values(SPOOL_STATE);
-    expect(states).toHaveLength(5);
+    expect(states).toHaveLength(6);
     expect(states).toContain('inventory');
     expect(states).toContain('mounted');
     expect(states).toContain('stored');
     expect(states).toContain('exhausted');
+    expect(states).toContain('overdrawn');
     expect(states).toContain('discarded');
   });
 

--- a/tests/unit/dashboard_spool.test.js
+++ b/tests/unit/dashboard_spool.test.js
@@ -41,9 +41,12 @@ vi.mock('../../3dp_lib/dashboard_connection.js', () => ({
 
 import {
   SPOOL_STATE,
+  SPOOL_BALANCE_STATE,
   MATERIAL_DENSITY,
   getSpoolState,
   getSpoolStateLabel,
+  getSpoolBalanceState,
+  getSpoolBalanceStateLabel,
   formatSpoolDisplayId,
   formatFilamentAmount,
   formatRemainingFilamentAmount,
@@ -65,9 +68,14 @@ import {
   getAttributionIssueIdsForHost,
   countAttributionIssuesForHost,
   updateSpool,
+  addSpool,
 } from '../../3dp_lib/dashboard_spool.js';
 import { monitorData } from '../../3dp_lib/dashboard_data.js';
 import { loadHistory, saveHistory } from '../../3dp_lib/dashboard_printmanager.js';
+
+const {
+  buildInferredLedgerReconciliationReport
+} = await import('../../3dp_lib/dashboard_inferred_reconciliation.js');
 
 // =============================================
 // getSpoolState
@@ -90,9 +98,8 @@ describe('getSpoolState', () => {
     expect(getSpoolState({ isActive: true })).toBe(SPOOL_STATE.MOUNTED);
   });
 
-  it('負残量は台帳上の超過使用状態として分類する', () => {
-    expect(getSpoolState({ remainingLengthMm: -1 })).toBe(SPOOL_STATE.OVERDRAWN);
-    expect(getSpoolState({ isActive: true, remainingLengthMm: -1 })).toBe(SPOOL_STATE.OVERDRAWN);
+  it('負残量でも装着中ライフサイクル状態は MOUNTED のまま保持する', () => {
+    expect(getSpoolState({ isActive: true, remainingLengthMm: -1 })).toBe(SPOOL_STATE.MOUNTED);
   });
 
   it('deleted優先: deleted=true + isActive=true → DISCARDED', () => {
@@ -144,7 +151,6 @@ describe('getSpoolStateLabel', () => {
     expect(getSpoolStateLabel(SPOOL_STATE.MOUNTED)).toBe('装着中');
     expect(getSpoolStateLabel(SPOOL_STATE.STORED)).toBe('保管中');
     expect(getSpoolStateLabel(SPOOL_STATE.EXHAUSTED)).toBe('使い切り');
-    expect(getSpoolStateLabel(SPOOL_STATE.OVERDRAWN)).toBe('超過使用');
     expect(getSpoolStateLabel(SPOOL_STATE.DISCARDED)).toBe('廃棄済');
   });
 
@@ -152,6 +158,22 @@ describe('getSpoolStateLabel', () => {
     expect(getSpoolStateLabel('unknown')).toBe('不明');
     expect(getSpoolStateLabel(null)).toBe('不明');
     expect(getSpoolStateLabel('')).toBe('不明');
+  });
+});
+
+describe('getSpoolBalanceState / getSpoolBalanceStateLabel', () => {
+  it('signed remaining の残量状態をライフサイクルとは別軸で返す', () => {
+    expect(getSpoolBalanceState({ isActive: true, remainingLengthMm: -300 })).toBe(SPOOL_BALANCE_STATE.OVERDRAWN);
+    expect(getSpoolBalanceState({ remainingLengthMm: 0 })).toBe(SPOOL_BALANCE_STATE.ZERO);
+    expect(getSpoolBalanceState({ remainingLengthMm: 1 })).toBe(SPOOL_BALANCE_STATE.POSITIVE);
+    expect(getSpoolBalanceState({ remainingLengthMm: null })).toBe(SPOOL_BALANCE_STATE.UNKNOWN);
+  });
+
+  it('残量状態ラベルを返す', () => {
+    expect(getSpoolBalanceStateLabel(SPOOL_BALANCE_STATE.OVERDRAWN)).toBe('超過使用');
+    expect(getSpoolBalanceStateLabel(SPOOL_BALANCE_STATE.ZERO)).toBe('残量0');
+    expect(getSpoolBalanceStateLabel(SPOOL_BALANCE_STATE.POSITIVE)).toBe('残量あり');
+    expect(getSpoolBalanceStateLabel(SPOOL_BALANCE_STATE.UNKNOWN)).toBe('残量不明');
   });
 });
 
@@ -421,6 +443,75 @@ describe('updateSpool — signed remaining manual baseline', () => {
       source: 'manual-remaining-adjustment',
       eventId: monitorData.usageHistory[0].usageId,
     });
+  });
+});
+
+describe('addSpool — O7 remaining baseline', () => {
+  beforeEach(() => {
+    monitorData.filamentSpools = [];
+    monitorData.spoolSerialCounter = 0;
+  });
+
+  it('新規スプール作成時に signed 残量照合 baseline を初期化する', () => {
+    const spool = addSpool({
+      name: 'Baseline spool',
+      totalLengthMm: 10000,
+      remainingLengthMm: 10000,
+      usedLengthLog: [],
+    });
+
+    expect(spool.remainingLedgerBaseline).toMatchObject({
+      remainingLengthMm: 10000,
+      usedLengthLogIndex: 0,
+      source: 'spool-created',
+    });
+    expect(Number.isFinite(spool.remainingLedgerBaseline.createdAt)).toBe(true);
+  });
+
+  it('addSpool 作成baseline以降の通常使用量を O7 が ok として照合する', () => {
+    const spool = addSpool({
+      name: 'O7 baseline spool',
+      totalLengthMm: 10000,
+      remainingLengthMm: 10000,
+      usedLengthLog: [],
+    });
+    spool.usedLengthLog.push({ jobId: 'job-1', used: 500 });
+    spool.remainingLengthMm = 9500;
+
+    const report = buildInferredLedgerReconciliationReport({ nowMs: 9000 });
+
+    expect(report.remainingBalanceOkCount).toBe(1);
+    expect(report.remainingBalanceUnverifiableCount).toBe(0);
+    expect(report.remainingBalances[0]).toMatchObject({
+      spoolId: spool.id,
+      baselineRemainingMm: 10000,
+      usedLengthLogStartIndex: 0,
+      netUsedMm: 500,
+      expectedRemainingMm: 9500,
+      remainingLengthMm: 9500,
+      status: 'ok',
+    });
+    expect(report.issues).not.toContainEqual(expect.objectContaining({
+      reason: 'remaining_baseline_boundary_unknown',
+      spoolId: spool.id,
+    }));
+  });
+
+  it('明示済み baseline がある場合は上書きせず保持する', () => {
+    const existingBaseline = {
+      remainingLengthMm: -500,
+      usedLengthLogIndex: 2,
+      createdAt: 111,
+      source: 'imported-baseline',
+    };
+
+    const spool = addSpool({
+      name: 'Imported baseline spool',
+      remainingLengthMm: -500,
+      remainingLedgerBaseline: existingBaseline,
+    });
+
+    expect(spool.remainingLedgerBaseline).toEqual(existingBaseline);
   });
 });
 
@@ -884,14 +975,13 @@ describe('getAttributionPresentation / getAttributionIssueIdsForHost（Phase5 U1
 // SPOOL_STATE 定数の完全性
 // =============================================
 describe('SPOOL_STATE 定数', () => {
-  it('6状態が定義されている', () => {
+  it('5状態が定義されている', () => {
     const states = Object.values(SPOOL_STATE);
-    expect(states).toHaveLength(6);
+    expect(states).toHaveLength(5);
     expect(states).toContain('inventory');
     expect(states).toContain('mounted');
     expect(states).toContain('stored');
     expect(states).toContain('exhausted');
-    expect(states).toContain('overdrawn');
     expect(states).toContain('discarded');
   });
 

--- a/tests/unit/dashboard_storage_migration.test.js
+++ b/tests/unit/dashboard_storage_migration.test.js
@@ -267,6 +267,29 @@ describe('v2.2.1027 追加フィールドの round-trip', () => {
     expect(monitorData.inferredRecoveryEvents.map(event => event.eventId)).toEqual(["ir-a", "ir-b"]);
   });
 
+  it('#426 signed remaining: import は負残量と表示モード互換名を保持する', async () => {
+    monitorData.filamentSpools = [
+      { id: 'sp-neg', remainingLengthMm: 500, updatedAt: 10 },
+    ];
+    monitorData.appSettings = { connectionTargets: [], panelLayout: [] };
+
+    await importAllData({
+      appSettings: {
+        connectionTargets: [],
+        panelLayout: [],
+        filamentRemainingDisplayMode: 'signed',
+      },
+      filamentSpools: [
+        { id: 'sp-neg', remainingLengthMm: -1250, updatedAt: 20 },
+        { id: 'sp-new-neg', remainingLengthMm: -300, updatedAt: 30 },
+      ],
+    });
+
+    expect(monitorData.filamentSpools.find(sp => sp.id === 'sp-neg').remainingLengthMm).toBe(-1250);
+    expect(monitorData.filamentSpools.find(sp => sp.id === 'sp-new-neg').remainingLengthMm).toBe(-300);
+    expect(monitorData.appSettings.negativeRemainingDisplayMode).toBe('show-negative');
+  });
+
   it('P1-1: import は同一 opId(別evId)の mount を1件に畳む', async () => {
     monitorData.mountHistory = [{ opId: 'op1', evId: 'A', type: 'mount', spoolId: 's', ts: 1 }];
     await importAllData({


### PR DESCRIPTION
## Summary
- Extend O7 read-only reconciliation to recalculate spool remaining balances from `startLength` and `usedLengthLog`.
- Include normal print-finalize entries, O5 confirmed decision events, and O5 undo reversal events in the net-used total.
- Surface remaining-balance mismatch and unverifiable counts with read-only repair hints in the Recovery view model.
- Update Japanese and English filament manuals for the O7B/C diagnostic scope.

## Safety
- The reconciliation path remains read-only and does not mutate spool remaining length, candidate state, history, or recovery flags.
- Missing `startLength` or `remainingLengthMm` is counted as unverifiable instead of producing a false mismatch.
- Invalid or unknown used-length entries fail closed as warning diagnostics.

## Validation
- `npx vitest run tests/unit/dashboard_inferred_reconciliation.test.js tests/unit/dashboard_inferred_candidate_view.test.js --silent`
- `npx eslint 3dp_lib/dashboard_inferred_reconciliation.js 3dp_lib/dashboard_inferred_candidate_view.js --quiet`
- `git diff --check`
- `npx vitest run --silent`