### PR TITLE
O9 confirmed-only remaining gates

### DIFF
--- a/3dp_lib/dashboard_aggregator.js
+++ b/3dp_lib/dashboard_aggregator.js
@@ -21,9 +21,9 @@
  * - {@link setHistoryPersistFunc}：履歴永続化関数の登録
  * - {@link getCurrentPrintID}：現在の印刷IDを取得
  *
-* @version 1.390.1246 (PR #413)
+* @version 1.390.1281 (PR #427)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-07-22 19:00:00
+* @lastModified 2026-08-04 15:22:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -61,6 +61,10 @@ import { normalizeJobId } from "./dashboard_utils.js";
 import { monotonicNowMs, randomEventId } from "./dashboard_time.js";
 import { recordObservation, observationDue } from "./dashboard_offline_observation.js";
 import { runInferredContinuityShadow } from "./dashboard_offline_live_shadow.js";
+import {
+  getIrreversibleFilamentRemaining,
+  IRREVERSIBLE_REMAINING_ACTION
+} from "./dashboard_filament_remaining_model.js";
 
 // ---------------------------------------------------------------------------
 // 状態変数／タイムスタンプ定義（per-host 管理）
@@ -71,6 +75,32 @@ let aggregatorTimer = null;
 
 /** リレーブリッジ配信コールバック（Phase 6 で登録） */
 let _relayBroadcastCallback = null;
+
+/**
+ * runout 文脈へ記録する confirmed-only 残量スナップショットを作成する。
+ *
+ * 【詳細説明】
+ * - O9 では不可逆判断に projected 残量を混ぜないため、runout ゲートへ渡す残量も Model 層の
+ *   confirmed-only API から取得する。
+ * - 正本スプールが見つからない、または確定残量が不明な場合は `NaN` を返し、
+ *   `runoutGateHeld()` 側の既存 fail-closed 分岐に委譲する。
+ *
+ * @private
+ * @function _confirmedRunoutRemainingSnapshot
+ * @param {?Object} spool - 現在装着中スプール。
+ * @returns {{remainingMm:number,remainingPct:number}} runout イベントへ保存する残量情報。
+ */
+function _confirmedRunoutRemainingSnapshot(spool) {
+  const gate = getIrreversibleFilamentRemaining(spool, {
+    action: IRREVERSIBLE_REMAINING_ACTION.RUNOUT_DECISION
+  });
+  if (!gate.ok) return { remainingMm: NaN, remainingPct: NaN };
+  const total = Number(spool?.totalLengthMm);
+  return {
+    remainingMm: Number(gate.remainingMm),
+    remainingPct: total > 0 ? (Number(gate.remainingMm) / total) * 100 : NaN
+  };
+}
 
 /**
  * リレーブリッジの配信コールバックを登録する。
@@ -673,15 +703,14 @@ export function ingestData(data, hostname) {
         try {
           const _curSp = getCurrentSpool(host);
           const _stNow = Number(storedData.state?.rawValue || 0);
-          const _total = Number(_curSp?.totalLengthMm);
+          const _remaining = _confirmedRunoutRemainingSnapshot(_curSp);
           recordFilamentEvent({
             host,
             ts: nowMs,
             stateAtEvent: _stNow,
             oldSpoolId: _curSp?.id ?? null,
-            oldRemainingMm: Number(_curSp?.remainingLengthMm),
-            oldRemainingPct: _curSp && _total > 0
-              ? (Number(_curSp.remainingLengthMm) / _total) * 100 : NaN,
+            oldRemainingMm: _remaining.remainingMm,
+            oldRemainingPct: _remaining.remainingPct,
             runout: true,
             inflightJobId: _curSp?.currentPrintID || (machine?.printStore?.current?.id ?? null)
           });
@@ -1168,14 +1197,14 @@ export function aggregatorUpdate() {
         && st === PRINT_STATE_CODE.printPaused
         && s.lastPrintState === PRINT_STATE_CODE.printStarted) {
       try {
-        const _total = Number(spool.totalLengthMm);
+        const _remaining = _confirmedRunoutRemainingSnapshot(spool);
         recordFilamentEvent({
           host,
           ts: _now,
           stateAtEvent: PRINT_STATE_CODE.printPaused,
           oldSpoolId: spool.id,
-          oldRemainingMm: Number(spool.remainingLengthMm),
-          oldRemainingPct: _total > 0 ? (Number(spool.remainingLengthMm) / _total) * 100 : NaN,
+          oldRemainingMm: _remaining.remainingMm,
+          oldRemainingPct: _remaining.remainingPct,
           runout: s.currentMaterialStatus === 1,
           inflightJobId: spool.currentPrintID || (machine?.printStore?.current?.id ?? null)
         });

--- a/3dp_lib/dashboard_filament_remaining_model.js
+++ b/3dp_lib/dashboard_filament_remaining_model.js
@@ -1,0 +1,340 @@
+/**
+ * @fileoverview
+ * @description 3Dプリンタ監視ツール 3dpmon 用 フィラメント残量モデル モジュール
+ * @file dashboard_filament_remaining_model.js
+ * @copyright (c) pumpCurry 2025 / 5r4ce2
+ * @author pumpCurry
+ * -----------------------------------------------------------
+ * @module dashboard_filament_remaining_model
+ *
+ * 【機能内容サマリ】
+ * - O8/O9 向けに、確定残量と推定残量を分離した Model 層 API を提供する。
+ * - pending inferred candidate から表示用 projected 残量を集計する。
+ * - runout、印刷可否、在庫消費、廃棄などの不可逆判断では confirmed 残量だけを返す。
+ *
+ * 【公開関数一覧】
+ * - {@link buildFilamentRemainingModel}：確定残量・推定残量・不可逆ゲート情報を構築する
+ * - {@link getIrreversibleFilamentRemaining}：不可逆判断用の確定残量だけを取得する
+ * - {@link canExecuteIrreversibleRemainingAction}：必要量つき不可逆判断を confirmed 残量で検証する
+ *
+ * @version 1.390.1280 (PR #427)
+ * @since   1.390.1280 (PR #427)
+ * @lastModified 2026-08-04 14:20:23
+ * -----------------------------------------------------------
+ * @todo
+ * - none
+ */
+
+"use strict";
+
+import { monitorData } from "./dashboard_data.js";
+import { INFERRED_CANDIDATE_STATUS } from "./dashboard_offline_candidate_store.js";
+
+/**
+ * 残量モデルの用途分類。
+ *
+ * 【詳細説明】
+ * - `DISPLAY` は projected 残量を表示してよい用途を表す。
+ * - `IRREVERSIBLE` は在庫や台帳、実行可否を変える用途を表し、confirmed 残量だけを使う。
+ *
+ * @enum {string}
+ */
+export const FILAMENT_REMAINING_USAGE_KIND = Object.freeze({
+  DISPLAY: "display",
+  IRREVERSIBLE: "irreversible"
+});
+
+/**
+ * 不可逆残量判断の代表アクション。
+ *
+ * 【詳細説明】
+ * - 文字列は監査ログや UI 表示に出しても意味が分かるよう、用途名をそのまま保持する。
+ * - 新しい不可逆操作を追加する場合も、Model 層の confirmed-only ゲートを経由させる。
+ *
+ * @enum {string}
+ */
+export const IRREVERSIBLE_REMAINING_ACTION = Object.freeze({
+  RUNOUT_DECISION: "runout-decision",
+  PRINT_START_GATE: "print-start-gate",
+  INVENTORY_CONSUMPTION: "inventory-consumption",
+  SPOOL_DISCARD: "spool-discard",
+  AUTO_SPOOL_SELECTION: "auto-spool-selection",
+  ORDER_ALERT: "order-alert",
+  PRODUCTION_PLANNING: "production-planning",
+  LEDGER_MUTATION: "ledger-mutation"
+});
+
+/**
+ * 値を有限な mm 数へ正規化する。
+ *
+ * 【詳細説明】
+ * - signed 残量仕様では負値も有効なので、0 未満を拒否しない。
+ * - `null` や非数は残量不明として `null` へ落とす。
+ *
+ * @private
+ * @function _finiteMmOrNull
+ * @param {*} value - mm 相当の値。
+ * @returns {?number} 有限数なら number、不明なら null。
+ */
+function _finiteMmOrNull(value) {
+  if (value == null || value === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * スプール ID またはスプールオブジェクトから実スプールを解決する。
+ *
+ * 【詳細説明】
+ * - UI からはオブジェクト、テストやドメイン処理からは ID が渡るため両方を受ける。
+ * - 見つからない場合は `null` を返し、呼び出し側が fail-closed できるようにする。
+ *
+ * @private
+ * @function _resolveSpool
+ * @param {string|Object|null|undefined} spoolOrId - スプール ID またはスプールオブジェクト。
+ * @returns {?Object} 解決済みスプール。
+ */
+function _resolveSpool(spoolOrId) {
+  if (!spoolOrId) return null;
+  if (typeof spoolOrId === "object") return spoolOrId;
+  const id = String(spoolOrId);
+  return (monitorData.filamentSpools || []).find(spool => String(spool?.id) === id || String(spool?.spoolId) === id) || null;
+}
+
+/**
+ * candidate store の値配列を取得する。
+ *
+ * 【詳細説明】
+ * - import/restore 直後などで store が未初期化でも空配列として扱う。
+ * - テストでは `options.candidates` を渡すことで monitorData に依存せず検証できる。
+ *
+ * @private
+ * @function _candidateRecords
+ * @param {{candidates?:Array<Object>|Object.<string,Object>}} [options] - candidate 注入オプション。
+ * @returns {Array<Object>} candidate record 配列。
+ */
+function _candidateRecords(options = {}) {
+  const source = options.candidates ?? monitorData.inferredCandidateStore;
+  if (Array.isArray(source)) return source.filter(Boolean);
+  if (source && typeof source === "object") return Object.values(source).filter(Boolean);
+  return [];
+}
+
+/**
+ * スプールに紐付く pending inferred candidate を取得する。
+ *
+ * 【詳細説明】
+ * - confirmed/rejected/reassigned/superseded/undone は確定済みまたは退避済みなので projected 残量へ含めない。
+ * - candidate は host を跨いで同じ spool に積まれる可能性があるため、既定では spool 単位で合算する。
+ * - `host` が指定された場合だけ host 単位の表示へ絞る。
+ *
+ * @private
+ * @function _pendingCandidatesForSpool
+ * @param {string} spoolId - 対象スプール ID。
+ * @param {{host?:string,candidates?:Array<Object>|Object.<string,Object>}} [options] - 絞り込みオプション。
+ * @returns {Array<Object>} pending candidate 配列。
+ */
+function _pendingCandidatesForSpool(spoolId, options = {}) {
+  if (!spoolId) return [];
+  const host = options.host != null ? String(options.host) : null;
+  return _candidateRecords(options).filter(record => {
+    if (!record || record.status !== INFERRED_CANDIDATE_STATUS.PENDING) return false;
+    if (String(record.candidateSpoolId ?? "") !== String(spoolId)) return false;
+    if (host && String(record.host ?? "") !== host) return false;
+    const usedMm = _finiteMmOrNull(record.usedMm);
+    return usedMm != null && usedMm > 0;
+  });
+}
+
+/**
+ * pending candidate の推定使用量を合計する。
+ *
+ * 【詳細説明】
+ * - O8 表示用の projected 残量にだけ使う。
+ * - 不正値や 0 以下の usedMm は候補表示対象にしない。
+ *
+ * @private
+ * @function _sumPendingUsedMm
+ * @param {Array<Object>} records - pending candidate 配列。
+ * @returns {number} 推定使用量合計 mm。
+ */
+function _sumPendingUsedMm(records) {
+  return records.reduce((sum, record) => {
+    const usedMm = _finiteMmOrNull(record?.usedMm);
+    return usedMm != null && usedMm > 0 ? sum + usedMm : sum;
+  }, 0);
+}
+
+/**
+ * 確定残量・推定残量・不可逆ゲート情報を構築する。
+ *
+ * 【詳細説明】
+ * - `confirmedRemainingMm` は `spool.remainingLengthMm` の raw signed 値であり、台帳上の真値として扱う。
+ * - `projectedRemainingMm` は pending inferred candidate を差し引いた表示・予測専用の値であり、保存しない。
+ * - `irreversibleRemainingMm` は常に confirmed 残量と同じ値を返し、projected 値を不可逆判断へ混入させない。
+ *
+ * @function buildFilamentRemainingModel
+ * @param {string|Object|null|undefined} spoolOrId - スプール ID またはスプールオブジェクト。
+ * @param {{host?:string,candidates?:Array<Object>|Object.<string,Object>}} [options] - 表示対象の絞り込み。
+ * @returns {{
+ *   ok:boolean,
+ *   reason:?string,
+ *   spool:?Object,
+ *   spoolId:?string,
+ *   confirmedRemainingMm:?number,
+ *   pendingInferredUsedMm:number,
+ *   pendingCandidateCount:number,
+ *   pendingCandidateHashes:Array<string>,
+ *   projectedRemainingMm:?number,
+ *   hasPendingInferredUsage:boolean,
+ *   usageKind:string,
+ *   irreversibleRemainingMm:?number,
+ *   irreversibleSource:string,
+ *   warnings:Array<string>
+ * }} 残量 Model。
+ * @example
+ * const model = buildFilamentRemainingModel(spool);
+ */
+export function buildFilamentRemainingModel(spoolOrId, options = {}) {
+  const spool = _resolveSpool(spoolOrId);
+  if (!spool) {
+    return {
+      ok: false,
+      reason: "spool_not_found",
+      spool: null,
+      spoolId: null,
+      confirmedRemainingMm: null,
+      pendingInferredUsedMm: 0,
+      pendingCandidateCount: 0,
+      pendingCandidateHashes: [],
+      projectedRemainingMm: null,
+      hasPendingInferredUsage: false,
+      usageKind: FILAMENT_REMAINING_USAGE_KIND.DISPLAY,
+      irreversibleRemainingMm: null,
+      irreversibleSource: "confirmed-ledger",
+      warnings: ["spool-not-found"]
+    };
+  }
+
+  const spoolId = String(spool.id ?? spool.spoolId ?? "");
+  const confirmedRemainingMm = _finiteMmOrNull(spool.remainingLengthMm);
+  const pendingCandidates = _pendingCandidatesForSpool(spoolId, options);
+  const pendingInferredUsedMm = _sumPendingUsedMm(pendingCandidates);
+  const projectedRemainingMm = confirmedRemainingMm == null
+    ? null
+    : confirmedRemainingMm - pendingInferredUsedMm;
+  const warnings = [];
+  if (confirmedRemainingMm == null) warnings.push("confirmed-remaining-unknown");
+  if (pendingInferredUsedMm > 0) warnings.push("projected-remaining-display-only");
+
+  return {
+    ok: confirmedRemainingMm != null,
+    reason: confirmedRemainingMm == null ? "confirmed_remaining_unknown" : null,
+    spool,
+    spoolId,
+    confirmedRemainingMm,
+    pendingInferredUsedMm,
+    pendingCandidateCount: pendingCandidates.length,
+    pendingCandidateHashes: pendingCandidates.map(record => String(record.candidateHash ?? "")).filter(Boolean),
+    projectedRemainingMm,
+    hasPendingInferredUsage: pendingInferredUsedMm > 0,
+    usageKind: FILAMENT_REMAINING_USAGE_KIND.DISPLAY,
+    irreversibleRemainingMm: confirmedRemainingMm,
+    irreversibleSource: "confirmed-ledger",
+    warnings
+  };
+}
+
+/**
+ * 不可逆判断用の確定残量だけを取得する。
+ *
+ * 【詳細説明】
+ * - O9 の中心契約として、pending inferred candidate が存在しても projected 残量は返すだけで判断値にしない。
+ * - 呼び出し元は `remainingMm` のみを runout/廃棄/自動選択/在庫消費などの判定に使う。
+ * - 確定残量が不明な場合は fail-closed で `ok:false` を返す。
+ *
+ * @function getIrreversibleFilamentRemaining
+ * @param {string|Object|null|undefined} spoolOrId - スプール ID またはスプールオブジェクト。
+ * @param {{action?:string,host?:string,candidates?:Array<Object>|Object.<string,Object>}} [options] - 判定文脈。
+ * @returns {{
+ *   ok:boolean,
+ *   reason:?string,
+ *   action:string,
+ *   spoolId:?string,
+ *   remainingMm:?number,
+ *   source:string,
+ *   projectedRemainingMm:?number,
+ *   ignoredPendingInferredUsedMm:number
+ * }} 不可逆判断用残量。
+ * @example
+ * const gate = getIrreversibleFilamentRemaining(spool, { action: IRREVERSIBLE_REMAINING_ACTION.RUNOUT_DECISION });
+ */
+export function getIrreversibleFilamentRemaining(spoolOrId, options = {}) {
+  const model = buildFilamentRemainingModel(spoolOrId, options);
+  const action = options.action || IRREVERSIBLE_REMAINING_ACTION.LEDGER_MUTATION;
+  if (!model.ok) {
+    return {
+      ok: false,
+      reason: model.reason || "confirmed_remaining_unknown",
+      action,
+      spoolId: model.spoolId,
+      remainingMm: null,
+      source: "confirmed-ledger",
+      projectedRemainingMm: model.projectedRemainingMm,
+      ignoredPendingInferredUsedMm: model.pendingInferredUsedMm
+    };
+  }
+  return {
+    ok: true,
+    reason: null,
+    action,
+    spoolId: model.spoolId,
+    remainingMm: model.confirmedRemainingMm,
+    source: "confirmed-ledger",
+    projectedRemainingMm: model.projectedRemainingMm,
+    ignoredPendingInferredUsedMm: model.pendingInferredUsedMm
+  };
+}
+
+/**
+ * 必要量を伴う不可逆判断を confirmed 残量だけで検証する。
+ *
+ * 【詳細説明】
+ * - print start gate や自動 spool 選択などで「指定量を満たすか」を確認するための Model API。
+ * - pending inferred candidate で projected 残量が不足していても、この関数の判定は confirmed 残量だけで行う。
+ * - 逆に projected 残量が足りていても confirmed が不足する場合は拒否する。
+ *
+ * @function canExecuteIrreversibleRemainingAction
+ * @param {string|Object|null|undefined} spoolOrId - スプール ID またはスプールオブジェクト。
+ * @param {*} requiredMm - 必要量 mm。
+ * @param {{action?:string,host?:string,candidates?:Array<Object>|Object.<string,Object>}} [options] - 判定文脈。
+ * @returns {{
+ *   ok:boolean,
+ *   reason:?string,
+ *   action:string,
+ *   spoolId:?string,
+ *   remainingMm:?number,
+ *   requiredMm:number,
+ *   projectedRemainingMm:?number,
+ *   ignoredPendingInferredUsedMm:number
+ * }} 判定結果。
+ * @example
+ * const canPrint = canExecuteIrreversibleRemainingAction(spool, 12000, { action: "print-start-gate" });
+ */
+export function canExecuteIrreversibleRemainingAction(spoolOrId, requiredMm, options = {}) {
+  const required = Math.max(0, Number(requiredMm) || 0);
+  const gate = getIrreversibleFilamentRemaining(spoolOrId, options);
+  if (!gate.ok) {
+    return {
+      ...gate,
+      requiredMm: required
+    };
+  }
+  const ok = gate.remainingMm >= required;
+  return {
+    ...gate,
+    ok,
+    reason: ok ? null : "confirmed_remaining_insufficient",
+    requiredMm: required
+  };
+}

--- a/3dp_lib/dashboard_filament_remaining_model.js
+++ b/3dp_lib/dashboard_filament_remaining_model.js
@@ -17,9 +17,9 @@
  * - {@link getIrreversibleFilamentRemaining}：不可逆判断用の確定残量だけを取得する
  * - {@link canExecuteIrreversibleRemainingAction}：必要量つき不可逆判断を confirmed 残量で検証する
  *
- * @version 1.390.1280 (PR #427)
+ * @version 1.390.1281 (PR #427)
  * @since   1.390.1280 (PR #427)
- * @lastModified 2026-08-04 14:20:23
+ * @lastModified 2026-08-04 15:22:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -99,6 +99,52 @@ function _resolveSpool(spoolOrId) {
   if (typeof spoolOrId === "object") return spoolOrId;
   const id = String(spoolOrId);
   return (monitorData.filamentSpools || []).find(spool => String(spool?.id) === id || String(spool?.spoolId) === id) || null;
+}
+
+/**
+ * スプール引数から正本検索に使う ID を抽出する。
+ *
+ * 【詳細説明】
+ * - 不可逆操作では UI が保持している古いオブジェクトを権威値として使わない。
+ * - そのため、オブジェクトで渡された場合も ID だけを取り出し、monitorData の正本へ再解決する。
+ *
+ * @private
+ * @function _spoolIdFromInput
+ * @param {string|Object|null|undefined} spoolOrId - スプール ID またはスプールオブジェクト。
+ * @returns {?string} 正本検索に使うスプール ID。
+ */
+function _spoolIdFromInput(spoolOrId) {
+  if (!spoolOrId) return null;
+  if (typeof spoolOrId === "object") {
+    const id = spoolOrId.id ?? spoolOrId.spoolId;
+    return id == null || id === "" ? null : String(id);
+  }
+  return String(spoolOrId);
+}
+
+/**
+ * 不可逆操作向けに monitorData 内の正本スプールを解決する。
+ *
+ * 【詳細説明】
+ * - `buildFilamentRemainingModel()` は表示用のためオブジェクトをそのまま扱える。
+ * - この関数は O9 の不可逆ゲート専用で、必ず現在の `monitorData.filamentSpools` から正本を取得する。
+ * - 正本が見つからない場合は fail-closed の理由を返す。
+ *
+ * @private
+ * @function _resolveCanonicalSpool
+ * @param {string|Object|null|undefined} spoolOrId - スプール ID またはスプールオブジェクト。
+ * @returns {{spool:?Object,spoolId:?string,reason:?string}} 正本スプール解決結果。
+ */
+function _resolveCanonicalSpool(spoolOrId) {
+  const spoolId = _spoolIdFromInput(spoolOrId);
+  if (!spoolId) {
+    return { spool: null, spoolId: null, reason: "canonical_spool_not_found" };
+  }
+  const spool = (monitorData.filamentSpools || [])
+    .find(record => String(record?.id) === spoolId || String(record?.spoolId) === spoolId) || null;
+  return spool
+    ? { spool, spoolId, reason: null }
+    : { spool: null, spoolId, reason: "canonical_spool_not_found" };
 }
 
 /**
@@ -270,8 +316,22 @@ export function buildFilamentRemainingModel(spoolOrId, options = {}) {
  * const gate = getIrreversibleFilamentRemaining(spool, { action: IRREVERSIBLE_REMAINING_ACTION.RUNOUT_DECISION });
  */
 export function getIrreversibleFilamentRemaining(spoolOrId, options = {}) {
-  const model = buildFilamentRemainingModel(spoolOrId, options);
   const action = options.action || IRREVERSIBLE_REMAINING_ACTION.LEDGER_MUTATION;
+  const canonical = _resolveCanonicalSpool(spoolOrId);
+  if (!canonical.spool) {
+    return {
+      ok: false,
+      reason: canonical.reason,
+      action,
+      spoolId: canonical.spoolId,
+      remainingMm: null,
+      source: "confirmed-ledger",
+      projectedRemainingMm: null,
+      ignoredPendingInferredUsedMm: 0
+    };
+  }
+
+  const model = buildFilamentRemainingModel(canonical.spool, options);
   if (!model.ok) {
     return {
       ok: false,
@@ -322,7 +382,21 @@ export function getIrreversibleFilamentRemaining(spoolOrId, options = {}) {
  * const canPrint = canExecuteIrreversibleRemainingAction(spool, 12000, { action: "print-start-gate" });
  */
 export function canExecuteIrreversibleRemainingAction(spoolOrId, requiredMm, options = {}) {
-  const required = Math.max(0, Number(requiredMm) || 0);
+  const action = options.action || IRREVERSIBLE_REMAINING_ACTION.LEDGER_MUTATION;
+  const spoolId = _spoolIdFromInput(spoolOrId);
+  const required = requiredMm == null || requiredMm === "" ? NaN : Number(requiredMm);
+  if (!Number.isFinite(required) || required < 0) {
+    return {
+      ok: false,
+      reason: "required_mm_invalid",
+      action,
+      spoolId,
+      remainingMm: null,
+      requiredMm: null,
+      projectedRemainingMm: null,
+      ignoredPendingInferredUsedMm: 0
+    };
+  }
   const gate = getIrreversibleFilamentRemaining(spoolOrId, options);
   if (!gate.ok) {
     return {

--- a/3dp_lib/dashboard_spool.js
+++ b/3dp_lib/dashboard_spool.js
@@ -30,9 +30,9 @@
  * - {@link autoCorrectCurrentSpool}：履歴から残量補正
  * - {@link mountNewSpoolFromPreset}：新品開封＋装着（リレー子対応の複合操作）
  *
-* @version 1.390.1280 (PR #426)
+* @version 1.390.1281 (PR #427)
 * @since   1.390.193 (PR #86)
-* @lastModified 2026-08-04 12:15:00
+* @lastModified 2026-08-04 15:22:00
  * -----------------------------------------------------------
  * @todo
  * - none
@@ -64,6 +64,10 @@ import { sendRelayFilament } from "./dashboard_client_sync.js";
 import { normalizeJobId } from "./dashboard_utils.js";
 import { wallNowMs, randomEventId } from "./dashboard_time.js";
 import { isCompletedHistoryEntry } from "./dashboard_history_identity.js";
+import {
+  getIrreversibleFilamentRemaining,
+  IRREVERSIBLE_REMAINING_ACTION
+} from "./dashboard_filament_remaining_model.js";
 
 /**
  * リレー子クライアント（satellite/readonly）として動作中かを判定する。
@@ -506,7 +510,10 @@ export function buildWasteReport() {
   for (const sp of allSpools) {
     // 廃棄済みで残量がある（＝ロス発生）スプールのみ対象
     if (!sp.deleted && !sp.isDeleted) continue;
-    const remain = sp.remainingLengthMm || 0;
+    const remainGate = getIrreversibleFilamentRemaining(sp, {
+      action: IRREVERSIBLE_REMAINING_ACTION.SPOOL_DISCARD
+    });
+    const remain = remainGate.ok ? remainGate.remainingMm : 0;
     if (remain <= 0) continue;
 
     count++;
@@ -1450,6 +1457,13 @@ export function deleteSpool(id, hostname) {
   const host = hostname;
   const s = monitorData.filamentSpools.find(sp => sp.id === id);
   if (!s) return;
+  const discardGate = getIrreversibleFilamentRemaining(id, {
+    action: IRREVERSIBLE_REMAINING_ACTION.SPOOL_DISCARD
+  });
+  if (!discardGate.ok) {
+    console.warn(`[deleteSpool] confirmed 残量を検証できないため廃棄を拒否: id=${id} reason=${discardGate.reason}`);
+    return;
+  }
   if (host && Array.isArray(s.printIdRanges) && s.printIdRanges.length) {
     const machine = monitorData.machines[host] || {};
     const pid = machine.printStore?.current?.id ?? "";

--- a/tests/unit/dashboard_filament_remaining_model.test.js
+++ b/tests/unit/dashboard_filament_remaining_model.test.js
@@ -136,6 +136,28 @@ describe("getIrreversibleFilamentRemaining", () => {
     expect(gate.reason).toBe("confirmed_remaining_unknown");
     expect(gate.remainingMm).toBe(null);
   });
+
+  it("不可逆判断では渡された古いオブジェクトではなく monitorData の正本を使う", () => {
+    mockMonitorData.filamentSpools = [spool({ remainingLengthMm: -500 })];
+    const staleUiCopy = spool({ remainingLengthMm: 5000 });
+
+    const gate = getIrreversibleFilamentRemaining(staleUiCopy, {
+      action: IRREVERSIBLE_REMAINING_ACTION.SPOOL_DISCARD
+    });
+
+    expect(gate.ok).toBe(true);
+    expect(gate.remainingMm).toBe(-500);
+  });
+
+  it("不可逆判断で正本スプールを取得できない場合は fail-closed する", () => {
+    const gate = getIrreversibleFilamentRemaining(spool({ id: "ghost", spoolId: "ghost" }), {
+      action: IRREVERSIBLE_REMAINING_ACTION.SPOOL_DISCARD
+    });
+
+    expect(gate.ok).toBe(false);
+    expect(gate.reason).toBe("canonical_spool_not_found");
+    expect(gate.spoolId).toBe("ghost");
+  });
 });
 
 describe("canExecuteIrreversibleRemainingAction", () => {
@@ -179,5 +201,22 @@ describe("canExecuteIrreversibleRemainingAction", () => {
     expect(result.ok).toBe(false);
     expect(result.reason).toBe("confirmed_remaining_insufficient");
     expect(result.remainingMm).toBe(-300);
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["null", null],
+    ["NaN", NaN],
+    ["Infinity", Infinity],
+    ["文字列", "abc"],
+    ["負数", -1]
+  ])("requiredMm が不正値(%s)なら 0 に丸めず fail-closed する", (_label, requiredMm) => {
+    const result = canExecuteIrreversibleRemainingAction("S1", requiredMm, {
+      action: IRREVERSIBLE_REMAINING_ACTION.PRINT_START_GATE
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("required_mm_invalid");
+    expect(result.requiredMm).toBe(null);
   });
 });

--- a/tests/unit/dashboard_filament_remaining_model.test.js
+++ b/tests/unit/dashboard_filament_remaining_model.test.js
@@ -1,0 +1,183 @@
+/**
+ * @fileoverview dashboard_filament_remaining_model.js の単体テスト。
+ * O8/O9 の Model 層が、表示用 projected 残量と不可逆判断用 confirmed 残量を混同しないことを検証する。
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockMonitorData = {
+  filamentSpools: [],
+  inferredCandidateStore: {}
+};
+
+vi.mock("../../3dp_lib/dashboard_data.js", () => ({ monitorData: mockMonitorData }));
+
+const {
+  IRREVERSIBLE_REMAINING_ACTION,
+  buildFilamentRemainingModel,
+  getIrreversibleFilamentRemaining,
+  canExecuteIrreversibleRemainingAction
+} = await import("../../3dp_lib/dashboard_filament_remaining_model.js");
+
+/**
+ * テスト用スプールを作成する。
+ *
+ * @function spool
+ * @param {Object} [overrides] - 上書きするフィールド。
+ * @returns {Object} スプール fixture。
+ */
+function spool(overrides = {}) {
+  return {
+    id: "S1",
+    spoolId: "S1",
+    remainingLengthMm: 10000,
+    totalLengthMm: 330000,
+    ...overrides
+  };
+}
+
+/**
+ * テスト用 candidate record を作成する。
+ *
+ * @function candidate
+ * @param {Object} [overrides] - 上書きするフィールド。
+ * @returns {Object} candidate fixture。
+ */
+function candidate(overrides = {}) {
+  return {
+    candidateHash: "ic-a",
+    candidateSpoolId: "S1",
+    host: "k1",
+    usedMm: 3000,
+    status: "pending",
+    ...overrides
+  };
+}
+
+beforeEach(() => {
+  mockMonitorData.filamentSpools = [spool()];
+  mockMonitorData.inferredCandidateStore = {};
+});
+
+describe("buildFilamentRemainingModel", () => {
+  it("pending inferred candidate を表示用 projected 残量へだけ反映する", () => {
+    mockMonitorData.inferredCandidateStore = {
+      "ic-a": candidate({ candidateHash: "ic-a", usedMm: 3000 }),
+      "ic-b": candidate({ candidateHash: "ic-b", usedMm: 1200 }),
+      "ic-confirmed": candidate({ candidateHash: "ic-c", usedMm: 500, status: "confirmed" })
+    };
+
+    const model = buildFilamentRemainingModel("S1");
+
+    expect(model.ok).toBe(true);
+    expect(model.confirmedRemainingMm).toBe(10000);
+    expect(model.pendingInferredUsedMm).toBe(4200);
+    expect(model.pendingCandidateCount).toBe(2);
+    expect(model.pendingCandidateHashes).toEqual(["ic-a", "ic-b"]);
+    expect(model.projectedRemainingMm).toBe(5800);
+    expect(model.irreversibleRemainingMm).toBe(10000);
+    expect(model.warnings).toContain("projected-remaining-display-only");
+  });
+
+  it("host が指定された場合は表示対象 candidate を host 単位に絞る", () => {
+    mockMonitorData.inferredCandidateStore = {
+      "ic-a": candidate({ candidateHash: "ic-a", host: "k1", usedMm: 3000 }),
+      "ic-b": candidate({ candidateHash: "ic-b", host: "k2", usedMm: 1200 })
+    };
+
+    const model = buildFilamentRemainingModel("S1", { host: "k1" });
+
+    expect(model.pendingInferredUsedMm).toBe(3000);
+    expect(model.pendingCandidateHashes).toEqual(["ic-a"]);
+    expect(model.projectedRemainingMm).toBe(7000);
+  });
+
+  it("確定残量が不明なら projected も不可逆判断値も不明にする", () => {
+    mockMonitorData.filamentSpools = [spool({ remainingLengthMm: null })];
+    mockMonitorData.inferredCandidateStore = {
+      "ic-a": candidate({ usedMm: 3000 })
+    };
+
+    const model = buildFilamentRemainingModel("S1");
+
+    expect(model.ok).toBe(false);
+    expect(model.reason).toBe("confirmed_remaining_unknown");
+    expect(model.confirmedRemainingMm).toBe(null);
+    expect(model.projectedRemainingMm).toBe(null);
+    expect(model.irreversibleRemainingMm).toBe(null);
+  });
+});
+
+describe("getIrreversibleFilamentRemaining", () => {
+  it("pending inferred candidate があっても不可逆判断には confirmed 残量を返す", () => {
+    mockMonitorData.inferredCandidateStore = {
+      "ic-a": candidate({ usedMm: 9000 })
+    };
+
+    const gate = getIrreversibleFilamentRemaining("S1", {
+      action: IRREVERSIBLE_REMAINING_ACTION.RUNOUT_DECISION
+    });
+
+    expect(gate.ok).toBe(true);
+    expect(gate.action).toBe(IRREVERSIBLE_REMAINING_ACTION.RUNOUT_DECISION);
+    expect(gate.remainingMm).toBe(10000);
+    expect(gate.projectedRemainingMm).toBe(1000);
+    expect(gate.ignoredPendingInferredUsedMm).toBe(9000);
+    expect(gate.source).toBe("confirmed-ledger");
+  });
+
+  it("confirmed 残量が不明な不可逆判断は fail-closed する", () => {
+    mockMonitorData.filamentSpools = [spool({ remainingLengthMm: "unknown" })];
+
+    const gate = getIrreversibleFilamentRemaining("S1", {
+      action: IRREVERSIBLE_REMAINING_ACTION.SPOOL_DISCARD
+    });
+
+    expect(gate.ok).toBe(false);
+    expect(gate.reason).toBe("confirmed_remaining_unknown");
+    expect(gate.remainingMm).toBe(null);
+  });
+});
+
+describe("canExecuteIrreversibleRemainingAction", () => {
+  it("必要量判定は projected ではなく confirmed 残量で行う", () => {
+    mockMonitorData.inferredCandidateStore = {
+      "ic-a": candidate({ usedMm: 9500 })
+    };
+
+    const result = canExecuteIrreversibleRemainingAction("S1", 8000, {
+      action: IRREVERSIBLE_REMAINING_ACTION.PRINT_START_GATE
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.remainingMm).toBe(10000);
+    expect(result.projectedRemainingMm).toBe(500);
+    expect(result.ignoredPendingInferredUsedMm).toBe(9500);
+  });
+
+  it("confirmed 残量が必要量を満たさない場合は projected に関係なく拒否する", () => {
+    mockMonitorData.inferredCandidateStore = {
+      "ic-a": candidate({ usedMm: 100 })
+    };
+
+    const result = canExecuteIrreversibleRemainingAction("S1", 12000, {
+      action: IRREVERSIBLE_REMAINING_ACTION.AUTO_SPOOL_SELECTION
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("confirmed_remaining_insufficient");
+    expect(result.remainingMm).toBe(10000);
+    expect(result.projectedRemainingMm).toBe(9900);
+  });
+
+  it("signed confirmed 残量が負数なら必要量ありの不可逆操作を拒否する", () => {
+    mockMonitorData.filamentSpools = [spool({ remainingLengthMm: -300 })];
+
+    const result = canExecuteIrreversibleRemainingAction("S1", 1, {
+      action: IRREVERSIBLE_REMAINING_ACTION.PRODUCTION_PLANNING
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("confirmed_remaining_insufficient");
+    expect(result.remainingMm).toBe(-300);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a model-layer filament remaining API that separates display/projection from irreversible ledger decisions.
- Keep pending inferred usage visible for forecasting while enforcing confirmed-only values for irreversible actions.
- Cover unknown, negative, host-filtered, and pending-candidate cases with unit tests.

## Validation
- npx vitest run tests/unit/dashboard_filament_remaining_model.test.js
- npx eslint 3dp_lib/dashboard_filament_remaining_model.js tests/unit/dashboard_filament_remaining_model.test.js --quiet
- npx vitest run